### PR TITLE
Add Field Commands

### DIFF
--- a/cmd/objects.go
+++ b/cmd/objects.go
@@ -7,6 +7,7 @@ import (
 )
 
 func init() {
+	objectsCmd.AddCommand(objects.FieldCmd)
 	objectsCmd.AddCommand(objects.TidyCmd)
 	rootCmd.AddCommand(objectsCmd)
 }

--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -1,0 +1,62 @@
+package objects
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/objects"
+)
+
+var requiredOnly bool
+
+func init() {
+	listFieldsCmd.Flags().BoolVarP(&requiredOnly, "required", "r", false, "required fields only")
+
+	FieldCmd.AddCommand(listFieldsCmd)
+}
+
+var FieldCmd = &cobra.Command{
+	Use:   "field",
+	Short: "Manage object field metadata",
+}
+
+var listFieldsCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List object fields",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			listFields(file)
+		}
+	},
+}
+
+var alwaysRequired map[string]bool = map[string]bool{
+	"Name":    true,
+	"OwnerId": true,
+}
+
+func listFields(file string) {
+	o, err := objects.Open(file)
+	if err != nil {
+		log.Warn("parsing object failed: " + err.Error())
+		return
+	}
+	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	var filters []objects.FieldFilter
+	if requiredOnly {
+		filters = append(filters, func(f objects.Field) bool {
+			isRequired := alwaysRequired[f.FullName.Text] || (f.Required != nil && f.Required.Text == "true")
+			isMasterDetail := f.Type != nil && f.Type.Text == "MasterDetail"
+			return isRequired || isMasterDetail
+		})
+	}
+	fields := o.GetFields(filters...)
+	for _, f := range fields {
+		fmt.Printf("%s.%s\n", objectName, f.FullName.Text)
+	}
+}

--- a/objects/fields.go
+++ b/objects/fields.go
@@ -1,0 +1,19 @@
+package objects
+
+import ()
+
+type FieldFilter func(Field) bool
+
+func (o *CustomObject) GetFields(filters ...FieldFilter) []Field {
+	var fields []Field
+FIELDS:
+	for _, f := range o.Fields {
+		for _, filter := range filters {
+			if !filter(f) {
+				continue FIELDS
+			}
+		}
+		fields = append(fields, f)
+	}
+	return fields
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -6,6 +6,189 @@ import (
 	"github.com/octoberswimmer/force-md/internal"
 )
 
+type BooleanText struct {
+	Text string `xml:",chardata"`
+}
+
+type Field struct {
+	FullName struct {
+		Text string `xml:",chardata"`
+	} `xml:"fullName"`
+	CaseSensitive *struct {
+		Text string `xml:",chardata"`
+	} `xml:"caseSensitive"`
+	DefaultValue *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"defaultValue"`
+	DeleteConstraint *struct {
+		Text string `xml:",chardata"`
+	} `xml:"deleteConstraint"`
+	Description *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"description"`
+	DisplayFormat *struct {
+		Text string `xml:",chardata"`
+	} `xml:"displayFormat"`
+	DisplayLocationInDecimal *struct {
+		Text string `xml:",chardata"`
+	} `xml:"displayLocationInDecimal"`
+	ExternalId *struct {
+		Text string `xml:",chardata"`
+	} `xml:"externalId"`
+	Formula *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"formula"`
+	FormulaTreatBlanksAs *struct {
+		Text string `xml:",chardata"`
+	} `xml:"formulaTreatBlanksAs"`
+	InlineHelpText *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"inlineHelpText"`
+	Label *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"label"`
+	LookupFilter *struct {
+		Active struct {
+			Text string `xml:",chardata"`
+		} `xml:"active"`
+		ErrorMessage *struct {
+			Text string `xml:",innerxml"`
+		} `xml:"errorMessage"`
+		FilterItems []struct {
+			Field struct {
+				Text string `xml:",chardata"`
+			} `xml:"field"`
+			Operation struct {
+				Text string `xml:",chardata"`
+			} `xml:"operation"`
+			Value *struct {
+				Text string `xml:",chardata"`
+			} `xml:"value"`
+			ValueField *struct {
+				Text string `xml:",chardata"`
+			} `xml:"valueField"`
+		} `xml:"filterItems"`
+		IsOptional struct {
+			Text string `xml:",chardata"`
+		} `xml:"isOptional"`
+	} `xml:"lookupFilter"`
+	Precision *struct {
+		Text string `xml:",chardata"`
+	} `xml:"precision"`
+	Length *struct {
+		Text string `xml:",chardata"`
+	} `xml:"length"`
+	ReferenceTo *struct {
+		Text string `xml:",chardata"`
+	} `xml:"referenceTo"`
+	RelationshipLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"relationshipLabel"`
+	RelationshipName *struct {
+		Text string `xml:",chardata"`
+	} `xml:"relationshipName"`
+	Required *struct {
+		Text string `xml:",chardata"`
+	} `xml:"required"`
+	Scale *struct {
+		Text string `xml:",chardata"`
+	} `xml:"scale"`
+	TrackFeedHistory *struct {
+		Text string `xml:",chardata"`
+	} `xml:"trackFeedHistory"`
+	SummarizedField *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summarizedField"`
+	SummaryFilterItems []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Operation struct {
+			Text string `xml:",chardata"`
+		} `xml:"operation"`
+		Value struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"summaryFilterItems"`
+	SummaryForeignKey *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summaryForeignKey"`
+	SummaryOperation *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summaryOperation"`
+	RelationshipOrder *struct {
+		Text string `xml:",chardata"`
+	} `xml:"relationshipOrder"`
+	ReparentableMasterDetail *struct {
+		Text string `xml:",chardata"`
+	} `xml:"reparentableMasterDetail"`
+	FieldManageability *struct {
+		Text string `xml:",chardata"`
+	} `xml:"fieldManageability"`
+	MetadataRelationshipControllingField *struct {
+		Text string `xml:",chardata"`
+	} `xml:"metadataRelationshipControllingField"`
+	TrackHistory *struct {
+		Text string `xml:",chardata"`
+	} `xml:"trackHistory"`
+	TrackTrending *struct {
+		Text string `xml:",chardata"`
+	} `xml:"trackTrending"`
+	Type *struct {
+		Text string `xml:",chardata"`
+	} `xml:"type"`
+	Unique *struct {
+		Text string `xml:",chardata"`
+	} `xml:"unique"`
+	WriteRequiresMasterRead *struct {
+		Text string `xml:",chardata"`
+	} `xml:"writeRequiresMasterRead"`
+	ValueSet *struct {
+		ControllingField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"controllingField"`
+		Restricted *struct {
+			Text string `xml:",chardata"`
+		} `xml:"restricted"`
+		ValueSetDefinition *struct {
+			Sorted struct {
+				Text string `xml:",chardata"`
+			} `xml:"sorted"`
+			Value []struct {
+				FullName struct {
+					Text string `xml:",innerxml"`
+				} `xml:"fullName"`
+				Default struct {
+					Text string `xml:",chardata"`
+				} `xml:"default"`
+				IsActive *struct {
+					Text string `xml:",chardata"`
+				} `xml:"isActive"`
+				Label struct {
+					Text string `xml:",innerxml"`
+				} `xml:"label"`
+				Color *struct {
+					Text string `xml:",chardata"`
+				} `xml:"color"`
+			} `xml:"value"`
+		} `xml:"valueSetDefinition"`
+		ValueSetName *struct {
+			Text string `xml:",chardata"`
+		} `xml:"valueSetName"`
+		ValueSettings []struct {
+			ControllingFieldValue []struct {
+				Text string `xml:",innerxml"`
+			} `xml:"controllingFieldValue"`
+			ValueName struct {
+				Text string `xml:",chardata"`
+			} `xml:"valueName"`
+		} `xml:"valueSettings"`
+	} `xml:"valueSet"`
+	VisibleLines *struct {
+		Text string `xml:",chardata"`
+	} `xml:"visibleLines"`
+}
+
 type CustomObject struct {
 	XMLName         xml.Name `xml:"CustomObject"`
 	Xmlns           string   `xml:"xmlns,attr"`
@@ -118,185 +301,8 @@ type CustomObject struct {
 			Text string `xml:",chardata"`
 		} `xml:"label"`
 	} `xml:"fieldSets"`
-	Fields []struct {
-		FullName struct {
-			Text string `xml:",chardata"`
-		} `xml:"fullName"`
-		CaseSensitive *struct {
-			Text string `xml:",chardata"`
-		} `xml:"caseSensitive"`
-		DefaultValue *struct {
-			Text string `xml:",chardata"`
-		} `xml:"defaultValue"`
-		DeleteConstraint *struct {
-			Text string `xml:",chardata"`
-		} `xml:"deleteConstraint"`
-		Description *struct {
-			Text string `xml:",innerxml"`
-		} `xml:"description"`
-		DisplayFormat *struct {
-			Text string `xml:",chardata"`
-		} `xml:"displayFormat"`
-		DisplayLocationInDecimal *struct {
-			Text string `xml:",chardata"`
-		} `xml:"displayLocationInDecimal"`
-		ExternalId *struct {
-			Text string `xml:",chardata"`
-		} `xml:"externalId"`
-		Formula *struct {
-			Text string `xml:",innerxml"`
-		} `xml:"formula"`
-		FormulaTreatBlanksAs *struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaTreatBlanksAs"`
-		InlineHelpText *struct {
-			Text string `xml:",innerxml"`
-		} `xml:"inlineHelpText"`
-		Label *struct {
-			Text string `xml:",innerxml"`
-		} `xml:"label"`
-		LookupFilter *struct {
-			Active struct {
-				Text string `xml:",chardata"`
-			} `xml:"active"`
-			ErrorMessage *struct {
-				Text string `xml:",innerxml"`
-			} `xml:"errorMessage"`
-			FilterItems []struct {
-				Field struct {
-					Text string `xml:",chardata"`
-				} `xml:"field"`
-				Operation struct {
-					Text string `xml:",chardata"`
-				} `xml:"operation"`
-				Value *struct {
-					Text string `xml:",chardata"`
-				} `xml:"value"`
-				ValueField *struct {
-					Text string `xml:",chardata"`
-				} `xml:"valueField"`
-			} `xml:"filterItems"`
-			IsOptional struct {
-				Text string `xml:",chardata"`
-			} `xml:"isOptional"`
-		} `xml:"lookupFilter"`
-		Precision *struct {
-			Text string `xml:",chardata"`
-		} `xml:"precision"`
-		Length *struct {
-			Text string `xml:",chardata"`
-		} `xml:"length"`
-		ReferenceTo *struct {
-			Text string `xml:",chardata"`
-		} `xml:"referenceTo"`
-		RelationshipLabel *struct {
-			Text string `xml:",chardata"`
-		} `xml:"relationshipLabel"`
-		RelationshipName *struct {
-			Text string `xml:",chardata"`
-		} `xml:"relationshipName"`
-		Required *struct {
-			Text string `xml:",chardata"`
-		} `xml:"required"`
-		Scale *struct {
-			Text string `xml:",chardata"`
-		} `xml:"scale"`
-		TrackFeedHistory *struct {
-			Text string `xml:",chardata"`
-		} `xml:"trackFeedHistory"`
-		SummarizedField *struct {
-			Text string `xml:",chardata"`
-		} `xml:"summarizedField"`
-		SummaryFilterItems []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Operation struct {
-				Text string `xml:",chardata"`
-			} `xml:"operation"`
-			Value struct {
-				Text string `xml:",chardata"`
-			} `xml:"value"`
-		} `xml:"summaryFilterItems"`
-		SummaryForeignKey *struct {
-			Text string `xml:",chardata"`
-		} `xml:"summaryForeignKey"`
-		SummaryOperation *struct {
-			Text string `xml:",chardata"`
-		} `xml:"summaryOperation"`
-		RelationshipOrder *struct {
-			Text string `xml:",chardata"`
-		} `xml:"relationshipOrder"`
-		ReparentableMasterDetail *struct {
-			Text string `xml:",chardata"`
-		} `xml:"reparentableMasterDetail"`
-		FieldManageability *struct {
-			Text string `xml:",chardata"`
-		} `xml:"fieldManageability"`
-		MetadataRelationshipControllingField *struct {
-			Text string `xml:",chardata"`
-		} `xml:"metadataRelationshipControllingField"`
-		TrackHistory *struct {
-			Text string `xml:",chardata"`
-		} `xml:"trackHistory"`
-		TrackTrending *struct {
-			Text string `xml:",chardata"`
-		} `xml:"trackTrending"`
-		Type *struct {
-			Text string `xml:",chardata"`
-		} `xml:"type"`
-		Unique *struct {
-			Text string `xml:",chardata"`
-		} `xml:"unique"`
-		WriteRequiresMasterRead *struct {
-			Text string `xml:",chardata"`
-		} `xml:"writeRequiresMasterRead"`
-		ValueSet *struct {
-			ControllingField *struct {
-				Text string `xml:",chardata"`
-			} `xml:"controllingField"`
-			Restricted *struct {
-				Text string `xml:",chardata"`
-			} `xml:"restricted"`
-			ValueSetDefinition *struct {
-				Sorted struct {
-					Text string `xml:",chardata"`
-				} `xml:"sorted"`
-				Value []struct {
-					FullName struct {
-						Text string `xml:",innerxml"`
-					} `xml:"fullName"`
-					Default struct {
-						Text string `xml:",chardata"`
-					} `xml:"default"`
-					IsActive *struct {
-						Text string `xml:",chardata"`
-					} `xml:"isActive"`
-					Label struct {
-						Text string `xml:",innerxml"`
-					} `xml:"label"`
-					Color *struct {
-						Text string `xml:",chardata"`
-					} `xml:"color"`
-				} `xml:"value"`
-			} `xml:"valueSetDefinition"`
-			ValueSetName *struct {
-				Text string `xml:",chardata"`
-			} `xml:"valueSetName"`
-			ValueSettings []struct {
-				ControllingFieldValue []struct {
-					Text string `xml:",innerxml"`
-				} `xml:"controllingFieldValue"`
-				ValueName struct {
-					Text string `xml:",chardata"`
-				} `xml:"valueName"`
-			} `xml:"valueSettings"`
-		} `xml:"valueSet"`
-		VisibleLines *struct {
-			Text string `xml:",chardata"`
-		} `xml:"visibleLines"`
-	} `xml:"fields"`
-	Label *struct {
+	Fields []Field `xml:"fields"`
+	Label  *struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 	ListViews []struct {

--- a/profile/fieldPermissions.go
+++ b/profile/fieldPermissions.go
@@ -40,3 +40,28 @@ func (p *Profile) DeleteFieldPermissions(fieldName string) error {
 	p.FieldPermissions = newPerms
 	return nil
 }
+
+func (p *Profile) AddFieldPermissions(fieldName string) error {
+	for _, f := range p.FieldPermissions {
+		if f.Field.Text == fieldName {
+			return errors.New("field already exists")
+		}
+	}
+
+	p.FieldPermissions = append(p.FieldPermissions, defaultFieldPermissions(fieldName))
+	p.FieldPermissions.Tidy()
+	return nil
+}
+
+func defaultFieldPermissions(fieldName string) FieldPermissions {
+	var falseBooleanText = BooleanText{
+		Text: "false",
+	}
+
+	fp := FieldPermissions{
+		Field:    FieldName{fieldName},
+		Editable: falseBooleanText,
+		Readable: falseBooleanText,
+	}
+	return fp
+}

--- a/profile/tidy.go
+++ b/profile/tidy.go
@@ -11,9 +11,7 @@ func (p *Profile) Tidy() {
 	sort.Slice(p.ClassAccesses, func(i, j int) bool {
 		return p.ClassAccesses[i].ApexClass.Text < p.ClassAccesses[j].ApexClass.Text
 	})
-	sort.Slice(p.FieldPermissions, func(i, j int) bool {
-		return p.FieldPermissions[i].Field.Text < p.FieldPermissions[j].Field.Text
-	})
+	p.FieldPermissions.Tidy()
 	p.ObjectPermissions.Tidy()
 	sort.Slice(p.PageAccesses, func(i, j int) bool {
 		return p.PageAccesses[i].ApexPage.Text < p.PageAccesses[j].ApexPage.Text
@@ -35,5 +33,11 @@ func (p *Profile) Tidy() {
 func (op ObjectPermissionsList) Tidy() {
 	sort.Slice(op, func(i, j int) bool {
 		return op[i].Object.Text < op[j].Object.Text
+	})
+}
+
+func (fp FieldPermissionsList) Tidy() {
+	sort.Slice(fp, func(i, j int) bool {
+		return fp[i].Field.Text < fp[j].Field.Text
 	})
 }


### PR DESCRIPTION
Add `objects field list` command to list fields on an object.

Add `profile field-permissions add` command to add a new field as an
alternative to `profile field-permissions clone`.