### PR TITLE
Merge Layout Assignments

### DIFF
--- a/cmd/profile/merge.go
+++ b/cmd/profile/merge.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -101,6 +102,16 @@ func mergePermissions(file string, apply profile.Profile) {
 		if err != nil && err != profile.TabExistsError {
 			log.Warn(fmt.Sprintf("adding tab %s failed for %s: %s", t.Tab, file, err.Error()))
 			return
+		}
+	}
+	for _, l := range apply.LayoutAssignments {
+		bits := strings.SplitN(l.Layout, "-", 2)
+		objectName := bits[0]
+		layoutName := bits[1]
+		if l.RecordType != nil {
+			p.SetObjectLayoutForRecordType(objectName, layoutName, l.RecordType.Text)
+		} else {
+			p.SetObjectLayout(objectName, layoutName)
 		}
 	}
 	for _, u := range apply.UserPermissions {

--- a/profile/layout.go
+++ b/profile/layout.go
@@ -20,6 +20,9 @@ func (p *Profile) GetLayouts(objectName string) LayoutAssignmentList {
 func (p *Profile) SetObjectLayout(objectName, layoutName string) {
 	layoutPrefix := objectName + "-"
 	for i, f := range p.LayoutAssignments {
+		if f.RecordType != nil {
+			continue
+		}
 		if strings.HasPrefix(f.Layout, layoutPrefix) {
 			p.LayoutAssignments[i].Layout = layoutPrefix + layoutName
 			return


### PR DESCRIPTION
Update `profile merge` to merge layout assignments.

Fix setting profile layout assignments so that a RecordType assignment
is not overwritten with a default assignment.
