### PR TITLE
List and Show Objects in Permission Set

### DIFF
--- a/permissionset/objectPermissions.go
+++ b/permissionset/objectPermissions.go
@@ -8,6 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type ObjectFilter func(ObjectPermissions) bool
+
 func (p *PermissionSet) SetObjectPermissions(objectName string, updates ObjectPermissions) error {
 	found := false
 	for i, f := range p.ObjectPermissions {
@@ -92,4 +94,18 @@ func (p *PermissionSet) DeleteObjectTabVisibility(objectName string) {
 		}
 	}
 	p.TabSettings = newTabs
+}
+
+func (p *PermissionSet) GetObjectPermissions(filters ...ObjectFilter) []ObjectPermissions {
+	var objectPermissions []ObjectPermissions
+OBJECTS:
+	for _, o := range p.ObjectPermissions {
+		for _, filter := range filters {
+			if !filter(o) {
+				continue OBJECTS
+			}
+		}
+		objectPermissions = append(objectPermissions, o)
+	}
+	return objectPermissions
 }


### PR DESCRIPTION
Add `permissionset object-permissions list` and `permissionset
object-permissions show` commands to list objects with permissions
defined in permission sets and to show the details.