### PR TITLE
Add/Edit Permission Sets

### DIFF
--- a/cmd/permissionset.go
+++ b/cmd/permissionset.go
@@ -11,6 +11,8 @@ func init() {
 	permissionSetCmd.AddCommand(permissionset.TidyCmd)
 	permissionSetCmd.AddCommand(permissionset.TabCmd)
 	permissionSetCmd.AddCommand(permissionset.ApexClassCmd)
+	permissionSetCmd.AddCommand(permissionset.NewCmd)
+	permissionSetCmd.AddCommand(permissionset.ObjectPermissionsCmd)
 	RootCmd.AddCommand(permissionSetCmd)
 }
 

--- a/cmd/permissionset/field.go
+++ b/cmd/permissionset/field.go
@@ -11,14 +11,32 @@ import (
 )
 
 var sourceField string
-var newField string
+var fieldName string
 
 func init() {
 	cloneCmd.Flags().StringVarP(&sourceField, "source", "s", "", "source field name")
-	cloneCmd.Flags().StringVarP(&newField, "field", "f", "", "new field name")
+	cloneCmd.Flags().StringVarP(&fieldName, "field", "f", "", "new field name")
 	cloneCmd.MarkFlagRequired("source")
 	cloneCmd.MarkFlagRequired("field")
+
+	addFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
+	addFieldCmd.MarkFlagRequired("field")
+
+	deleteFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
+	deleteFieldCmd.MarkFlagRequired("field")
+
+	editFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
+	editFieldCmd.Flags().BoolP("edit", "e", false, "allow edit")
+	editFieldCmd.Flags().BoolP("read", "r", false, "allow read")
+	editFieldCmd.Flags().BoolP("no-edit", "E", false, "disallow edit")
+	editFieldCmd.Flags().BoolP("no-read", "R", false, "disallow read")
+	editFieldCmd.Flags().SortFlags = false
+	editFieldCmd.MarkFlagRequired("field")
+
 	FieldPermissionsCmd.AddCommand(cloneCmd)
+	FieldPermissionsCmd.AddCommand(addFieldCmd)
+	FieldPermissionsCmd.AddCommand(editFieldCmd)
+	FieldPermissionsCmd.AddCommand(deleteFieldCmd)
 }
 
 var FieldPermissionsCmd = &cobra.Command{
@@ -44,7 +62,7 @@ func addNewField(file string) {
 		log.Warn("parsing permission set failed: " + err.Error())
 		return
 	}
-	err = p.CloneFieldPermissions(sourceField, newField)
+	err = p.CloneFieldPermissions(sourceField, fieldName)
 	if err != nil {
 		log.Warn(fmt.Sprintf("clone failed for %s: %s", file, err.Error()))
 		return
@@ -54,4 +72,102 @@ func addNewField(file string) {
 		log.Warn("update failed: " + err.Error())
 		return
 	}
+}
+
+var editFieldCmd = &cobra.Command{
+	Use:   "edit -f SObject.Field [flags] [filename]...",
+	Short: "Update field permissions",
+	Long:  "Update field permissions in permission sets",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		perms := fieldPermissionsToUpdate(cmd)
+		for _, file := range args {
+			updateFieldPermissions(file, perms)
+		}
+	},
+}
+
+var addFieldCmd = &cobra.Command{
+	Use:   "add -f SObject.Field [flags] [filename]...",
+	Short: "Add field permissions",
+	Long:  "Add field permissions in permission sets",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			addFieldPermissions(file)
+		}
+	},
+}
+
+var deleteFieldCmd = &cobra.Command{
+	Use:   "delete -f SObject.Field [flags] [filename]...",
+	Short: "Delete field permissions",
+	Long:  "Delete field permissions in permission sets",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			deleteFieldPermissions(file, fieldName)
+		}
+	},
+}
+
+func addFieldPermissions(file string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permissionset failed: " + err.Error())
+		return
+	}
+	err = p.AddFieldPermissions(fieldName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func deleteFieldPermissions(file string, fieldName string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing profile failed: " + err.Error())
+		return
+	}
+	err = p.DeleteFieldPermissions(fieldName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func updateFieldPermissions(file string, perms permissionset.FieldPermissions) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permissionset failed: " + err.Error())
+		return
+	}
+	err = p.SetFieldPermissions(fieldName, perms)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func fieldPermissionsToUpdate(cmd *cobra.Command) permissionset.FieldPermissions {
+	perms := permissionset.FieldPermissions{}
+	perms.Editable = textValue(cmd, "edit")
+	perms.Readable = textValue(cmd, "read")
+	return perms
 }

--- a/cmd/permissionset/new.go
+++ b/cmd/permissionset/new.go
@@ -1,0 +1,57 @@
+package permissionset
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/internal"
+	"github.com/octoberswimmer/force-md/permissionset"
+)
+
+var (
+	label       string
+	description string
+)
+
+func init() {
+	NewCmd.Flags().StringVarP(&label, "label", "l", "", "label")
+	NewCmd.Flags().StringVarP(&description, "description", "d", "", "description")
+	NewCmd.MarkFlagRequired("label")
+}
+
+var trueBooleanText = permissionset.BooleanText{
+	Text: "true",
+}
+
+var falseBooleanText = permissionset.BooleanText{
+	Text: "true",
+}
+
+var NewCmd = &cobra.Command{
+	Use:   "new [flags] [filename]...",
+	Short: "Create new permission set",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			addPermissionSet(file)
+		}
+	},
+}
+
+func addPermissionSet(file string) {
+	p := &permissionset.PermissionSet{
+		Xmlns:                 "http://soap.sforce.com/2006/04/metadata",
+		HasActivationRequired: falseBooleanText,
+		Label:                 label,
+	}
+	if description != "" {
+		p.Description = &permissionset.Description{
+			Text: description,
+		}
+	}
+	err := internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("write failed: " + err.Error())
+		return
+	}
+}

--- a/cmd/permissionset/objectPermissions.go
+++ b/cmd/permissionset/objectPermissions.go
@@ -1,0 +1,162 @@
+package permissionset
+
+import (
+	"fmt"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/internal"
+	"github.com/octoberswimmer/force-md/permissionset"
+)
+
+var (
+	objectName string
+)
+
+func init() {
+	editObjectCmd.Flags().StringVarP(&objectName, "object", "o", "", "object name")
+	editObjectCmd.Flags().BoolP("create", "c", false, "allow create")
+	editObjectCmd.Flags().BoolP("delete", "d", false, "allow delete")
+	editObjectCmd.Flags().BoolP("edit", "e", false, "allow edit")
+	editObjectCmd.Flags().BoolP("read", "r", false, "allow read")
+	editObjectCmd.Flags().BoolP("modify-all", "m", false, "allow modify all")
+	editObjectCmd.Flags().BoolP("view-all", "v", false, "allow view all")
+	editObjectCmd.Flags().BoolP("no-create", "C", false, "disallow create")
+	editObjectCmd.Flags().BoolP("no-delete", "D", false, "disallow delete")
+	editObjectCmd.Flags().BoolP("no-edit", "E", false, "disallow edit")
+	editObjectCmd.Flags().BoolP("no-read", "R", false, "disallow read")
+	editObjectCmd.Flags().BoolP("no-modify-all", "M", false, "disallow modify all")
+	editObjectCmd.Flags().BoolP("no-view-all", "V", false, "disallow view all")
+	editObjectCmd.Flags().SortFlags = false
+	editObjectCmd.MarkFlagRequired("object")
+
+	addObjectCmd.Flags().StringVarP(&objectName, "object", "o", "", "object name")
+	addObjectCmd.MarkFlagRequired("object")
+
+	deleteObjectCmd.Flags().StringVarP(&objectName, "object", "o", "", "object name")
+	deleteObjectCmd.MarkFlagRequired("object")
+
+	ObjectPermissionsCmd.AddCommand(editObjectCmd)
+	ObjectPermissionsCmd.AddCommand(addObjectCmd)
+	ObjectPermissionsCmd.AddCommand(deleteObjectCmd)
+}
+
+var ObjectPermissionsCmd = &cobra.Command{
+	Use:   "object-permissions",
+	Short: "Update object permissions",
+}
+
+var editObjectCmd = &cobra.Command{
+	Use:   "edit -o SObject [flags] [filename]...",
+	Short: "Update object permissions",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		perms := objectPermissionsToUpdate(cmd)
+		for _, file := range args {
+			updateObjectPermissions(file, perms)
+		}
+	},
+}
+
+var addObjectCmd = &cobra.Command{
+	Use:   "add -o SObject [flags] [filename]...",
+	Short: "Add object permissions",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			addObjectPermissions(file)
+		}
+	},
+}
+
+var deleteObjectCmd = &cobra.Command{
+	Use:   "delete -o SObject [flags] [filename]...",
+	Short: "Delete object permissions",
+	Long:  "Delete object permissions and related field permissions in permission sets",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			deleteObjectPermissions(file, objectName)
+		}
+	},
+}
+
+func textValue(cmd *cobra.Command, flag string) (t permissionset.BooleanText) {
+	if cmd.Flags().Changed(flag) {
+		val, _ := cmd.Flags().GetBool(flag)
+		t = permissionset.BooleanText{
+			Text: strconv.FormatBool(val),
+		}
+	}
+	antiFlag := "no-" + flag
+	if cmd.Flags().Changed(antiFlag) {
+		val, _ := cmd.Flags().GetBool(antiFlag)
+		t = permissionset.BooleanText{
+			Text: strconv.FormatBool(!val),
+		}
+	}
+	return t
+}
+
+func objectPermissionsToUpdate(cmd *cobra.Command) permissionset.ObjectPermissions {
+	perms := permissionset.ObjectPermissions{}
+	perms.AllowCreate = textValue(cmd, "create")
+	perms.AllowDelete = textValue(cmd, "delete")
+	perms.AllowEdit = textValue(cmd, "edit")
+	perms.AllowRead = textValue(cmd, "read")
+	perms.ModifyAllRecords = textValue(cmd, "modify-all")
+	perms.ViewAllRecords = textValue(cmd, "view-all")
+	return perms
+}
+
+func updateObjectPermissions(file string, perms permissionset.ObjectPermissions) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permissionset failed: " + err.Error())
+		return
+	}
+	err = p.SetObjectPermissions(objectName, perms)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func addObjectPermissions(file string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permissionset failed: " + err.Error())
+		return
+	}
+	err = p.AddObjectPermissions(objectName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func deleteObjectPermissions(file string, objectName string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permission set failed: " + err.Error())
+		return
+	}
+	p.DeleteObjectPermissions(objectName)
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}

--- a/docs/force-md_permissionset.md
+++ b/docs/force-md_permissionset.md
@@ -17,6 +17,8 @@ Manage Permission Sets
 * [force-md](force-md.md)	 - force-md manipulate Salesforce metadata
 * [force-md permissionset apex-class](force-md_permissionset_apex-class.md)	 - Manage apex class visibility
 * [force-md permissionset field-permissions](force-md_permissionset_field-permissions.md)	 - Manage field permissions
+* [force-md permissionset new](force-md_permissionset_new.md)	 - Create new permission set
+* [force-md permissionset object-permissions](force-md_permissionset_object-permissions.md)	 - Update object permissions
 * [force-md permissionset tab](force-md_permissionset_tab.md)	 - Manage tab visibility
 * [force-md permissionset tidy](force-md_permissionset_tidy.md)	 - Tidy Permission Set metadata
 

--- a/docs/force-md_permissionset_field-permissions.md
+++ b/docs/force-md_permissionset_field-permissions.md
@@ -15,5 +15,8 @@ Manage field permissions
 ### SEE ALSO
 
 * [force-md permissionset](force-md_permissionset.md)	 - Manage Permission Sets
+* [force-md permissionset field-permissions add](force-md_permissionset_field-permissions_add.md)	 - Add field permissions
 * [force-md permissionset field-permissions clone](force-md_permissionset_field-permissions_clone.md)	 - Clone field permissions
+* [force-md permissionset field-permissions delete](force-md_permissionset_field-permissions_delete.md)	 - Delete field permissions
+* [force-md permissionset field-permissions edit](force-md_permissionset_field-permissions_edit.md)	 - Update field permissions
 

--- a/docs/force-md_permissionset_field-permissions_add.md
+++ b/docs/force-md_permissionset_field-permissions_add.md
@@ -1,0 +1,23 @@
+## force-md permissionset field-permissions add
+
+Add field permissions
+
+### Synopsis
+
+Add field permissions in permission sets
+
+```
+force-md permissionset field-permissions add -f SObject.Field [flags] [filename]...
+```
+
+### Options
+
+```
+  -f, --field string   field name
+  -h, --help           help for add
+```
+
+### SEE ALSO
+
+* [force-md permissionset field-permissions](force-md_permissionset_field-permissions.md)	 - Manage field permissions
+

--- a/docs/force-md_permissionset_field-permissions_delete.md
+++ b/docs/force-md_permissionset_field-permissions_delete.md
@@ -1,0 +1,23 @@
+## force-md permissionset field-permissions delete
+
+Delete field permissions
+
+### Synopsis
+
+Delete field permissions in permission sets
+
+```
+force-md permissionset field-permissions delete -f SObject.Field [flags] [filename]...
+```
+
+### Options
+
+```
+  -f, --field string   field name
+  -h, --help           help for delete
+```
+
+### SEE ALSO
+
+* [force-md permissionset field-permissions](force-md_permissionset_field-permissions.md)	 - Manage field permissions
+

--- a/docs/force-md_permissionset_field-permissions_edit.md
+++ b/docs/force-md_permissionset_field-permissions_edit.md
@@ -1,0 +1,27 @@
+## force-md permissionset field-permissions edit
+
+Update field permissions
+
+### Synopsis
+
+Update field permissions in permission sets
+
+```
+force-md permissionset field-permissions edit -f SObject.Field [flags] [filename]...
+```
+
+### Options
+
+```
+  -f, --field string   field name
+  -e, --edit           allow edit
+  -r, --read           allow read
+  -E, --no-edit        disallow edit
+  -R, --no-read        disallow read
+  -h, --help           help for edit
+```
+
+### SEE ALSO
+
+* [force-md permissionset field-permissions](force-md_permissionset_field-permissions.md)	 - Manage field permissions
+

--- a/docs/force-md_permissionset_new.md
+++ b/docs/force-md_permissionset_new.md
@@ -1,0 +1,24 @@
+## force-md permissionset new
+
+Create new permission set
+
+### Synopsis
+
+Create new permission set
+
+```
+force-md permissionset new [flags] [filename]...
+```
+
+### Options
+
+```
+  -d, --description string   description
+  -h, --help                 help for new
+  -l, --label string         label
+```
+
+### SEE ALSO
+
+* [force-md permissionset](force-md_permissionset.md)	 - Manage Permission Sets
+

--- a/docs/force-md_permissionset_object-permissions.md
+++ b/docs/force-md_permissionset_object-permissions.md
@@ -1,0 +1,21 @@
+## force-md permissionset object-permissions
+
+Update object permissions
+
+### Synopsis
+
+Update object permissions
+
+### Options
+
+```
+  -h, --help   help for object-permissions
+```
+
+### SEE ALSO
+
+* [force-md permissionset](force-md_permissionset.md)	 - Manage Permission Sets
+* [force-md permissionset object-permissions add](force-md_permissionset_object-permissions_add.md)	 - Add object permissions
+* [force-md permissionset object-permissions delete](force-md_permissionset_object-permissions_delete.md)	 - Delete object permissions
+* [force-md permissionset object-permissions edit](force-md_permissionset_object-permissions_edit.md)	 - Update object permissions
+

--- a/docs/force-md_permissionset_object-permissions_add.md
+++ b/docs/force-md_permissionset_object-permissions_add.md
@@ -1,0 +1,23 @@
+## force-md permissionset object-permissions add
+
+Add object permissions
+
+### Synopsis
+
+Add object permissions
+
+```
+force-md permissionset object-permissions add -o SObject [flags] [filename]...
+```
+
+### Options
+
+```
+  -h, --help            help for add
+  -o, --object string   object name
+```
+
+### SEE ALSO
+
+* [force-md permissionset object-permissions](force-md_permissionset_object-permissions.md)	 - Update object permissions
+

--- a/docs/force-md_permissionset_object-permissions_delete.md
+++ b/docs/force-md_permissionset_object-permissions_delete.md
@@ -1,0 +1,23 @@
+## force-md permissionset object-permissions delete
+
+Delete object permissions
+
+### Synopsis
+
+Delete object permissions and related field permissions in permission sets
+
+```
+force-md permissionset object-permissions delete -o SObject [flags] [filename]...
+```
+
+### Options
+
+```
+  -h, --help            help for delete
+  -o, --object string   object name
+```
+
+### SEE ALSO
+
+* [force-md permissionset object-permissions](force-md_permissionset_object-permissions.md)	 - Update object permissions
+

--- a/docs/force-md_permissionset_object-permissions_edit.md
+++ b/docs/force-md_permissionset_object-permissions_edit.md
@@ -1,0 +1,35 @@
+## force-md permissionset object-permissions edit
+
+Update object permissions
+
+### Synopsis
+
+Update object permissions
+
+```
+force-md permissionset object-permissions edit -o SObject [flags] [filename]...
+```
+
+### Options
+
+```
+  -o, --object string   object name
+  -c, --create          allow create
+  -d, --delete          allow delete
+  -e, --edit            allow edit
+  -r, --read            allow read
+  -m, --modify-all      allow modify all
+  -v, --view-all        allow view all
+  -C, --no-create       disallow create
+  -D, --no-delete       disallow delete
+  -E, --no-edit         disallow edit
+  -R, --no-read         disallow read
+  -M, --no-modify-all   disallow modify all
+  -V, --no-view-all     disallow view all
+  -h, --help            help for edit
+```
+
+### SEE ALSO
+
+* [force-md permissionset object-permissions](force-md_permissionset_object-permissions.md)	 - Update object permissions
+

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,8 +49,10 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -74,7 +77,9 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -137,10 +142,12 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/permissionset/clone.go
+++ b/permissionset/clone.go
@@ -11,7 +11,7 @@ func (p *PermissionSet) CloneFieldPermissions(src, dest string) error {
 	for _, f := range p.FieldPermissions {
 		if f.Field.Text == src {
 			found = true
-			clone := FieldPermission{}
+			clone := FieldPermissions{}
 			clone.Editable.Text = f.Editable.Text
 			clone.Readable.Text = f.Readable.Text
 			clone.Field.Text = dest

--- a/permissionset/fieldPermissions.go
+++ b/permissionset/fieldPermissions.go
@@ -1,0 +1,67 @@
+package permissionset
+
+import (
+	"fmt"
+
+	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+)
+
+func (p *PermissionSet) SetFieldPermissions(fieldName string, updates FieldPermissions) error {
+	found := false
+	for i, f := range p.FieldPermissions {
+		if f.Field.Text == fieldName {
+			found = true
+			if err := mergo.Merge(&updates, f); err != nil {
+				return errors.Wrap(err, "merging permissions")
+			}
+			p.FieldPermissions[i] = updates
+		}
+	}
+	if !found {
+		return fmt.Errorf("field not found: %s", fieldName)
+	}
+	return nil
+}
+
+func (p *PermissionSet) DeleteFieldPermissions(fieldName string) error {
+	found := false
+	newPerms := p.FieldPermissions[:0]
+	for _, f := range p.FieldPermissions {
+		if f.Field.Text == fieldName {
+			found = true
+		} else {
+			newPerms = append(newPerms, f)
+		}
+	}
+	if !found {
+		return errors.New("field not found")
+	}
+	p.FieldPermissions = newPerms
+	return nil
+}
+
+func (p *PermissionSet) AddFieldPermissions(fieldName string) error {
+	for _, f := range p.FieldPermissions {
+		if f.Field.Text == fieldName {
+			return errors.New("field already exists")
+		}
+	}
+
+	p.FieldPermissions = append(p.FieldPermissions, defaultFieldPermissions(fieldName))
+	p.FieldPermissions.Tidy()
+	return nil
+}
+
+func defaultFieldPermissions(fieldName string) FieldPermissions {
+	var falseBooleanText = BooleanText{
+		Text: "false",
+	}
+
+	fp := FieldPermissions{
+		Field:    FieldName{fieldName},
+		Editable: falseBooleanText,
+		Readable: falseBooleanText,
+	}
+	return fp
+}

--- a/permissionset/objectPermissions.go
+++ b/permissionset/objectPermissions.go
@@ -1,0 +1,95 @@
+package permissionset
+
+import (
+	"strings"
+
+	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func (p *PermissionSet) SetObjectPermissions(objectName string, updates ObjectPermissions) error {
+	found := false
+	for i, f := range p.ObjectPermissions {
+		if f.Object.Text == objectName {
+			found = true
+			if err := mergo.Merge(&updates, f); err != nil {
+				return errors.Wrap(err, "merging permissions")
+			}
+			p.ObjectPermissions[i] = updates
+		}
+	}
+	if !found {
+		return errors.New("object not found")
+	}
+	return nil
+}
+
+func defaultObjectPermissions(objectName string) ObjectPermissions {
+	var falseBooleanText = BooleanText{
+		Text: "false",
+	}
+
+	op := ObjectPermissions{
+		Object:           ObjectName{objectName},
+		AllowCreate:      falseBooleanText,
+		AllowDelete:      falseBooleanText,
+		AllowEdit:        falseBooleanText,
+		AllowRead:        falseBooleanText,
+		ModifyAllRecords: falseBooleanText,
+		ViewAllRecords:   falseBooleanText,
+	}
+	return op
+}
+
+func (p *PermissionSet) AddObjectPermissions(objectName string) error {
+	for _, f := range p.ObjectPermissions {
+		if f.Object.Text == objectName {
+			return errors.New("object already exists")
+		}
+	}
+
+	p.ObjectPermissions = append(p.ObjectPermissions, defaultObjectPermissions(objectName))
+	p.ObjectPermissions.Tidy()
+	return nil
+}
+
+func (p *PermissionSet) DeleteObjectPermissions(objectName string) {
+	found := false
+	newObjectPerms := p.ObjectPermissions[:0]
+	for _, f := range p.ObjectPermissions {
+		if f.Object.Text == objectName {
+			found = true
+		} else {
+			newObjectPerms = append(newObjectPerms, f)
+		}
+	}
+	p.ObjectPermissions = newObjectPerms
+	if !found {
+		log.Warn(errors.New("object not found"))
+	}
+
+	p.DeleteObjectFieldPermissions(objectName)
+	p.DeleteObjectTabVisibility(objectName)
+}
+
+func (p *PermissionSet) DeleteObjectFieldPermissions(objectName string) {
+	newFieldPerms := p.FieldPermissions[:0]
+	fieldPrefix := objectName + "."
+	for _, f := range p.FieldPermissions {
+		if !strings.HasPrefix(f.Field.Text, fieldPrefix) {
+			newFieldPerms = append(newFieldPerms, f)
+		}
+	}
+	p.FieldPermissions = newFieldPerms
+}
+
+func (p *PermissionSet) DeleteObjectTabVisibility(objectName string) {
+	newTabs := p.TabSettings[:0]
+	for _, f := range p.TabSettings {
+		if f.Tab == objectName {
+			newTabs = append(newTabs, f)
+		}
+	}
+	p.TabSettings = newTabs
+}

--- a/permissionset/permissionset.go
+++ b/permissionset/permissionset.go
@@ -11,16 +11,8 @@ type ApexClass struct {
 	Enabled   string `xml:"enabled"`
 }
 
-type FieldPermission struct {
-	Editable struct {
-		Text string `xml:",chardata"`
-	} `xml:"editable"`
-	Field struct {
-		Text string `xml:",chardata"`
-	} `xml:"field"`
-	Readable struct {
-		Text string `xml:",chardata"`
-	} `xml:"readable"`
+type Description struct {
+	Text string `xml:",chardata"`
 }
 
 type License struct {
@@ -32,44 +24,48 @@ type TabSettings struct {
 	Visibility string `xml:"visibility"`
 }
 
+type BooleanText struct {
+	Text string `xml:",chardata"`
+}
+
+type ObjectPermissions struct {
+	AllowCreate      BooleanText `xml:"allowCreate"`
+	AllowDelete      BooleanText `xml:"allowDelete"`
+	AllowEdit        BooleanText `xml:"allowEdit"`
+	AllowRead        BooleanText `xml:"allowRead"`
+	ModifyAllRecords BooleanText `xml:"modifyAllRecords"`
+	Object           ObjectName  `xml:"object"`
+	ViewAllRecords   BooleanText `xml:"viewAllRecords"`
+}
+
+type ObjectName struct {
+	Text string `xml:",chardata"`
+}
+
+type FieldName struct {
+	Text string `xml:",chardata"`
+}
+
+type ObjectPermissionsList []ObjectPermissions
+
+type FieldPermissions struct {
+	Editable BooleanText `xml:"editable"`
+	Field    FieldName   `xml:"field"`
+	Readable BooleanText `xml:"readable"`
+}
+
+type FieldPermissionsList []FieldPermissions
+
 type PermissionSet struct {
-	XMLName       xml.Name    `xml:"PermissionSet"`
-	Xmlns         string      `xml:"xmlns,attr"`
-	ClassAccesses []ApexClass `xml:"classAccesses"`
-	Description   struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	FieldPermissions      []FieldPermission `xml:"fieldPermissions"`
-	HasActivationRequired struct {
-		Text string `xml:",chardata"`
-	} `xml:"hasActivationRequired"`
-	Label struct {
-		Text string `xml:",chardata"`
-	} `xml:"label"`
-	ObjectPermissions []struct {
-		AllowCreate struct {
-			Text string `xml:",chardata"`
-		} `xml:"allowCreate"`
-		AllowDelete struct {
-			Text string `xml:",chardata"`
-		} `xml:"allowDelete"`
-		AllowEdit struct {
-			Text string `xml:",chardata"`
-		} `xml:"allowEdit"`
-		AllowRead struct {
-			Text string `xml:",chardata"`
-		} `xml:"allowRead"`
-		ModifyAllRecords struct {
-			Text string `xml:",chardata"`
-		} `xml:"modifyAllRecords"`
-		Object struct {
-			Text string `xml:",chardata"`
-		} `xml:"object"`
-		ViewAllRecords struct {
-			Text string `xml:",chardata"`
-		} `xml:"viewAllRecords"`
-	} `xml:"objectPermissions"`
-	PageAccesses []struct {
+	XMLName               xml.Name              `xml:"PermissionSet"`
+	Xmlns                 string                `xml:"xmlns,attr"`
+	ClassAccesses         []ApexClass           `xml:"classAccesses"`
+	Description           *Description          `xml:"description"`
+	FieldPermissions      FieldPermissionsList  `xml:"fieldPermissions"`
+	HasActivationRequired BooleanText           `xml:"hasActivationRequired"`
+	Label                 string                `xml:"label"`
+	ObjectPermissions     ObjectPermissionsList `xml:"objectPermissions"`
+	PageAccesses          []struct {
 		ApexPage struct {
 			Text string `xml:",chardata"`
 		} `xml:"apexPage"`

--- a/permissionset/tidy.go
+++ b/permissionset/tidy.go
@@ -11,12 +11,8 @@ func (p *PermissionSet) Tidy() {
 	sort.Slice(p.ClassAccesses, func(i, j int) bool {
 		return p.ClassAccesses[i].ApexClass < p.ClassAccesses[j].ApexClass
 	})
-	sort.Slice(p.FieldPermissions, func(i, j int) bool {
-		return p.FieldPermissions[i].Field.Text < p.FieldPermissions[j].Field.Text
-	})
-	sort.Slice(p.ObjectPermissions, func(i, j int) bool {
-		return p.ObjectPermissions[i].Object.Text < p.ObjectPermissions[j].Object.Text
-	})
+	p.FieldPermissions.Tidy()
+	p.ObjectPermissions.Tidy()
 	sort.Slice(p.PageAccesses, func(i, j int) bool {
 		return p.PageAccesses[i].ApexPage.Text < p.PageAccesses[j].ApexPage.Text
 	})
@@ -31,5 +27,17 @@ func (p *PermissionSet) Tidy() {
 	})
 	sort.Slice(p.CustomPermissions, func(i, j int) bool {
 		return p.CustomPermissions[i].Name.Text < p.CustomPermissions[j].Name.Text
+	})
+}
+
+func (op ObjectPermissionsList) Tidy() {
+	sort.Slice(op, func(i, j int) bool {
+		return op[i].Object.Text < op[j].Object.Text
+	})
+}
+
+func (fp FieldPermissionsList) Tidy() {
+	sort.Slice(fp, func(i, j int) bool {
+		return fp[i].Field.Text < fp[j].Field.Text
 	})
 }


### PR DESCRIPTION
Add `permissionset new` command to add a new permission set.

Add `permissionset object-permissions` command to edit object permissions.

Add commands to edit field permissions in permission sets:
	`permissionset field-permissions add`
	`permissionset field-permissions edit`
	`permissionset field-permissions delete`