### PR TITLE
Add `application` Command

### DIFF
--- a/application/actions.go
+++ b/application/actions.go
@@ -1,0 +1,41 @@
+package application
+
+import (
+	"errors"
+)
+
+type ProfileActionOverrideFilter func(ProfileActionOverride) bool
+
+func (o *CustomApplication) GetProfileActionOverrides(filters ...ProfileActionOverrideFilter) []ProfileActionOverride {
+	var actions []ProfileActionOverride
+ACTIONS:
+	for _, a := range o.ProfileActionOverrides {
+		for _, filter := range filters {
+			if !filter(a) {
+				continue ACTIONS
+			}
+		}
+		actions = append(actions, a)
+	}
+	return actions
+}
+
+func (o *CustomApplication) DeleteActionOverrides(filters ...ProfileActionOverrideFilter) error {
+	found := false
+	newActions := o.ProfileActionOverrides[:0]
+ACTIONS:
+	for _, a := range o.ProfileActionOverrides {
+		for _, filter := range filters {
+			if !filter(a) {
+				newActions = append(newActions, a)
+				continue ACTIONS
+			}
+		}
+		found = true
+	}
+	if !found {
+		return errors.New("no actions found")
+	}
+	o.ProfileActionOverrides = newActions
+	return nil
+}

--- a/application/application.go
+++ b/application/application.go
@@ -1,0 +1,113 @@
+package application
+
+import (
+	"encoding/xml"
+
+	. "github.com/octoberswimmer/force-md/general"
+	"github.com/octoberswimmer/force-md/internal"
+)
+
+type ProfileActionOverride struct {
+	ActionName        string  `xml:"actionName"`
+	Content           string  `xml:"content"`
+	FormFactor        string  `xml:"formFactor"`
+	PageOrSobjectType string  `xml:"pageOrSobjectType"`
+	RecordType        *string `xml:"recordType"`
+	Type              string  `xml:"type"`
+	Profile           string  `xml:"profile"`
+}
+
+type ProfileActionOverrideList []ProfileActionOverride
+
+type CustomApplication struct {
+	XMLName xml.Name `xml:"CustomApplication"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Brand   *struct {
+		HeaderColor struct {
+			Text string `xml:",chardata"`
+		} `xml:"headerColor"`
+		Logo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"logo"`
+		LogoVersion *struct {
+			Text string `xml:",chardata"`
+		} `xml:"logoVersion"`
+		ShouldOverrideOrgTheme struct {
+			Text string `xml:",chardata"`
+		} `xml:"shouldOverrideOrgTheme"`
+	} `xml:"brand"`
+	DefaultLandingTab *struct {
+		Text string `xml:",chardata"`
+	} `xml:"defaultLandingTab"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	ActionOverrides []struct {
+		ActionName struct {
+			Text string `xml:",chardata"`
+		} `xml:"actionName"`
+		Comment struct {
+			Text string `xml:",chardata"`
+		} `xml:"comment"`
+		Content struct {
+			Text string `xml:",chardata"`
+		} `xml:"content"`
+		FormFactor struct {
+			Text string `xml:",chardata"`
+		} `xml:"formFactor"`
+		SkipRecordTypeSelect struct {
+			Text string `xml:",chardata"`
+		} `xml:"skipRecordTypeSelect"`
+		Type struct {
+			Text string `xml:",chardata"`
+		} `xml:"type"`
+		PageOrSobjectType struct {
+			Text string `xml:",chardata"`
+		} `xml:"pageOrSobjectType"`
+	} `xml:"actionOverrides"`
+	FormFactors []struct {
+		Text string `xml:",chardata"`
+	} `xml:"formFactors"`
+	IsNavAutoTempTabsDisabled *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isNavAutoTempTabsDisabled"`
+	IsNavPersonalizationDisabled *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isNavPersonalizationDisabled"`
+	IsNavTabPersistenceDisabled *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isNavTabPersistenceDisabled"`
+	Label *struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	Logo *struct {
+		Text string `xml:",chardata"`
+	} `xml:"logo"`
+	NavType *struct {
+		Text string `xml:",chardata"`
+	} `xml:"navType"`
+	ProfileActionOverrides ProfileActionOverrideList `xml:"profileActionOverrides"`
+	SetupExperience        *struct {
+		Text string `xml:",chardata"`
+	} `xml:"setupExperience"`
+	Tabs   []TextLiteral `xml:"tabs"`
+	UiType *struct {
+		Text string `xml:",chardata"`
+	} `xml:"uiType"`
+	UtilityBar *struct {
+		Text string `xml:",chardata"`
+	} `xml:"utilityBar"`
+	WorkspaceConfig *struct {
+		Mappings []struct {
+			FieldName *string `xml:"fieldName"`
+			Tab       *string `xml:"tab"`
+		} `xml:"mappings"`
+	} `xml:"workspaceConfig"`
+}
+
+func (p *CustomApplication) MetaCheck() {}
+
+func Open(path string) (*CustomApplication, error) {
+	p := &CustomApplication{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/application/tab.go
+++ b/application/tab.go
@@ -1,0 +1,47 @@
+package application
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	. "github.com/octoberswimmer/force-md/general"
+)
+
+var TabExistsError = errors.New("tab already exists")
+
+func (p *CustomApplication) AddTab(tabName string) error {
+	for _, t := range p.Tabs {
+		if strings.ToLower(t.Text) == strings.ToLower(tabName) {
+			return TabExistsError
+		}
+	}
+	p.Tabs = append(p.Tabs, TextLiteral{
+		Text: tabName,
+	})
+	sort.Slice(p.Tabs, func(i, j int) bool {
+		return p.Tabs[i].Text < p.Tabs[j].Text
+	})
+	return nil
+}
+
+func (p *CustomApplication) DeleteTab(tabName string) error {
+	found := false
+	newTabs := p.Tabs[:0]
+	for _, f := range p.Tabs {
+		if strings.ToLower(f.Text) == strings.ToLower(tabName) {
+			found = true
+		} else {
+			newTabs = append(newTabs, f)
+		}
+	}
+	if !found {
+		return errors.New("tab not found")
+	}
+	p.Tabs = newTabs
+	return nil
+}
+
+func (p *CustomApplication) GetTabs() []TextLiteral {
+	return p.Tabs
+}

--- a/application/tidy.go
+++ b/application/tidy.go
@@ -1,0 +1,31 @@
+package application
+
+import "sort"
+
+func (a *CustomApplication) Tidy() {
+	a.ProfileActionOverrides.Tidy()
+}
+
+func (pao ProfileActionOverrideList) Tidy() {
+	sort.Slice(pao, func(i, j int) bool {
+		if pao[i].PageOrSobjectType != pao[j].PageOrSobjectType {
+			return pao[i].PageOrSobjectType < pao[j].PageOrSobjectType
+		}
+		if pao[i].ActionName != pao[j].ActionName {
+			return pao[i].ActionName < pao[j].ActionName
+		}
+		if pao[i].RecordType != nil && pao[j].RecordType != nil && *pao[i].RecordType != *pao[j].RecordType {
+			return *pao[i].RecordType < *pao[j].RecordType
+		}
+		if pao[i].FormFactor != pao[j].FormFactor {
+			return pao[i].FormFactor > pao[j].FormFactor
+		}
+		if pao[i].Profile != pao[j].Profile {
+			return pao[i].Profile < pao[j].Profile
+		}
+		if pao[i].Type != pao[j].Type {
+			return pao[i].Type < pao[j].Type
+		}
+		return pao[i].Content < pao[j].Content
+	})
+}

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/cmd/application"
+)
+
+func init() {
+	applicationCmd.AddCommand(application.ActionCmd)
+	applicationCmd.AddCommand(application.TabCmd)
+	applicationCmd.AddCommand(application.TidyCmd)
+	RootCmd.AddCommand(applicationCmd)
+}
+
+var applicationCmd = &cobra.Command{
+	Use:   "application",
+	Short: "Manage Applications",
+}

--- a/cmd/application/actions.go
+++ b/cmd/application/actions.go
@@ -1,0 +1,202 @@
+package application
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag"
+
+	"github.com/octoberswimmer/force-md/application"
+	"github.com/octoberswimmer/force-md/internal"
+)
+
+var action Action
+var formFactor FormFactor
+var profile string
+var pageObject string
+var recordType string
+var content string
+
+type Action enumflag.Flag
+type FormFactor enumflag.Flag
+
+const (
+	NoneAction Action = iota
+	View
+	Tab
+)
+
+const (
+	NoneFormFactor FormFactor = iota
+	Large
+	Small
+)
+
+var ActionIds = map[Action][]string{
+	NoneAction: {"None"},
+	View:       {"View"},
+	Tab:        {"Tab"},
+}
+
+var FormFactorIds = map[FormFactor][]string{
+	NoneFormFactor: {"None"},
+	Large:          {"Large"},
+	Small:          {"Small"},
+}
+
+func init() {
+	tableActionCmd.Flags().VarP(enumflag.New(&action, "action", ActionIds, enumflag.EnumCaseInsensitive),
+		"action", "a", "action; can be 'Tab' or 'View'")
+
+	tableActionCmd.Flags().VarP(enumflag.New(&formFactor, "formfactor", FormFactorIds, enumflag.EnumCaseInsensitive),
+		"formfactor", "f", "form factor; can be 'Large' or 'Small'")
+
+	tableActionCmd.Flags().StringVarP(&profile, "profile", "p", "", "profile name")
+	tableActionCmd.Flags().StringVarP(&pageObject, "object", "o", "", "sobject or page name")
+	tableActionCmd.Flags().StringVarP(&recordType, "recordType", "r", "", "record type")
+	tableActionCmd.Flags().StringVarP(&content, "content", "c", "", "content")
+
+	deleteActionCmd.Flags().StringVarP(&profile, "profile", "p", "", "profile name")
+	deleteActionCmd.Flags().StringVarP(&pageObject, "object", "o", "", "sobject or page name")
+	deleteActionCmd.Flags().StringVarP(&content, "content", "c", "", "content")
+	deleteActionCmd.Flags().VarP(enumflag.New(&formFactor, "formfactor", FormFactorIds, enumflag.EnumCaseInsensitive),
+		"formfactor", "f", "form factor; can be 'Large' or 'Small'")
+
+	ActionCmd.AddCommand(tableActionCmd)
+	ActionCmd.AddCommand(deleteActionCmd)
+}
+
+var ActionCmd = &cobra.Command{
+	Use:   "action",
+	Short: "Manage Profile Action Overrides ",
+}
+
+var tableActionCmd = &cobra.Command{
+	Use:   "table [flags] [filename]...",
+	Short: "List Profile Action Overrides in a table",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			tableProfileActionOverrides(file)
+		}
+	},
+}
+
+var deleteActionCmd = &cobra.Command{
+	Use:   "delete [flags] [filename]...",
+	Short: "Delete action overrides",
+	Long:  "Delete action overrides from applications",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			deleteActionOverride(file)
+		}
+	},
+}
+
+func deleteActionOverride(file string) {
+	o, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing application failed: " + err.Error())
+		return
+	}
+	var filters []application.ProfileActionOverrideFilter
+	if content != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.Content) == strings.ToLower(content)
+		})
+	}
+	switch formFactor {
+	case Large, Small:
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return a.FormFactor == FormFactorIds[formFactor][0]
+		})
+	}
+	if profile != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.Profile) == strings.ToLower(profile)
+		})
+	}
+	if pageObject != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.PageOrSobjectType) == strings.ToLower(pageObject)
+		})
+	}
+	err = o.DeleteActionOverrides(filters...)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(o, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func tableProfileActionOverrides(file string) {
+	w, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing applications failed: " + err.Error())
+		return
+	}
+	applicationName := strings.TrimSuffix(path.Base(file), ".app")
+	var filters []application.ProfileActionOverrideFilter
+	switch action {
+	case Tab, View:
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return a.ActionName == ActionIds[action][0]
+		})
+	}
+	switch formFactor {
+	case Large, Small:
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return a.FormFactor == FormFactorIds[formFactor][0]
+		})
+	}
+	if profile != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.Profile) == strings.ToLower(profile)
+		})
+	}
+	if pageObject != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.PageOrSobjectType) == strings.ToLower(pageObject)
+		})
+	}
+	if recordType != "" {
+		if !strings.Contains(recordType, ".") && pageObject != "" {
+			recordType = pageObject + "." + recordType
+		}
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return a.RecordType != nil && strings.ToLower(*a.RecordType) == strings.ToLower(recordType)
+		})
+	}
+	if content != "" {
+		filters = append(filters, func(a application.ProfileActionOverride) bool {
+			return strings.ToLower(a.Content) == strings.ToLower(content)
+		})
+	}
+	actions := w.GetProfileActionOverrides(filters...)
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Application", "Page/Object", "Record Type", "Profile", "Action", "Form Factor", "Lightning Page"})
+	table.SetAutoMergeCells(true)
+	table.SetAutoMergeCellsByColumnIndex([]int{1, 2})
+	table.SetRowLine(true)
+	for _, r := range actions {
+		recordType := ""
+		if r.RecordType != nil {
+			recordType = *r.RecordType
+		}
+		table.Append([]string{applicationName, r.PageOrSobjectType, recordType, r.Profile, r.ActionName, r.FormFactor, r.Content})
+	}
+	if table.NumLines() > 0 {
+		table.Render()
+	}
+}

--- a/cmd/application/tab.go
+++ b/cmd/application/tab.go
@@ -1,0 +1,110 @@
+package application
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/application"
+	"github.com/octoberswimmer/force-md/internal"
+)
+
+var tabName string
+
+func init() {
+	addTabCmd.Flags().StringVarP(&tabName, "tab", "t", "", "tab name")
+	addTabCmd.MarkFlagRequired("tab")
+
+	deleteTabCmd.Flags().StringVarP(&tabName, "tab", "t", "", "tab name")
+	deleteTabCmd.MarkFlagRequired("tab")
+
+	TabCmd.AddCommand(addTabCmd)
+	TabCmd.AddCommand(deleteTabCmd)
+	TabCmd.AddCommand(listTabsCmd)
+}
+
+var TabCmd = &cobra.Command{
+	Use:   "tab",
+	Short: "Manage tabs",
+}
+
+var addTabCmd = &cobra.Command{
+	Use:   "add -t TabName [flags] [filename]...",
+	Short: "Add tab visibility",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			addTab(file)
+		}
+	},
+}
+
+var deleteTabCmd = &cobra.Command{
+	Use:                   "delete -c TabName [filename]...",
+	Short:                 "Delete tab",
+	Long:                  "Delete tab from application",
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			deleteTab(file, tabName)
+		}
+	},
+}
+
+var listTabsCmd = &cobra.Command{
+	Use:                   "list [filename]...",
+	Short:                 "List tabs",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			listTabs(file)
+		}
+	},
+}
+
+func addTab(file string) {
+	p, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing application failed: " + err.Error())
+		return
+	}
+	p.AddTab(tabName)
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func deleteTab(file string, tabName string) {
+	p, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing application failed: " + err.Error())
+		return
+	}
+	err = p.DeleteTab(tabName)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(p, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func listTabs(file string) {
+	p, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing permissionset failed: " + err.Error())
+		return
+	}
+	tabs := p.GetTabs()
+	for _, a := range tabs {
+		fmt.Println(a.Text)
+	}
+}

--- a/cmd/application/tidy.go
+++ b/cmd/application/tidy.go
@@ -1,0 +1,32 @@
+package application
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/application"
+	"github.com/octoberswimmer/force-md/general"
+)
+
+var TidyCmd = &cobra.Command{
+	Use:                   "tidy [filename]...",
+	Short:                 "Tidy custom application",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			tidy(file)
+		}
+	},
+}
+
+func tidy(file string) {
+	p, err := application.Open(file)
+	if err != nil {
+		log.Warn("parsing application failed: " + err.Error())
+		return
+	}
+	if err := general.Tidy(p, file); err != nil {
+		log.Warn("tidying failed: " + err.Error())
+	}
+}

--- a/cmd/objects.go
+++ b/cmd/objects.go
@@ -12,6 +12,7 @@ func init() {
 	objectsCmd.AddCommand(objects.RecordTypeCmd)
 	objectsCmd.AddCommand(objects.TidyCmd)
 	objectsCmd.AddCommand(objects.ValidationRuleCmd)
+	objectsCmd.AddCommand(objects.ActionCmd)
 	RootCmd.AddCommand(objectsCmd)
 }
 

--- a/cmd/objects/action.go
+++ b/cmd/objects/action.go
@@ -1,0 +1,120 @@
+package objects
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag"
+
+	"github.com/octoberswimmer/force-md/objects"
+)
+
+var actionType Type
+var formFactor FormFactor
+
+type Type enumflag.Flag
+type FormFactor enumflag.Flag
+
+const (
+	NoneType Type = iota
+	Default
+	Flexipage
+	LightningComponent
+	Scontrol
+	Standard
+	Visualforce
+)
+
+const (
+	NoneFormFactor FormFactor = iota
+	Large
+	Small
+)
+
+var TypeIds = map[Type][]string{
+	NoneType:           {"None"},
+	Default:            {"Default"},
+	Flexipage:          {"FlexiPage"},
+	LightningComponent: {"LightningComponent"},
+	Scontrol:           {"Scontrol"},
+	Standard:           {"Standard"},
+	Visualforce:        {"Visualforce"},
+}
+
+var FormFactorIds = map[FormFactor][]string{
+	NoneFormFactor: {"None"},
+	Large:          {"Large"},
+	Small:          {"Small"},
+}
+
+func init() {
+	tableActionCmd.Flags().VarP(enumflag.New(&actionType, "type", TypeIds, enumflag.EnumCaseInsensitive),
+		"type", "t", "type; can be 'Default', 'FlexiPage', 'LightningComponent', 'Scontrol', 'Standard', or 'Visualforce'")
+
+	tableActionCmd.Flags().VarP(enumflag.New(&formFactor, "formfactor", FormFactorIds, enumflag.EnumCaseInsensitive),
+		"formfactor", "f", "form factor; can be 'Large' or 'Small'")
+
+	ActionCmd.AddCommand(tableActionCmd)
+}
+
+var ActionCmd = &cobra.Command{
+	Use:   "action",
+	Short: "Manage Action Overrides ",
+}
+
+var tableActionCmd = &cobra.Command{
+	Use:   "table [flags] [filename]...",
+	Short: "List Action Overrides in a table",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			tableActionOverrides(file)
+		}
+	},
+}
+
+func tableActionOverrides(file string) {
+	w, err := objects.Open(file)
+	if err != nil {
+		log.Warn("parsing applications failed: " + err.Error())
+		return
+	}
+	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	var filters []objects.ActionOverrideFilter
+	switch actionType {
+	case Default, Flexipage, LightningComponent, Scontrol, Standard, Visualforce:
+		filters = append(filters, func(a objects.ActionOverride) bool {
+			return strings.ToLower(a.Type) == strings.ToLower(TypeIds[actionType][0])
+		})
+	}
+	switch formFactor {
+	case Large, Small:
+		filters = append(filters, func(a objects.ActionOverride) bool {
+			return a.FormFactor != nil && strings.ToLower(*a.FormFactor) == strings.ToLower(FormFactorIds[formFactor][0])
+		})
+	}
+	actions := w.GetActionOverrides(filters...)
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Object", "Action", "Form Factor", "Type", "Page/Component"})
+	table.SetAutoMergeCells(true)
+	table.SetAutoMergeCellsByColumnIndex([]int{1, 2, 3})
+	table.SetRowLine(true)
+	for _, r := range actions {
+		var formFactor, content string
+		if r.FormFactor != nil {
+			formFactor = *r.FormFactor
+		}
+		if r.Content != nil {
+			content = *r.Content
+		}
+		table.Append([]string{objectName, r.ActionName, formFactor, r.Type, content})
+	}
+	if table.NumLines() > 0 {
+		table.Render()
+	}
+}

--- a/objects/actions.go
+++ b/objects/actions.go
@@ -1,0 +1,17 @@
+package objects
+
+type ActionOverrideFilter func(ActionOverride) bool
+
+func (o *CustomObject) GetActionOverrides(filters ...ActionOverrideFilter) []ActionOverride {
+	var actions []ActionOverride
+ACTIONS:
+	for _, a := range o.ActionOverrides {
+		for _, filter := range filters {
+			if !filter(a) {
+				continue ACTIONS
+			}
+		}
+		actions = append(actions, a)
+	}
+	return actions
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -253,29 +253,20 @@ type RecordType struct {
 	} `xml:"label"`
 	PicklistValues PicklistList `xml:"picklistValues"`
 }
+
+type ActionOverride struct {
+	ActionName           string       `xml:"actionName"`
+	Comment              *string      `xml:"comment"`
+	Content              *string      `xml:"content"`
+	FormFactor           *string      `xml:"formFactor"`
+	SkipRecordTypeSelect *BooleanText `xml:"skipRecordTypeSelect"`
+	Type                 string       `xml:"type"`
+}
+
 type CustomObject struct {
-	XMLName         xml.Name `xml:"CustomObject"`
-	Xmlns           string   `xml:"xmlns,attr"`
-	ActionOverrides []struct {
-		ActionName struct {
-			Text string `xml:",chardata"`
-		} `xml:"actionName"`
-		Comment *struct {
-			Text string `xml:",chardata"`
-		} `xml:"comment"`
-		Content *struct {
-			Text string `xml:",chardata"`
-		} `xml:"content"`
-		FormFactor *struct {
-			Text string `xml:",chardata"`
-		} `xml:"formFactor"`
-		SkipRecordTypeSelect *struct {
-			Text string `xml:",chardata"`
-		} `xml:"skipRecordTypeSelect"`
-		Type struct {
-			Text string `xml:",chardata"`
-		} `xml:"type"`
-	} `xml:"actionOverrides"`
+	XMLName              xml.Name         `xml:"CustomObject"`
+	Xmlns                string           `xml:"xmlns,attr"`
+	ActionOverrides      []ActionOverride `xml:"actionOverrides"`
 	AllowInChatterGroups *struct {
 		Text string `xml:",chardata"`
 	} `xml:"allowInChatterGroups"`


### PR DESCRIPTION
Add `application` command to manage custom applications.  Currently
supports profile action overrides and tabs.

Add `objects action table` command to show default actions for an
object.
