### PR TITLE
Strip Object From Layout Name

### DIFF
--- a/cmd/profile/layouts.go
+++ b/cmd/profile/layouts.go
@@ -98,6 +98,7 @@ func editLayout(file string, object, layout string, recordType string) {
 	}
 	if recordType != "" {
 		recordType = strings.TrimPrefix(recordType, object+".")
+		layout = strings.TrimPrefix(layout, object+"-")
 		p.SetObjectLayoutForRecordType(object, layout, recordType)
 	} else {
 		p.SetObjectLayout(object, layout)


### PR DESCRIPTION
Update `profile layout edit` to accept the layout name with our without
the object-name prefix.
