### PR TITLE
Add `permissionset recordtype` Commands

### DIFF
--- a/cmd/permissionset.go
+++ b/cmd/permissionset.go
@@ -17,6 +17,7 @@ func init() {
 	permissionSetCmd.AddCommand(permissionset.UserPermissionsCmd)
 	permissionSetCmd.AddCommand(permissionset.CustomPermissionsCmd)
 	permissionSetCmd.AddCommand(permissionset.ApplicationCmd)
+	permissionSetCmd.AddCommand(permissionset.RecordTypeCmd)
 	permissionSetCmd.AddCommand(permissionset.MergeCmd)
 	RootCmd.AddCommand(permissionSetCmd)
 }

--- a/cmd/permissionset/recordtype.go
+++ b/cmd/permissionset/recordtype.go
@@ -1,0 +1,128 @@
+package permissionset
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/internal"
+	"github.com/octoberswimmer/force-md/permissionset"
+)
+
+var sourceRecordType string
+var recordTypeName string
+
+func init() {
+	addRecordTypeCmd.Flags().StringVarP(&recordTypeName, "recordtype", "r", "", "record type name")
+	addRecordTypeCmd.MarkFlagRequired("recordtype")
+
+	deleteRecordTypeCmd.Flags().StringVarP(&recordTypeName, "recordtype", "r", "", "record type name")
+	deleteRecordTypeCmd.MarkFlagRequired("recordtype")
+
+	RecordTypeCmd.AddCommand(addRecordTypeCmd)
+	RecordTypeCmd.AddCommand(deleteRecordTypeCmd)
+	RecordTypeCmd.AddCommand(listRecordTypesCmd)
+}
+
+var RecordTypeCmd = &cobra.Command{
+	Use:   "recordtype",
+	Short: "Manage record type visibility",
+}
+
+var addRecordTypeCmd = &cobra.Command{
+	Use:                   "add -r SObject.RecordType [filename]...",
+	Short:                 "Add record type",
+	Long:                  "Add record type to permission sets",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			addRecordTypeVisibility(file)
+		}
+	},
+}
+
+var deleteRecordTypeCmd = &cobra.Command{
+	Use:                   "delete -r SObject.RecordType [filename]...",
+	Short:                 "Delete record type",
+	Long:                  "Delete record type visisiblity from permission sets",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			deleteRecordTypeVisibility(file, recordTypeName)
+		}
+	},
+}
+
+var listRecordTypesCmd = &cobra.Command{
+	Use:                   "list [filename]...",
+	Short:                 "List record types",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			listRecordTypes(file)
+		}
+	},
+}
+
+func addRecordTypeVisibility(file string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permission set failed: " + err.Error())
+		return
+	}
+	err = p.AddRecordType(recordTypeName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func deleteRecordTypeVisibility(file string, recordTypeName string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permission sets failed: " + err.Error())
+		return
+	}
+	err = p.DeleteRecordType(recordTypeName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func listRecordTypes(file string) {
+	p, err := permissionset.Open(file)
+	if err != nil {
+		log.Warn("parsing permission sets failed: " + err.Error())
+		return
+	}
+	recordTypes := p.GetRecordTypeVisibility()
+	for _, a := range recordTypes {
+		var perms []string
+		if a.Visible.Text == "true" {
+			perms = append(perms, "visible")
+		} else {
+			perms = append(perms, "not visible")
+		}
+		permsString := "no access"
+		if len(perms) > 0 {
+			permsString = strings.Join(perms, " ")
+		}
+		fmt.Printf("%s: %s\n", a.RecordType, permsString)
+	}
+}

--- a/permissionset/recordtype.go
+++ b/permissionset/recordtype.go
@@ -1,6 +1,8 @@
 package permissionset
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 
 	. "github.com/octoberswimmer/force-md/general"
@@ -19,5 +21,30 @@ func (p *PermissionSet) AddRecordType(recordType string) error {
 		Visible:    TrueText,
 	})
 	p.RecordTypeVisibilities.Tidy()
+	return nil
+}
+
+func (p *PermissionSet) GetRecordTypeVisibility() RecordTypeList {
+	return p.RecordTypeVisibilities
+}
+
+func (p *PermissionSet) DeleteRecordType(recordtype string) error {
+	bits := strings.SplitN(recordtype, ".", 2)
+	if len(bits) != 2 {
+		return errors.New("record type should be ObjectName.RecordTypeName")
+	}
+	found := false
+	newPerms := p.RecordTypeVisibilities[:0]
+	for _, f := range p.RecordTypeVisibilities {
+		if f.RecordType == recordtype {
+			found = true
+		} else {
+			newPerms = append(newPerms, f)
+		}
+	}
+	if !found {
+		return errors.New("record type not found")
+	}
+	p.RecordTypeVisibilities = newPerms
 	return nil
 }


### PR DESCRIPTION
Add `permissionset recordtype` commands to add and delete Record Types
from Permission Sets.
