### PR TITLE
List Workflow Alerts By Sender Type; Edit Workflow Alert Sender

### DIFF
--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -330,57 +329,20 @@ func writeFields(file string, fieldsDir string) {
 
 func setFields(cmd *cobra.Command) objects.Field {
 	field := objects.Field{}
-	field.Label = textValue(cmd, "label")
-	field.Unique = booleanTextValue(cmd, "unique")
-	field.ExternalId = booleanTextValue(cmd, "external-id")
-	field.TrackHistory = booleanTextValue(cmd, "history-tracking")
-	field.TrackTrending = booleanTextValue(cmd, "trending")
-	field.Required = booleanTextValue(cmd, "required")
-	field.Description = textValue(cmd, "description")
-	field.Type = textValue(cmd, "type")
-	field.InlineHelpText = textValue(cmd, "inline-help")
-	field.ReferenceTo = textValue(cmd, "references")
-	field.RelationshipName = textValue(cmd, "relationship-name")
-	field.DefaultValue = textValue(cmd, "default")
-	field.Precision = integerValue(cmd, "precision")
-	field.Scale = integerValue(cmd, "scale")
-	field.Length = integerValue(cmd, "length")
+	field.Label = TextValue(cmd, "label")
+	field.Unique = BooleanTextValue(cmd, "unique")
+	field.ExternalId = BooleanTextValue(cmd, "external-id")
+	field.TrackHistory = BooleanTextValue(cmd, "history-tracking")
+	field.TrackTrending = BooleanTextValue(cmd, "trending")
+	field.Required = BooleanTextValue(cmd, "required")
+	field.Description = TextValue(cmd, "description")
+	field.Type = TextValue(cmd, "type")
+	field.InlineHelpText = TextValue(cmd, "inline-help")
+	field.ReferenceTo = TextValue(cmd, "references")
+	field.RelationshipName = TextValue(cmd, "relationship-name")
+	field.DefaultValue = TextValue(cmd, "default")
+	field.Precision = IntegerValue(cmd, "precision")
+	field.Scale = IntegerValue(cmd, "scale")
+	field.Length = IntegerValue(cmd, "length")
 	return field
-}
-
-func textValue(cmd *cobra.Command, flag string) (t *objects.TextLiteral) {
-	if cmd.Flags().Changed(flag) {
-		val, _ := cmd.Flags().GetString(flag)
-		t = &objects.TextLiteral{
-			Text: val,
-		}
-	}
-	return t
-}
-
-func integerValue(cmd *cobra.Command, flag string) (t *IntegerText) {
-	if cmd.Flags().Changed(flag) {
-		val, _ := cmd.Flags().GetInt(flag)
-		t = &IntegerText{
-			Text: strconv.Itoa(val),
-		}
-	}
-	return t
-}
-
-func booleanTextValue(cmd *cobra.Command, flag string) (t *BooleanText) {
-	if cmd.Flags().Changed(flag) {
-		val, _ := cmd.Flags().GetBool(flag)
-		t = &BooleanText{
-			Text: strconv.FormatBool(val),
-		}
-	}
-	antiFlag := "no-" + flag
-	if cmd.Flags().Changed(antiFlag) {
-		val, _ := cmd.Flags().GetBool(antiFlag)
-		t = &BooleanText{
-			Text: strconv.FormatBool(!val),
-		}
-	}
-	return t
 }

--- a/cmd/workflow/alerts.go
+++ b/cmd/workflow/alerts.go
@@ -7,19 +7,48 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag"
 
+	. "github.com/octoberswimmer/force-md/general"
+	"github.com/octoberswimmer/force-md/internal"
 	"github.com/octoberswimmer/force-md/workflow"
 )
 
 var (
-	recipient string
-	group     string
+	recipient  string
+	group      string
+	alertName  string
+	senderType SenderType
 )
+
+type SenderType enumflag.Flag
+
+const (
+	None SenderType = iota
+	CurrentUser
+	DefaultWorkflowUser
+	OrgWideEmailAddress
+)
+
+var SenderTypeIds = map[SenderType][]string{
+	None:                {"None"},
+	CurrentUser:         {"CurrentUser"},
+	DefaultWorkflowUser: {"DefaultWorkflowUser"},
+	OrgWideEmailAddress: {"OrgWideEmailAddress"},
+}
 
 func init() {
 	listAlertsCmd.Flags().StringVarP(&recipient, "recipient", "r", "", "recipient or CC email address")
 	listAlertsCmd.Flags().StringVarP(&group, "group", "g", "", "group recipient (DeveloperName)")
+	listAlertsCmd.Flags().VarP(enumflag.New(&senderType, "sendertype", SenderTypeIds, enumflag.EnumCaseInsensitive),
+		"sendertype", "t", "sender type; can be 'CurrentUser', 'DefaultWorkflowUser', or 'OrgWideEmailAddress'")
+
+	editAlertCmd.Flags().StringVarP(&alertName, "alert", "a", "", "alert name")
+	editAlertCmd.Flags().StringP("sender", "s", "", "sender address")
+	editAlertCmd.MarkFlagRequired("alert")
+
 	AlertsCmd.AddCommand(listAlertsCmd)
+	AlertsCmd.AddCommand(editAlertCmd)
 }
 
 var AlertsCmd = &cobra.Command{
@@ -38,6 +67,19 @@ var listAlertsCmd = &cobra.Command{
 	},
 }
 
+var editAlertCmd = &cobra.Command{
+	Use:   "edit -a AlertName [flags] [filename]...",
+	Short: "Edit workflow alert",
+	Long:  "Edit workflow alert",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		alertUpdates := setFields(cmd)
+		for _, file := range args {
+			updateAlert(file, alertUpdates)
+		}
+	},
+}
+
 func listAlerts(file string) {
 	w, err := workflow.Open(file)
 	if err != nil {
@@ -46,6 +88,11 @@ func listAlerts(file string) {
 	}
 	var filters []workflow.AlertFilter
 	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	if senderType != 0 {
+		filters = append(filters, func(a workflow.Alert) bool {
+			return strings.ToLower(a.SenderType.Text) == strings.ToLower(SenderTypeIds[senderType][0])
+		})
+	}
 	if recipient != "" {
 		filters = append(filters, func(a workflow.Alert) bool {
 			t := strings.ToLower(recipient)
@@ -75,6 +122,32 @@ func listAlerts(file string) {
 	}
 	alerts := w.GetAlerts(filters...)
 	for _, r := range alerts {
-		fmt.Printf("%s.%s\n", objectName, r.FullName.Text)
+		fmt.Printf("%s.%s\n", objectName, r.FullName)
+	}
+}
+
+func setFields(cmd *cobra.Command) workflow.Alert {
+	alert := workflow.Alert{}
+	alert.SenderAddress = TextValue(cmd, "sender")
+	return alert
+}
+
+func updateAlert(file string, alertUpdates workflow.Alert) {
+	a, err := workflow.Open(file)
+	if err != nil {
+		log.Warn("parsing workflow failed: " + err.Error())
+		return
+	}
+	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	alertName = strings.ToLower(strings.TrimPrefix(alertName, objectName+"."))
+	err = a.UpdateAlert(alertName, alertUpdates)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(a, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
 	}
 }

--- a/general/flags.go
+++ b/general/flags.go
@@ -1,0 +1,44 @@
+package general
+
+import (
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func TextValue(cmd *cobra.Command, flag string) (t *TextLiteral) {
+	if cmd.Flags().Changed(flag) {
+		val, _ := cmd.Flags().GetString(flag)
+		t = &TextLiteral{
+			Text: val,
+		}
+	}
+	return t
+}
+
+func IntegerValue(cmd *cobra.Command, flag string) (t *IntegerText) {
+	if cmd.Flags().Changed(flag) {
+		val, _ := cmd.Flags().GetInt(flag)
+		t = &IntegerText{
+			Text: strconv.Itoa(val),
+		}
+	}
+	return t
+}
+
+func BooleanTextValue(cmd *cobra.Command, flag string) (t *BooleanText) {
+	if cmd.Flags().Changed(flag) {
+		val, _ := cmd.Flags().GetBool(flag)
+		t = &BooleanText{
+			Text: strconv.FormatBool(val),
+		}
+	}
+	antiFlag := "no-" + flag
+	if cmd.Flags().Changed(antiFlag) {
+		val, _ := cmd.Flags().GetBool(antiFlag)
+		t = &BooleanText{
+			Text: strconv.FormatBool(!val),
+		}
+	}
+	return t
+}

--- a/general/types.go
+++ b/general/types.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 )
 
+type TextLiteral struct {
+	Text string `xml:",innerxml"`
+}
+
 var TrueText = BooleanText{
 	Text: "true",
 }

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -7,10 +7,6 @@ import (
 	"github.com/octoberswimmer/force-md/internal"
 )
 
-type TextLiteral struct {
-	Text string `xml:",innerxml"`
-}
-
 type FieldList []Field
 
 type CustomField struct {

--- a/workflow/alert.go
+++ b/workflow/alert.go
@@ -1,0 +1,25 @@
+package workflow
+
+import (
+	"strings"
+
+	"github.com/imdario/mergo"
+	"github.com/pkg/errors"
+)
+
+func (o *Workflow) UpdateAlert(alertName string, updates Alert) error {
+	found := false
+	for i, f := range o.Alerts {
+		if strings.ToLower(f.FullName) == strings.ToLower(alertName) {
+			found = true
+			if err := mergo.Merge(&updates, f, mergo.WithNoOverrideEmptyStructValues); err != nil {
+				return errors.Wrap(err, "merging field updates")
+			}
+			o.Alerts[i] = updates
+		}
+	}
+	if !found {
+		return errors.New("alert not found")
+	}
+	return nil
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -8,73 +8,41 @@ import (
 )
 
 type Recipient struct {
-	Field struct {
-		Text string `xml:",chardata"`
-	} `xml:"field"`
-	Type struct {
-		Text string `xml:",chardata"`
-	} `xml:"type"`
+	Field     *TextLiteral `xml:"field"`
 	Recipient struct {
 		Text string `xml:",chardata"`
 	} `xml:"recipient"`
+	Type struct {
+		Text string `xml:",chardata"`
+	} `xml:"type"`
 }
 
 type Alert struct {
-	FullName struct {
-		Text string `xml:",chardata"`
-	} `xml:"fullName"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Protected struct {
-		Text string `xml:",chardata"`
-	} `xml:"protected"`
-	Recipients []Recipient `xml:"recipients"`
-	SenderType struct {
-		Text string `xml:",chardata"`
-	} `xml:"senderType"`
-	Template struct {
-		Text string `xml:",chardata"`
-	} `xml:"template"`
+	FullName string `xml:"fullName"`
 	CcEmails []struct {
 		Text string `xml:",chardata"`
 	} `xml:"ccEmails"`
+	Description   *TextLiteral `xml:"description"`
+	Protected     *BooleanText `xml:"protected"`
+	Recipients    []Recipient  `xml:"recipients"`
+	SenderAddress *TextLiteral `xml:"senderAddress"`
+	SenderType    *TextLiteral `xml:"senderType"`
+	Template      *TextLiteral `xml:"template"`
 }
 
 type FieldUpdate struct {
-	FullName struct {
-		Text string `xml:",chardata"`
-	} `xml:"fullName"`
-	Field struct {
-		Text string `xml:",chardata"`
-	} `xml:"field"`
-	LookupValue struct {
-		Text string `xml:",chardata"`
-	} `xml:"lookupValue"`
-	LookupValueType struct {
-		Text string `xml:",chardata"`
-	} `xml:"lookupValueType"`
-	Name struct {
-		Text string `xml:",chardata"`
-	} `xml:"name"`
-	NotifyAssignee struct {
-		Text string `xml:",chardata"`
-	} `xml:"notifyAssignee"`
-	Operation struct {
-		Text string `xml:",chardata"`
-	} `xml:"operation"`
-	Protected struct {
-		Text string `xml:",chardata"`
-	} `xml:"protected"`
-	Formula struct {
-		Text string `xml:",chardata"`
-	} `xml:"formula"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	LiteralValue struct {
-		Text string `xml:",chardata"`
-	} `xml:"literalValue"`
+	FullName           TextLiteral  `xml:"fullName"`
+	Description        *TextLiteral `xml:"description"`
+	Field              TextLiteral  `xml:"field"`
+	Formula            *TextLiteral `xml:"formula"`
+	LiteralValue       *TextLiteral `xml:"literalValue"`
+	LookupValue        *TextLiteral `xml:"lookupValue"`
+	LookupValueType    *TextLiteral `xml:"lookupValueType"`
+	Name               TextLiteral  `xml:"name"`
+	NotifyAssignee     *BooleanText `xml:"notifyAssignee"`
+	Operation          *TextLiteral `xml:"operation"`
+	Protected          *BooleanText `xml:"protected"`
+	ReevaluateOnChange *BooleanText `xml:"reevaluateOnChange"`
 }
 
 type Rule struct {
@@ -89,7 +57,8 @@ type Rule struct {
 			Text string `xml:",chardata"`
 		} `xml:"type"`
 	} `xml:"actions"`
-	Active        BooleanText `xml:"active"`
+	Active        BooleanText  `xml:"active"`
+	BooleanFilter *TextLiteral `xml:"booleanFilter"`
 	CriteriaItems []struct {
 		Field struct {
 			Text string `xml:",chardata"`
@@ -97,23 +66,12 @@ type Rule struct {
 		Operation struct {
 			Text string `xml:",chardata"`
 		} `xml:"operation"`
-		Value struct {
-			Text string `xml:",chardata"`
-		} `xml:"value"`
+		Value *TextLiteral `xml:"value"`
 	} `xml:"criteriaItems"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	TriggerType struct {
-		Text string `xml:",chardata"`
-	} `xml:"triggerType"`
-	Formula struct {
-		Text string `xml:",chardata"`
-	} `xml:"formula"`
-	BooleanFilter struct {
-		Text string `xml:",chardata"`
-	} `xml:"booleanFilter"`
-	WorkflowTimeTriggers struct {
+	Description          *TextLiteral `xml:"description"`
+	Formula              *TextLiteral `xml:"formula"`
+	TriggerType          *TextLiteral `xml:"triggerType"`
+	WorkflowTimeTriggers *struct {
 		Actions struct {
 			Name struct {
 				Text string `xml:",chardata"`
@@ -137,9 +95,9 @@ type Rule struct {
 type Workflow struct {
 	XMLName      xml.Name      `xml:"Workflow"`
 	Xmlns        string        `xml:"xmlns,attr"`
+	Alerts       []Alert       `xml:"alerts"`
 	FieldUpdates []FieldUpdate `xml:"fieldUpdates"`
 	Rules        []Rule        `xml:"rules"`
-	Alerts       []Alert       `xml:"alerts"`
 }
 
 func (p *Workflow) MetaCheck() {}


### PR DESCRIPTION
Add `--sendertype` flag to `workflow alert list` to filter alerts by
sender type.

Add `workflow alert edit` with initial support for editing workflow
alert senders.
