### PR TITLE
Fix Handling of ProfileSearchLayouts In Objects

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -499,7 +499,7 @@ type CustomObject struct {
 	PluralLabel *struct {
 		Text string `xml:",chardata"`
 	} `xml:"pluralLabel"`
-	ProfileSearchLayouts *struct {
+	ProfileSearchLayouts []struct {
 		Fields []struct {
 			Text string `xml:",chardata"`
 		} `xml:"fields"`


### PR DESCRIPTION
ProfileSearchLayouts should be list.

Fixes bug in which ProfileSearchLayouts were merged when editing object
metadata.
