### PR TITLE
Add `objects recordtype table` Command

### DIFF
--- a/cmd/objects/recordtype.go
+++ b/cmd/objects/recordtype.go
@@ -5,12 +5,14 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/objects"
 )
@@ -26,8 +28,15 @@ func init() {
 	writeRecordTypesCmd.Flags().StringP("directory", "d", "", "directory where record types should be output")
 	writeRecordTypesCmd.MarkFlagRequired("directory")
 
+	tableRecordTypesCmd.Flags().BoolP("active", "a", false, "is active")
+	tableRecordTypesCmd.Flags().BoolP("no-active", "A", false, "is not active")
+
+	listRecordTypesCmd.Flags().BoolP("active", "a", false, "is active")
+	listRecordTypesCmd.Flags().BoolP("no-active", "A", false, "is not active")
+
 	RecordTypeCmd.AddCommand(deleteRecordTypeCmd)
 	RecordTypeCmd.AddCommand(listRecordTypesCmd)
+	RecordTypeCmd.AddCommand(tableRecordTypesCmd)
 	RecordTypeCmd.AddCommand(recordtypePicklistCmd)
 	RecordTypeCmd.AddCommand(writeRecordTypesCmd)
 
@@ -86,9 +95,21 @@ var listRecordTypesCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		perms := recordTypeVisibilityFromFlags(cmd)
 		for _, file := range args {
-			listRecordType(file)
+			listRecordType(file, perms)
 		}
+	},
+}
+
+var tableRecordTypesCmd = &cobra.Command{
+	Use:                   "table [filename]...",
+	Short:                 "List object record types in a table",
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		perms := recordTypeVisibilityFromFlags(cmd)
+		tableRecordType(args, perms)
 	},
 }
 
@@ -117,14 +138,21 @@ var writeRecordTypesCmd = &cobra.Command{
 	},
 }
 
-func listRecordType(file string) {
+func listRecordType(file string, filter objects.RecordType) {
 	o, err := objects.Open(file)
 	if err != nil {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
 	objectName := strings.TrimSuffix(path.Base(file), ".object")
-	recordTypes := o.GetRecordTypes()
+	var filters []objects.RecordTypeFilter
+	filters = append(filters, func(r objects.RecordType) bool {
+		if filter.Active.Text != "" && filter.Active.ToBool() != r.Active.ToBool() {
+			return false
+		}
+		return true
+	})
+	recordTypes := o.GetRecordTypes(filters...)
 	for _, f := range recordTypes {
 		fmt.Printf("%s.%s\n", objectName, f.FullName)
 	}
@@ -168,6 +196,37 @@ func assignPicklistValueToRecordType(file string) {
 	if err != nil {
 		log.Warn("update failed: " + err.Error())
 		return
+	}
+}
+
+func tableRecordType(files []string, filter objects.RecordType) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Object", "Record Type", "Active"})
+	table.SetAutoMergeCells(true)
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
+	table.SetRowLine(true)
+	var filters []objects.RecordTypeFilter
+	filters = append(filters, func(r objects.RecordType) bool {
+		if filter.Active.Text != "" && filter.Active.ToBool() != r.Active.ToBool() {
+			return false
+		}
+		return true
+	})
+	for _, file := range files {
+		o, err := objects.Open(file)
+		if err != nil {
+			log.Warn("parsing object failed: " + err.Error())
+			return
+		}
+		objectName := strings.TrimSuffix(path.Base(file), ".object")
+		recordTypes := o.GetRecordTypes(filters...)
+
+		for _, r := range recordTypes {
+			table.Append([]string{objectName, r.FullName, r.Active.String()})
+		}
+	}
+	if table.NumLines() > 0 {
+		table.Render()
 	}
 }
 
@@ -228,4 +287,27 @@ func writeRecordTypes(file string, recordTypesDir string) {
 			return
 		}
 	}
+}
+
+func recordTypeVisibilityFromFlags(cmd *cobra.Command) objects.RecordType {
+	perms := objects.RecordType{}
+	perms.Active = textValue(cmd, "active")
+	return perms
+}
+
+func textValue(cmd *cobra.Command, flag string) (t BooleanText) {
+	if cmd.Flags().Changed(flag) {
+		val, _ := cmd.Flags().GetBool(flag)
+		t = BooleanText{
+			Text: strconv.FormatBool(val),
+		}
+	}
+	antiFlag := "no-" + flag
+	if cmd.Flags().Changed(antiFlag) {
+		val, _ := cmd.Flags().GetBool(antiFlag)
+		t = BooleanText{
+			Text: strconv.FormatBool(!val),
+		}
+	}
+	return t
 }

--- a/internal/strings.go
+++ b/internal/strings.go
@@ -1,0 +1,8 @@
+package internal
+
+import "strings"
+
+// Trim suffix plus anything that follows it.
+func TrimSuffixToEnd(s, suffix string) string {
+	return s[0:strings.LastIndex(s, suffix)]
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -313,10 +313,8 @@ type Picklist struct {
 type PicklistList []Picklist
 
 type RecordType struct {
-	FullName string `xml:"fullName"`
-	Active   struct {
-		Text string `xml:",chardata"`
-	} `xml:"active"`
+	FullName        string      `xml:"fullName"`
+	Active          BooleanText `xml:"active"`
 	BusinessProcess *struct {
 		Text string `xml:",chardata"`
 	} `xml:"businessProcess"`

--- a/objects/recordtype.go
+++ b/objects/recordtype.go
@@ -2,8 +2,20 @@ package objects
 
 import "github.com/pkg/errors"
 
-func (o *CustomObject) GetRecordTypes() []RecordType {
-	return o.RecordTypes
+type RecordTypeFilter func(RecordType) bool
+
+func (o *CustomObject) GetRecordTypes(filters ...RecordTypeFilter) []RecordType {
+	var recordTypes []RecordType
+RECORDTYPES:
+	for _, v := range o.RecordTypes {
+		for _, filter := range filters {
+			if !filter(v) {
+				continue RECORDTYPES
+			}
+		}
+		recordTypes = append(recordTypes, v)
+	}
+	return recordTypes
 }
 
 func (o *CustomObject) DeleteRecordType(recordType string) error {


### PR DESCRIPTION
Add `objects recordtype table` command to display object record tables
in a table.  Supports flags for filtering to only active or only
inactive Record Types.  Add same flags for `objects recordtype list`.
