### PR TITLE
Add `custommetadata new` and `custommetadata edit` Commands to Edit Custom Metadata Records

### DIFF
--- a/cmd/custommetadata.go
+++ b/cmd/custommetadata.go
@@ -9,6 +9,8 @@ import (
 func init() {
 	customMetadataCmd.AddCommand(custommetadata.TableCmd)
 	customMetadataCmd.AddCommand(custommetadata.ListCmd)
+	customMetadataCmd.AddCommand(custommetadata.NewCmd)
+	customMetadataCmd.AddCommand(custommetadata.EditCmd)
 	RootCmd.AddCommand(customMetadataCmd)
 }
 

--- a/cmd/custommetadata/edit.go
+++ b/cmd/custommetadata/edit.go
@@ -1,0 +1,99 @@
+package custommetadata
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/ForceCLI/force-md/custommetadata"
+	"github.com/ForceCLI/force-md/internal"
+)
+
+var (
+	field string
+	value string
+	label string
+)
+
+func init() {
+	EditCmd.Flags().StringVarP(&field, "field", "f", "", "field")
+	EditCmd.Flags().StringVarP(&value, "value", "v", "", "value")
+
+	EditCmd.Flags().StringVarP(&label, "label", "l", "", "label")
+
+	EditCmd.MarkFlagsRequiredTogether("field", "value")
+}
+
+var EditCmd = &cobra.Command{
+	Use:   "edit [filename]...",
+	Short: "Edit custom metadata",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			if field != "" {
+				editCustomMetadataValue(file, field, value)
+			}
+			if label != "" {
+				editCustomMetadataLabel(file, label)
+			}
+		}
+	},
+}
+
+func editCustomMetadataValue(file string, field string, value string) {
+	p, err := custommetadata.Open(file)
+	if err != nil {
+		log.Warn("parsing custom metadata failed: " + err.Error())
+		return
+	}
+	// Create new CustomMetadata element to deal with bugs
+	// marshaling/unmarshaling XML with namespaces
+	m := custommetadata.CustomMetadata{
+		Xmlns:     "http://soap.sforce.com/2006/04/metadata",
+		Xsi:       "http://www.w3.org/2001/XMLSchema-instance",
+		Xsd:       "http://www.w3.org/2001/XMLSchema",
+		Label:     p.Label,
+		Protected: p.Protected,
+	}
+	for _, v := range p.Values {
+		m.AddValue(v.Field, v.Value.Text)
+	}
+	m.Tidy()
+	err = m.UpdateFieldValue(field, value)
+	if err != nil {
+		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
+		return
+	}
+	err = internal.WriteToFile(m, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}
+
+func editCustomMetadataLabel(file string, label string) {
+	p, err := custommetadata.Open(file)
+	if err != nil {
+		log.Warn("parsing custom metadata failed: " + err.Error())
+		return
+	}
+	// Create new CustomMetadata element to deal with bugs
+	// marshaling/unmarshaling XML with namespaces
+	m := custommetadata.CustomMetadata{
+		Xmlns:     "http://soap.sforce.com/2006/04/metadata",
+		Xsi:       "http://www.w3.org/2001/XMLSchema-instance",
+		Xsd:       "http://www.w3.org/2001/XMLSchema",
+		Label:     label,
+		Protected: p.Protected,
+	}
+	for _, v := range p.Values {
+		m.AddValue(v.Field, v.Value.Text)
+	}
+	m.Tidy()
+	err = internal.WriteToFile(m, file)
+	if err != nil {
+		log.Warn("update failed: " + err.Error())
+		return
+	}
+}

--- a/cmd/custommetadata/new.go
+++ b/cmd/custommetadata/new.go
@@ -1,0 +1,61 @@
+package custommetadata
+
+import (
+	"github.com/antonmedv/expr"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/ForceCLI/force-md/custommetadata"
+	. "github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+)
+
+func init() {
+	NewCmd.Flags().StringP("label", "l", "", "label")
+	NewCmd.Flags().StringP("values", "v", "", "object describing values")
+	NewCmd.MarkFlagRequired("label")
+}
+
+var NewCmd = &cobra.Command{
+	Use:                   "new [filename]...",
+	Short:                 "Create new custom metadata record",
+	DisableFlagsInUseLine: false,
+	Example: `
+$ force-md custommetadata new src/customMetadata/My_Metadata.Example.md -l 'My Example' -v '{My_Field__c: "My Value", Default__c: true}'
+`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		label, _ := cmd.Flags().GetString("label")
+		values, _ := cmd.Flags().GetString("values")
+		for _, file := range args {
+			createFile(file, label, values)
+		}
+	},
+}
+
+func createFile(file string, label, values string) {
+	out, err := expr.Eval(values, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	parsed, ok := out.(map[string]any)
+	if !ok {
+		log.Fatal("Could not parse values")
+	}
+	m := custommetadata.CustomMetadata{
+		Xmlns:     "http://soap.sforce.com/2006/04/metadata",
+		Xsi:       "http://www.w3.org/2001/XMLSchema-instance",
+		Xsd:       "http://www.w3.org/2001/XMLSchema",
+		Label:     label,
+		Protected: FalseText,
+	}
+	for k, v := range parsed {
+		m.AddValue(k, v)
+	}
+	m.Tidy()
+	err = internal.WriteToFile(m, file)
+	if err != nil {
+		log.Warn("create failed: " + err.Error())
+		return
+	}
+}

--- a/custommetadata/custommetadata.go
+++ b/custommetadata/custommetadata.go
@@ -3,27 +3,29 @@ package custommetadata
 import (
 	"encoding/xml"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 )
 
+type TypedValue struct {
+	Text string `xml:",chardata"`
+	Type string `xml:"xsi:type,attr,omitempty"`
+	Nil  string `xml:"xsi:nil,attr,omitempty"`
+}
+
 type Value struct {
-	Field string `xml:"field"`
-	Value struct {
-		Text string `xml:",chardata"`
-		Type string `xml:"type,attr"`
-	} `xml:"value"`
+	Field string     `xml:"field"`
+	Value TypedValue `xml:"value"`
 }
 
 type CustomMetadata struct {
-	XMLName   xml.Name `xml:"CustomMetadata"`
-	Xmlns     string   `xml:"xmlns,attr"`
-	Xsi       string   `xml:"xsi,attr"`
-	Xsd       string   `xml:"xsd,attr"`
-	Label     string   `xml:"label"`
-	Protected struct {
-		Text string `xml:",chardata"`
-	} `xml:"protected"`
-	Values []Value `xml:"values"`
+	XMLName   xml.Name    `xml:"CustomMetadata"`
+	Xmlns     string      `xml:"xmlns,attr"`
+	Xsi       string      `xml:"xmlns:xsi,attr"`
+	Xsd       string      `xml:"xmlns:xsd,attr"`
+	Label     string      `xml:"label"`
+	Protected BooleanText `xml:"protected"`
+	Values    []Value     `xml:"values"`
 }
 
 func (p *CustomMetadata) MetaCheck() {}

--- a/custommetadata/edit.go
+++ b/custommetadata/edit.go
@@ -1,0 +1,45 @@
+package custommetadata
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (p *CustomMetadata) UpdateFieldValue(field string, value string) error {
+	found := false
+	for i, u := range p.Values {
+		if strings.ToLower(u.Field) == strings.ToLower(field) {
+			found = true
+			p.Values[i].Value.Text = value
+		}
+	}
+	if !found {
+		return errors.New("field not found")
+	}
+	return nil
+}
+
+func (m *CustomMetadata) AddValue(key string, value any) {
+	var valueType, stringValue string
+	switch t := value.(type) {
+	case bool:
+		valueType = "xsd:boolean"
+		stringValue = strconv.FormatBool(t)
+	case float32, float64:
+		valueType = "xsd:double"
+		stringValue = value.(string)
+	case int:
+		valueType = "xsd:int"
+		stringValue = strconv.Itoa(t)
+	default:
+		valueType = "xsd:string"
+		stringValue = fmt.Sprintf("%s", t)
+	}
+	if stringValue == "" {
+		m.Values = append(m.Values, Value{Field: key, Value: TypedValue{Nil: "true"}})
+	} else {
+		m.Values = append(m.Values, Value{Field: key, Value: TypedValue{Text: stringValue, Type: valueType}})
+	}
+}

--- a/custommetadata/tidy.go
+++ b/custommetadata/tidy.go
@@ -1,0 +1,11 @@
+package custommetadata
+
+import (
+	"sort"
+)
+
+func (p *CustomMetadata) Tidy() {
+	sort.Slice(p.Values, func(i, j int) bool {
+		return p.Values[i].Field < p.Values[j].Field
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/antonmedv/expr v1.12.5
 	github.com/cwarden/mergo v0.3.12-0.20210528180603-9b708ca2c584
 	github.com/imdario/mergo v0.3.16
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
@@ -16,7 +17,6 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/write.go
+++ b/internal/write.go
@@ -25,7 +25,7 @@ func WriteToFile(t interface{}, fileName string) error {
 	if err != nil {
 		return errors.Wrap(err, "serializing metadata")
 	}
-	b = selfClosing(b)
+	b = SelfClosing(b)
 	if ConvertNumericXMLEntities {
 		b = htmlEntities(b)
 	}
@@ -43,7 +43,7 @@ func htmlEntities(b []byte) []byte {
 }
 
 // Make empty tags self-closing
-func selfClosing(b []byte) []byte {
-	emptyTag := regexp.MustCompile(`(?:</?(\w+)>){2}`)
-	return emptyTag.ReplaceAll(b, []byte(`<$1/>`))
+func SelfClosing(b []byte) []byte {
+	emptyTag := regexp.MustCompile(`<(\w+)(\s*[^>]*)>\s*</[^>]+>`)
+	return emptyTag.ReplaceAll(b, []byte(`<$1$2/>`))
 }

--- a/internal/write_test.go
+++ b/internal/write_test.go
@@ -1,0 +1,34 @@
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/ForceCLI/force-md/internal"
+)
+
+func TestSelfClosing(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected []byte
+	}{
+		{
+			input:    []byte(`<x></x>`),
+			expected: []byte(`<x/>`),
+		},
+		{
+			input:    []byte(`<x attr="blah"></x>`),
+			expected: []byte(`<x attr="blah"/>`),
+		},
+		{
+			input:    []byte(`<x>contents</x>`),
+			expected: []byte(`<x>contents</x>`),
+		},
+	}
+
+	for _, test := range tests {
+		result := SelfClosing(test.input)
+		if string(result) != string(test.expected) {
+			t.Errorf("Input: %s\nExpected: %s\nGot: %s", test.input, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
Add `custommetadata new` command to create a new Custom Metadata record
file using an Expr object for the field-value mapping.

Add `custommetadata edit` command to edit an existing Custom Metadata
record.
