### PR TITLE
Add `profile object-permissions show` Command

### DIFF
--- a/cmd/profile/objectPermissions.go
+++ b/cmd/profile/objectPermissions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -185,7 +186,7 @@ func showObjectPermissions(file string, objectName string) {
 		return
 	}
 	objects := p.GetObjectPermissions(func(o profile.ObjectPermissions) bool {
-		return o.Object.Text == objectName
+		return strings.ToLower(o.Object.Text) == strings.ToLower(objectName)
 	})
 	if len(objects) == 0 {
 		log.Warn(fmt.Sprintf("object not found in %s", file))

--- a/profile/objectPermissions.go
+++ b/profile/objectPermissions.go
@@ -8,6 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type ObjectFilter func(ObjectPermissions) bool
+
 func (p *Profile) SetObjectPermissions(objectName string, updates ObjectPermissions) error {
 	found := false
 	for i, f := range p.ObjectPermissions {
@@ -105,4 +107,18 @@ func (p *Profile) DeleteObjectTabVisibility(objectName string) {
 		}
 	}
 	p.TabVisibilities = newTabs
+}
+
+func (p *Profile) GetObjectPermissions(filters ...ObjectFilter) []ObjectPermissions {
+	var objectPermissions []ObjectPermissions
+OBJECTS:
+	for _, o := range p.ObjectPermissions {
+		for _, filter := range filters {
+			if !filter(o) {
+				continue OBJECTS
+			}
+		}
+		objectPermissions = append(objectPermissions, o)
+	}
+	return objectPermissions
 }


### PR DESCRIPTION
Add `profile object-permissions show` command to show the
objectPermissions for an object defined within a profile.