### PR TITLE
Trim Source Format Extensions

### DIFF
--- a/cmd/application/actions.go
+++ b/cmd/application/actions.go
@@ -145,7 +145,7 @@ func tableProfileActionOverrides(file string) {
 		log.Warn("parsing applications failed: " + err.Error())
 		return
 	}
-	applicationName := strings.TrimSuffix(path.Base(file), ".app")
+	applicationName := internal.TrimSuffixToEnd(path.Base(file), ".app")
 	var filters []application.ProfileActionOverrideFilter
 	switch action {
 	case Tab, View:

--- a/cmd/matchingrules/rules.go
+++ b/cmd/matchingrules/rules.go
@@ -36,7 +36,7 @@ func listRules(file string) {
 		log.Warn("parsing matching rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".matchingRule")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".matchingRule")
 	rules := w.GetMatchingRules()
 	for _, r := range rules {
 		fmt.Printf("%s.%s\n", objectName, r.FullName.Text)
@@ -62,7 +62,7 @@ func deleteRule(file string, ruleName string) {
 		log.Warn("parsing matching rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".matchingRule")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".matchingRule")
 	ruleName = strings.TrimPrefix(ruleName, objectName+".")
 	err = p.DeleteRule(ruleName)
 	if err != nil {

--- a/cmd/objects/action.go
+++ b/cmd/objects/action.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
 
+	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/objects"
 )
 
@@ -83,7 +84,7 @@ func tableActionOverrides(file string) {
 		log.Warn("parsing applications failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	var filters []objects.ActionOverrideFilter
 	switch actionType {
 	case Default, Flexipage, LightningComponent, Scontrol, Standard, Visualforce:

--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -241,7 +241,7 @@ func listFields(file string, attributes objects.Field) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	var filters []objects.FieldFilter
 	requiredFilter := func(f objects.Field) bool {
 		isRequired := alwaysRequired[f.FullName] || (f.Required != nil && f.Required.Text == "true")
@@ -319,7 +319,7 @@ func graphFields(file string, attributes objects.Field, objectsOnly bool) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	var filters []objects.FieldFilter
 	requiredFilter := func(f objects.Field) bool {
 		isRequired := alwaysRequired[f.FullName] || (f.Required != nil && f.Required.Text == "true")
@@ -469,7 +469,7 @@ func tableFields(files []string, attributes objects.Field) {
 			log.Warn("parsing object failed: " + err.Error())
 			return
 		}
-		objectName := strings.TrimSuffix(path.Base(file), ".object")
+		objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 		fields = append(fields, field{object: objectName, fields: o.GetFields(filters...)})
 	}
 	table := tablewriter.NewWriter(os.Stdout)
@@ -515,7 +515,7 @@ func updateField(file string, fieldUpdates objects.Field) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldName = strings.ToLower(strings.TrimPrefix(fieldName, objectName+"."))
 	err = o.UpdateField(fieldName, fieldUpdates)
 	if err != nil {
@@ -535,7 +535,7 @@ func showField(file string, fieldName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldName = strings.ToLower(strings.TrimPrefix(fieldName, objectName+"."))
 	fields := o.GetFields(func(f objects.Field) bool {
 		return strings.ToLower(f.FullName) == fieldName
@@ -564,7 +564,7 @@ func deleteField(file string, fieldName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldName = strings.TrimPrefix(fieldName, objectName+".")
 	err = o.DeleteField(fieldName)
 	if err != nil {

--- a/cmd/objects/fieldset.go
+++ b/cmd/objects/fieldset.go
@@ -60,7 +60,7 @@ func listFieldSets(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldSets := o.GetFieldSets()
 	for _, f := range fieldSets {
 		fmt.Printf("%s.%s\n", objectName, f.FullName)
@@ -73,7 +73,7 @@ func deleteFieldSet(file string, fieldSetName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldSetName = strings.TrimPrefix(fieldSetName, objectName+".")
 	err = o.DeleteFieldSet(fieldSetName)
 	if err != nil {

--- a/cmd/objects/recordtype.go
+++ b/cmd/objects/recordtype.go
@@ -144,7 +144,7 @@ func listRecordType(file string, filter objects.RecordType) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	var filters []objects.RecordTypeFilter
 	filters = append(filters, func(r objects.RecordType) bool {
 		if filter.Active.Text != "" && filter.Active.ToBool() != r.Active.ToBool() {
@@ -164,7 +164,7 @@ func deleteRecordType(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	err = o.DeleteRecordType(strings.TrimPrefix(recordTypeName, objectName+"."))
 	if err != nil {
 		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
@@ -183,7 +183,7 @@ func assignPicklistValueToRecordType(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	field := strings.TrimPrefix(fieldName, objectName+".")
 	recordType := strings.TrimPrefix(recordTypeName, objectName+".")
 
@@ -218,7 +218,7 @@ func tableRecordType(files []string, filter objects.RecordType) {
 			log.Warn("parsing object failed: " + err.Error())
 			return
 		}
-		objectName := strings.TrimSuffix(path.Base(file), ".object")
+		objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 		recordTypes := o.GetRecordTypes(filters...)
 
 		for _, r := range recordTypes {
@@ -236,7 +236,7 @@ func tableRecordTypePicklistOptions(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	recordTypes := o.GetRecordTypes()
 
 	fieldName = strings.TrimPrefix(fieldName, objectName+".")

--- a/cmd/objects/validationrule.go
+++ b/cmd/objects/validationrule.go
@@ -76,7 +76,7 @@ func deleteRule(file string, ruleName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	ruleName = strings.TrimPrefix(ruleName, objectName+".")
 	err = o.DeleteRule(ruleName)
 	if err != nil {
@@ -96,7 +96,7 @@ func listRules(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	rules := o.GetValidationRules()
 	for _, r := range rules {
 		fmt.Printf("%s.%s\n", objectName, r.FullName)

--- a/cmd/objects/weblink.go
+++ b/cmd/objects/weblink.go
@@ -60,7 +60,7 @@ func listWebLinks(file string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	webLinks := o.GetWebLinks()
 	for _, f := range webLinks {
 		fmt.Printf("%s.%s\n", objectName, f.FullName)
@@ -73,7 +73,7 @@ func deleteWebLink(file string, webLinkName string) {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".object")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	webLinkName = strings.TrimPrefix(webLinkName, objectName+".")
 	err = o.DeleteWebLink(webLinkName)
 	if err != nil {

--- a/cmd/permissionset/field.go
+++ b/cmd/permissionset/field.go
@@ -252,7 +252,7 @@ func tableFieldPermissions(files []string) {
 			log.Warn("parsing permissionset failed: " + err.Error())
 			return
 		}
-		permissionSetName := strings.TrimSuffix(path.Base(file), ".profile")
+		permissionSetName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		perms = append(perms, perm{fields: p.GetFieldPermissions(filters...), permissionset: permissionSetName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/profile/applications.go
+++ b/cmd/profile/applications.go
@@ -243,7 +243,7 @@ func tableApplications(files []string, toApply profile.ApplicationVisibility) {
 			log.Warn("parsing profile failed: " + err.Error())
 			return
 		}
-		profileName := strings.TrimSuffix(path.Base(file), ".profile")
+		profileName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		perms = append(perms, perm{apps: p.GetApplications(filters...), profile: profileName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/profile/field.go
+++ b/cmd/profile/field.go
@@ -256,7 +256,7 @@ func tableFieldPermissions(files []string) {
 			log.Warn("parsing profile failed: " + err.Error())
 			return
 		}
-		profileName := strings.TrimSuffix(path.Base(file), ".profile")
+		profileName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		perms = append(perms, perm{fields: p.GetFieldPermissions(filters...), profile: profileName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/profile/layouts.go
+++ b/cmd/profile/layouts.go
@@ -213,7 +213,7 @@ func tableLayouts(files []string) {
 			log.Warn("parsing profile failed: " + err.Error())
 			return
 		}
-		profileName := strings.TrimSuffix(path.Base(file), ".profile")
+		profileName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		layouts = append(layouts, profileLayouts{layouts: p.GetLayouts(filters...), profile: profileName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/profile/objectPermissions.go
+++ b/cmd/profile/objectPermissions.go
@@ -356,7 +356,7 @@ func tableObjectPermissions(files []string, filter permissionset.ObjectPermissio
 			log.Warn("parsing profile failed: " + err.Error())
 			return
 		}
-		profileName := strings.TrimSuffix(path.Base(file), ".profile")
+		profileName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		perms = append(perms, perm{objects: p.GetObjectPermissions(filters...), profile: profileName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/profile/tabs.go
+++ b/cmd/profile/tabs.go
@@ -205,7 +205,7 @@ func tableTabPermissions(files []string) {
 			log.Warn("parsing profile failed: " + err.Error())
 			return
 		}
-		profileName := strings.TrimSuffix(path.Base(file), ".profile")
+		profileName := internal.TrimSuffixToEnd(path.Base(file), ".profile")
 		perms = append(perms, perm{tabs: p.GetTabs(filters...), profile: profileName})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/sharingrules/rules.go
+++ b/cmd/sharingrules/rules.go
@@ -65,7 +65,7 @@ func listCriteriaRules(file string) {
 		log.Warn("parsing sharing rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".sharingRules")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".sharingRules")
 	rules := w.GetCriteriaRules()
 	for _, r := range rules {
 		fmt.Printf("%s.%s\n", objectName, r.FullName.Text)
@@ -78,7 +78,7 @@ func listOwnerRules(file string) {
 		log.Warn("parsing sharing rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".sharingRules")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".sharingRules")
 	rules := w.GetOwnerRules()
 	for _, r := range rules {
 		fmt.Printf("%s.%s\n", objectName, r.FullName.Text)
@@ -117,7 +117,7 @@ func deleteCriteriaRule(file string, ruleName string) {
 		log.Warn("parsing sharing rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".sharingRules")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".sharingRules")
 	ruleName = strings.TrimPrefix(ruleName, objectName+".")
 	err = p.DeleteCriteriaRule(ruleName)
 	if err != nil {
@@ -137,7 +137,7 @@ func deleteOwnerRule(file string, ruleName string) {
 		log.Warn("parsing sharing rules failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".sharingRules")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".sharingRules")
 	ruleName = strings.TrimPrefix(ruleName, objectName+".")
 	err = p.DeleteOwnerRule(ruleName)
 	if err != nil {

--- a/cmd/standardvalueset/valueset.go
+++ b/cmd/standardvalueset/valueset.go
@@ -3,11 +3,11 @@ package standardvalueset
 import (
 	"fmt"
 	"path"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/standardvalueset"
 )
 
@@ -28,7 +28,7 @@ func listValues(file string) {
 		log.Warn("parsing value set failed: " + err.Error())
 		return
 	}
-	valueSet := strings.TrimSuffix(path.Base(file), ".standardValueSet")
+	valueSet := internal.TrimSuffixToEnd(path.Base(file), ".standardValueSet")
 	rules := w.GetValues()
 	for _, r := range rules {
 		fmt.Printf("%s: %s\n", valueSet, r.FullName.Text)

--- a/cmd/workflow/alerts.go
+++ b/cmd/workflow/alerts.go
@@ -105,7 +105,7 @@ func listAlerts(file string) {
 		return
 	}
 	var filters []workflow.AlertFilter
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	if senderType != 0 {
 		filters = append(filters, func(a workflow.Alert) bool {
 			return strings.ToLower(a.SenderType.Text) == strings.ToLower(SenderTypeIds[senderType][0])
@@ -156,7 +156,7 @@ func updateAlert(file string, alertName string, alertUpdates workflow.Alert) {
 		log.Warn("parsing workflow failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	alertName = strings.ToLower(strings.TrimPrefix(alertName, objectName+"."))
 	err = a.UpdateAlert(alertName, alertUpdates)
 	if err != nil {
@@ -176,7 +176,7 @@ func deleteAlert(file string, alertName string) {
 		log.Warn("parsing workflow failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	alertName = strings.ToLower(strings.TrimPrefix(alertName, objectName+"."))
 	err = a.DeleteAlert(alertName)
 	if err != nil {

--- a/cmd/workflow/fieldUpdates.go
+++ b/cmd/workflow/fieldUpdates.go
@@ -3,11 +3,11 @@ package workflow
 import (
 	"fmt"
 	"path"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/workflow"
 )
 
@@ -37,7 +37,7 @@ func listFieldUpdates(file string) {
 		log.Warn("parsing workflow failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	fieldUpdates := w.GetFieldUpdates()
 	for _, r := range fieldUpdates {
 		fmt.Printf("%s.%s\n", objectName, r.FullName.Text)

--- a/cmd/workflow/rules.go
+++ b/cmd/workflow/rules.go
@@ -61,7 +61,7 @@ func listRules(file string) {
 		log.Warn("parsing workflow failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	var filters []workflow.RuleFilter
 	if active {
 		filters = append(filters, func(r workflow.Rule) bool {
@@ -84,7 +84,7 @@ func deleteRule(file string, ruleName string) {
 		log.Warn("parsing workflow failed: " + err.Error())
 		return
 	}
-	objectName := strings.TrimSuffix(path.Base(file), ".workflow")
+	objectName := internal.TrimSuffixToEnd(path.Base(file), ".workflow")
 	ruleName = strings.ToLower(strings.TrimPrefix(ruleName, objectName+"."))
 	err = a.DeleteRule(ruleName)
 	if err != nil {


### PR DESCRIPTION
Replace use of strings.TrimSuffix to remove the extension from metadata
files with a new TrimSuffixToEnd function that trims the extension, plus
anything that follows it so it can be used with source-format files that
add "-meta.xml" to the filename, e.g. My_Profile.profile-meta.xml.
