### PR TITLE
Support Editing Field History Tracking

### DIFF
--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -49,6 +49,8 @@ func init() {
 	editFieldCmd.Flags().BoolP("no-unique", "U", false, "not unique")
 	editFieldCmd.Flags().BoolP("external-id", "e", false, "external id")
 	editFieldCmd.Flags().BoolP("no-external-id", "C", false, "not external id")
+	editFieldCmd.Flags().BoolP("history-tracking", "k", false, "history tracking")
+	editFieldCmd.Flags().BoolP("no-history-tracking", "K", false, "no history tracking")
 	editFieldCmd.MarkFlagRequired("field")
 
 	deleteFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
@@ -211,6 +213,8 @@ func updateField(file string, fieldUpdates objects.Field) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
+	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	fieldName = strings.ToLower(strings.TrimPrefix(fieldName, objectName+"."))
 	err = o.UpdateField(fieldName, fieldUpdates)
 	if err != nil {
 		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
@@ -271,6 +275,7 @@ func fieldUpdates(cmd *cobra.Command) objects.Field {
 	field.Label = textValue(cmd, "label")
 	field.Unique = booleanTextValue(cmd, "unique")
 	field.ExternalId = booleanTextValue(cmd, "external-id")
+	field.TrackHistory = booleanTextValue(cmd, "history-tracking")
 	field.Description = textValue(cmd, "description")
 	field.Type = textValue(cmd, "type")
 	field.InlineHelpText = textValue(cmd, "inline-help")

--- a/objects/fields.go
+++ b/objects/fields.go
@@ -1,6 +1,8 @@
 package objects
 
 import (
+	"strings"
+
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 )
@@ -43,7 +45,7 @@ func (o *CustomObject) AddField(fieldName string) error {
 func (o *CustomObject) UpdateField(fieldName string, updates Field) error {
 	found := false
 	for i, f := range o.Fields {
-		if f.FullName == fieldName {
+		if strings.ToLower(f.FullName) == strings.ToLower(fieldName) {
 			found = true
 			if err := mergo.Merge(&updates, f, mergo.WithNoOverrideEmptyStructValues); err != nil {
 				return errors.Wrap(err, "merging field updates")


### PR DESCRIPTION
Add `--history-tracking`/`--no-history-tracking` option for `objects
fields edit` to enable/disable history tracking on a field.

Make field name case-insensitive and allow object name to be included as
a prefix.