### PR TITLE
Permission Set Fixes

### DIFF
--- a/permissionset/clone.go
+++ b/permissionset/clone.go
@@ -2,6 +2,7 @@ package permissionset
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -9,6 +10,9 @@ import (
 func (p *PermissionSet) CloneFieldPermissions(src, dest string) error {
 	found := false
 	for _, f := range p.FieldPermissions {
+		if strings.ToLower(dest) == strings.ToLower(f.Field.Text) {
+			return errors.New("field already exists")
+		}
 		if f.Field.Text == src {
 			found = true
 			clone := FieldPermissions{}

--- a/permissionset/permissionset.go
+++ b/permissionset/permissionset.go
@@ -89,7 +89,6 @@ type PermissionSet struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 	} `xml:"customPermissions"`
-	TabSettings             []TabSettings      `xml:"tabSettings"`
 	UserPermissions         UserPermissionList `xml:"userPermissions"`
 	ApplicationVisibilities []struct {
 		Application struct {
@@ -107,6 +106,7 @@ type PermissionSet struct {
 			Text string `xml:",chardata"`
 		} `xml:"visible"`
 	} `xml:"recordTypeVisibilities"`
+	TabSettings []TabSettings `xml:"tabSettings"`
 }
 
 func (p *PermissionSet) MetaCheck() {}


### PR DESCRIPTION
Return an error from `permissionset field-permissions clone` if the
field already exists.

Move tabSettings to end of permission set.