### PR TITLE
Add `--dashboard-type` Flag to `dashboard edit` To Edit Dashboard Type

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -207,11 +207,9 @@ type Dashboard struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 	} `xml:"dashboardFilters"`
-	DashboardType struct {
-		Text string `xml:",chardata"`
-	} `xml:"dashboardType"`
-	Description  *TextLiteral `xml:"description"`
-	IsGridLayout struct {
+	DashboardType *TextLiteral `xml:"dashboardType"`
+	Description   *TextLiteral `xml:"description"`
+	IsGridLayout  struct {
 		Text string `xml:",chardata"`
 	} `xml:"isGridLayout"`
 	LeftSection *struct {

--- a/dashboard/edit.go
+++ b/dashboard/edit.go
@@ -9,3 +9,9 @@ func (o *Dashboard) UpdateRunningUser(user string) {
 		Text: user,
 	}
 }
+
+func (o *Dashboard) UpdateDashboardType(dashboardType string) {
+	o.DashboardType = &TextLiteral{
+		Text: dashboardType,
+	}
+}


### PR DESCRIPTION
Add `--dashboard-type` flag to `dashboard edit` command to set dashboard
type to SpecifiedUser, LoggedInUser, or MyTeamUser.
