### PR TITLE
Update `profile field table` to Handle Separate Field and Object Parameters

### DIFF
--- a/cmd/profile/field.go
+++ b/cmd/profile/field.go
@@ -232,6 +232,9 @@ func listFields(file string) {
 
 func tableFieldPermissions(files []string) {
 	var filters []profile.FieldFilter
+	if !strings.ContainsRune(fieldName, '.') && objectName != "" {
+		fieldName = objectName + "." + fieldName
+	}
 	if fieldName != "" {
 		filters = append(filters, func(f permissionset.FieldPermissions) bool {
 			return strings.ToLower(f.Field.Text) == strings.ToLower(fieldName)


### PR DESCRIPTION
If field and object parameters are provided to `profile field table`,
combine them to filter the fields in the profiles.
