### PR TITLE
Support New Fields in `objects recordtype picklist add`

### DIFF
--- a/cmd/objects/recordtype.go
+++ b/cmd/objects/recordtype.go
@@ -162,6 +162,9 @@ func tableRecordTypePicklistOptions(file string) {
 	objectName := strings.TrimSuffix(path.Base(file), ".object")
 	recordTypes := o.GetRecordTypes()
 
+	fieldName = strings.TrimPrefix(fieldName, objectName+".")
+	recordTypeName = strings.TrimPrefix(recordTypeName, objectName+".")
+
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Record Type", "Field", "Value", "Default"})
 	table.SetAutoMergeCells(true)

--- a/objects/fields.go
+++ b/objects/fields.go
@@ -98,6 +98,7 @@ func (o *CustomObject) AddFieldPicklistValue(fieldName string, recordType string
 		if strings.ToLower(f.FullName) != strings.ToLower(recordType) {
 			continue
 		}
+		option := ValueSetOption{FullName: picklistValue, Default: FalseText}
 		for j, p := range f.PicklistValues {
 			if strings.ToLower(p.Picklist) != strings.ToLower(fieldName) {
 				continue
@@ -108,14 +109,20 @@ func (o *CustomObject) AddFieldPicklistValue(fieldName string, recordType string
 				}
 			}
 			found = true
-			o.RecordTypes[i].PicklistValues[j].Values = append(o.RecordTypes[i].PicklistValues[j].Values, ValueSetOption{
-				FullName: picklistValue,
-				Default:  FalseText,
-			})
+			o.RecordTypes[i].PicklistValues[j].Values = append(o.RecordTypes[i].PicklistValues[j].Values, option)
+			o.RecordTypes[i].PicklistValues[j].Values.Tidy()
 		}
+		if !found {
+			o.RecordTypes[i].PicklistValues = append(o.RecordTypes[i].PicklistValues, Picklist{
+				Picklist: fieldName,
+				Values:   []ValueSetOption{option},
+			})
+			found = true
+		}
+		o.RecordTypes[i].PicklistValues.Tidy()
 	}
 	if !found {
-		return errors.New("field not found")
+		return errors.New("record type not found")
 	}
 	return nil
 }

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -228,6 +228,15 @@ type ValueSetOption struct {
 	Default  BooleanText `xml:"default"`
 }
 
+type ValueSetOptionList []ValueSetOption
+
+type Picklist struct {
+	Picklist string             `xml:"picklist"`
+	Values   ValueSetOptionList `xml:"values"`
+}
+
+type PicklistList []Picklist
+
 type RecordType struct {
 	FullName string `xml:"fullName"`
 	Active   struct {
@@ -242,10 +251,7 @@ type RecordType struct {
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	PicklistValues []struct {
-		Picklist string           `xml:"picklist"`
-		Values   []ValueSetOption `xml:"values"`
-	} `xml:"picklistValues"`
+	PicklistValues PicklistList `xml:"picklistValues"`
 }
 type CustomObject struct {
 	XMLName         xml.Name `xml:"CustomObject"`

--- a/objects/tidy.go
+++ b/objects/tidy.go
@@ -22,3 +22,15 @@ func (fields FieldList) Tidy() {
 		return fields[i].FullName < fields[j].FullName
 	})
 }
+
+func (values ValueSetOptionList) Tidy() {
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].FullName < values[j].FullName
+	})
+}
+
+func (picklists PicklistList) Tidy() {
+	sort.Slice(picklists, func(i, j int) bool {
+		return picklists[i].Picklist < picklists[j].Picklist
+	})
+}


### PR DESCRIPTION
Update `objects recordtype picklist add` so that a value can be added
for a field that doesn't have any picklist options assigned yet.
