### PR TITLE
Edit More Field Metadata

### DIFF
--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -31,7 +31,11 @@ func init() {
 	addFieldCmd.MarkFlagRequired("field")
 
 	editFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
-	editFieldCmd.Flags().StringP("label", "l", "", "field label")
+	editFieldCmd.Flags().StringP("label", "l", "", "label")
+	editFieldCmd.Flags().StringP("type", "t", "", "field type")
+	editFieldCmd.Flags().StringP("description", "d", "", "description")
+	editFieldCmd.Flags().StringP("default", "v", "", "default value")
+	editFieldCmd.Flags().StringP("inline-help", "i", "", "inline help")
 	editFieldCmd.Flags().BoolP("unique", "u", false, "unique")
 	editFieldCmd.Flags().BoolP("no-unique", "U", false, "not unique")
 	editFieldCmd.Flags().BoolP("external-id", "e", false, "external id")
@@ -233,6 +237,10 @@ func fieldUpdates(cmd *cobra.Command) objects.Field {
 	field.Label = textValue(cmd, "label")
 	field.Unique = booleanTextValue(cmd, "unique")
 	field.ExternalId = booleanTextValue(cmd, "external-id")
+	field.Description = textValue(cmd, "description")
+	field.Type = textValue(cmd, "type")
+	field.InlineHelpText = textValue(cmd, "inline-help")
+	field.DefaultValue = textValue(cmd, "default")
 	return field
 }
 

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -21,15 +21,11 @@ type Field struct {
 	CaseSensitive *struct {
 		Text string `xml:",chardata"`
 	} `xml:"caseSensitive"`
-	DefaultValue *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"defaultValue"`
+	DefaultValue     *TextLiteral `xml:"defaultValue"`
 	DeleteConstraint *struct {
 		Text string `xml:",chardata"`
 	} `xml:"deleteConstraint"`
-	Description *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"description"`
+	Description   *TextLiteral `xml:"description"`
 	DisplayFormat *struct {
 		Text string `xml:",chardata"`
 	} `xml:"displayFormat"`
@@ -43,11 +39,9 @@ type Field struct {
 	FormulaTreatBlanksAs *struct {
 		Text string `xml:",chardata"`
 	} `xml:"formulaTreatBlanksAs"`
-	InlineHelpText *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"inlineHelpText"`
-	Label        *TextLiteral `xml:"label"`
-	LookupFilter *struct {
+	InlineHelpText *TextLiteral `xml:"inlineHelpText"`
+	Label          *TextLiteral `xml:"label"`
+	LookupFilter   *struct {
 		Active struct {
 			Text string `xml:",chardata"`
 		} `xml:"active"`
@@ -134,9 +128,7 @@ type Field struct {
 	TrackTrending *struct {
 		Text string `xml:",chardata"`
 	} `xml:"trackTrending"`
-	Type *struct {
-		Text string `xml:",chardata"`
-	} `xml:"type"`
+	Type                    *TextLiteral `xml:"type"`
 	Unique                  *BooleanText `xml:"unique"`
 	WriteRequiresMasterRead *struct {
 		Text string `xml:",chardata"`


### PR DESCRIPTION
Update `objects fields edit` to support editing field type, description,
default value, and inline help text.