### PR TITLE
Support Fully-Qualified Field Name With `objects fields show`

### DIFF
--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -199,6 +199,8 @@ func showField(file string, fieldName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
+	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	fieldName = strings.TrimPrefix(fieldName, objectName+".")
 	fields := o.GetFields(func(f objects.Field) bool {
 		return f.FullName == fieldName
 	})


### PR DESCRIPTION
Support either the field name (e.g. `Name`) or the object and field name
(`Account.Name`) with `objects fields show`.