### PR TITLE
Improve `profile field-permissions` Errors

### DIFF
--- a/profile/clone.go
+++ b/profile/clone.go
@@ -1,12 +1,16 @@
 package profile
 
 import (
+	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 func (p *Profile) CloneFieldPermissions(src, dest string) error {
+	for _, f := range p.FieldPermissions {
+		if f.Field.Text == dest {
+			return fmt.Errorf("%s field already exists", dest)
+		}
+	}
 	found := false
 	for _, f := range p.FieldPermissions {
 		if f.Field.Text == src {
@@ -19,7 +23,7 @@ func (p *Profile) CloneFieldPermissions(src, dest string) error {
 		}
 	}
 	if !found {
-		return errors.New("source field not found")
+		return fmt.Errorf("source field %s not found", src)
 	}
 	sort.Slice(p.FieldPermissions, func(i, j int) bool {
 		return p.FieldPermissions[i].Field.Text < p.FieldPermissions[j].Field.Text

--- a/profile/fieldPermissions.go
+++ b/profile/fieldPermissions.go
@@ -1,6 +1,8 @@
 package profile
 
 import (
+	"fmt"
+
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 )
@@ -17,7 +19,7 @@ func (p *Profile) SetFieldPermissions(fieldName string, updates FieldPermissions
 		}
 	}
 	if !found {
-		return errors.New("field not found")
+		return fmt.Errorf("field not found: %s", fieldName)
 	}
 	return nil
 }


### PR DESCRIPTION
Return an error from `profile field-permissions clone` if the new field
already exists in the profile.

Update the error message for a missing source field to include the field
name.