### PR TITLE
Add `custommetadata table` Command

### DIFF
--- a/cmd/custommetadata.go
+++ b/cmd/custommetadata.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/cmd/custommetadata"
+)
+
+func init() {
+	customMetadataCmd.AddCommand(custommetadata.TableCmd)
+	RootCmd.AddCommand(customMetadataCmd)
+}
+
+var customMetadataCmd = &cobra.Command{
+	Use:   "custommetadata [command] [flags] [filename]...",
+	Short: "Manage Custom Metadata",
+}

--- a/cmd/custommetadata/list.go
+++ b/cmd/custommetadata/list.go
@@ -1,0 +1,64 @@
+package custommetadata
+
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/octoberswimmer/force-md/custommetadata"
+)
+
+func init() {
+}
+
+var TableCmd = &cobra.Command{
+	Use:   "table [flags] [filename]...",
+	Short: "List custom metadata in a table",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		tableCustomMetadata(args)
+	},
+}
+
+func tableCustomMetadata(files []string) {
+	var fieldNames []string
+	allFields := make(map[string]bool)
+	type record struct {
+		label  string
+		fields map[string]string
+	}
+	var records []record
+	for _, file := range files {
+		m, err := custommetadata.Open(file)
+		if err != nil {
+			log.Warn("parsing profile failed: " + err.Error())
+			return
+		}
+		// file := strings.TrimSuffix(path.Base(file), ".md")
+		fields := make(map[string]string)
+		for _, v := range m.Values {
+			if _, ok := allFields[v.Field]; !ok {
+				fieldNames = append(fieldNames, v.Field)
+				allFields[v.Field] = true
+			}
+			fields[v.Field] = v.Value.Text
+		}
+		records = append(records, record{m.Label, fields})
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoFormatHeaders(false)
+	table.SetHeader(append([]string{"Label"}, fieldNames...))
+	table.SetRowLine(true)
+	for _, r := range records {
+		row := []string{r.label}
+		for _, f := range fieldNames {
+			row = append(row, r.fields[f])
+		}
+		table.Append(row)
+	}
+	if table.NumLines() > 0 {
+		table.Render()
+	}
+}

--- a/custommetadata/custommetadata.go
+++ b/custommetadata/custommetadata.go
@@ -1,0 +1,34 @@
+package custommetadata
+
+import (
+	"encoding/xml"
+
+	"github.com/octoberswimmer/force-md/internal"
+)
+
+type Value struct {
+	Field string `xml:"field"`
+	Value struct {
+		Text string `xml:",chardata"`
+		Type string `xml:"type,attr"`
+	} `xml:"value"`
+}
+
+type CustomMetadata struct {
+	XMLName   xml.Name `xml:"CustomMetadata"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	Xsi       string   `xml:"xsi,attr"`
+	Xsd       string   `xml:"xsd,attr"`
+	Label     string   `xml:"label"`
+	Protected struct {
+		Text string `xml:",chardata"`
+	} `xml:"protected"`
+	Values []Value `xml:"values"`
+}
+
+func (p *CustomMetadata) MetaCheck() {}
+
+func Open(path string) (*CustomMetadata, error) {
+	p := &CustomMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}


### PR DESCRIPTION
Add `custommetadata table` command to list field values for custom
metadata records.
