### PR TITLE
Add --wide and --ignore-errors Options To Use of Managing Metadata in Git

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -17,35 +17,37 @@ type ProfileActionOverride struct {
 	Profile           string  `xml:"profile"`
 }
 
+type ActionOverride struct {
+	ActionName struct {
+		Text string `xml:",chardata"`
+	} `xml:"actionName"`
+	Comment *struct {
+		Text string `xml:",chardata"`
+	} `xml:"comment"`
+	Content struct {
+		Text string `xml:",chardata"`
+	} `xml:"content"`
+	FormFactor struct {
+		Text string `xml:",chardata"`
+	} `xml:"formFactor"`
+	SkipRecordTypeSelect struct {
+		Text string `xml:",chardata"`
+	} `xml:"skipRecordTypeSelect"`
+	Type struct {
+		Text string `xml:",chardata"`
+	} `xml:"type"`
+	PageOrSobjectType struct {
+		Text string `xml:",chardata"`
+	} `xml:"pageOrSobjectType"`
+}
+
 type ProfileActionOverrideList []ProfileActionOverride
 
 type CustomApplication struct {
-	XMLName         xml.Name `xml:"CustomApplication"`
-	Xmlns           string   `xml:"xmlns,attr"`
-	ActionOverrides []struct {
-		ActionName struct {
-			Text string `xml:",chardata"`
-		} `xml:"actionName"`
-		Comment *struct {
-			Text string `xml:",chardata"`
-		} `xml:"comment"`
-		Content struct {
-			Text string `xml:",chardata"`
-		} `xml:"content"`
-		FormFactor struct {
-			Text string `xml:",chardata"`
-		} `xml:"formFactor"`
-		SkipRecordTypeSelect struct {
-			Text string `xml:",chardata"`
-		} `xml:"skipRecordTypeSelect"`
-		Type struct {
-			Text string `xml:",chardata"`
-		} `xml:"type"`
-		PageOrSobjectType struct {
-			Text string `xml:",chardata"`
-		} `xml:"pageOrSobjectType"`
-	} `xml:"actionOverrides"`
-	Brand *struct {
+	XMLName         xml.Name         `xml:"CustomApplication"`
+	Xmlns           string           `xml:"xmlns,attr"`
+	ActionOverrides []ActionOverride `xml:"actionOverrides"`
+	Brand           *struct {
 		HeaderColor struct {
 			Text string `xml:",chardata"`
 		} `xml:"headerColor"`

--- a/application/marshal.go
+++ b/application/marshal.go
@@ -1,0 +1,14 @@
+package application
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+func (o ActionOverride) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+func (o ProfileActionOverride) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}

--- a/cmd/application/tidy.go
+++ b/cmd/application/tidy.go
@@ -1,16 +1,51 @@
 package application
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/ForceCLI/force-md/application"
 	"github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
 )
 
+var (
+	wide         bool
+	ignoreErrors bool
+)
+
+func init() {
+	TidyCmd.Flags().BoolVarP(&wide, "wide", "w", false, "flatten into wide format")
+	TidyCmd.Flags().BoolVarP(&ignoreErrors, "ignore-errors", "i", false, "ignore errors")
+}
+
 var TidyCmd = &cobra.Command{
-	Use:                   "tidy [filename]...",
-	Short:                 "Tidy custom application",
+	Use:   "tidy [filename]...",
+	Short: "Tidy custom application",
+	Long: `
+Tidy custom application metadata.
+
+	The --wide and --ignore-errors flags can be used to help manage
+	CustomApplication metadata stored in a git repository.
+
+	Configure clean and smudge git filters to use force-md:
+	$ git config --local filter.salesforce-application.clean 'force-md application tidy --wide --ignore-errors -'
+	$ git config --local filter.salesforce-application.smudge 'force-md application tidy --ignore-errors -'
+
+	Update .gitattributes to use the salesforce-application filter:
+	*.app-meta.xml filter=salesforce-application
+
+	The --wide flag will cause the CustomApplication metadata to be stored in a
+	flattened format that makes it easier to resolve merge conflicts.  If a child
+	of a profileActionOverrides element changes, for example, the entire
+	profileActionOverrides element will show up as changed because it's stored on a single line.
+
+	The smudge filter will cause the metadata to be unflattened so it's available
+	in the normal "long" format in the working copy.
+
+`,
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -21,10 +56,26 @@ var TidyCmd = &cobra.Command{
 }
 
 func tidy(file string) {
-	p, err := application.Open(file)
-	if err != nil {
-		log.Warn("parsing application failed: " + err.Error())
-		return
+	var p *application.CustomApplication
+	var err error
+	if ignoreErrors {
+		p = &application.CustomApplication{}
+		contents, err := internal.ParseMetadataXmlIfPossible(p, file)
+		if err != nil {
+			log.Warn("parse failure. leaving content unchanged.")
+			if _, err = os.Stdout.Write(contents); err != nil {
+				log.Warn("failed to write contents")
+			}
+		}
+	} else {
+		p, err = application.Open(file)
+		if err != nil {
+			log.Warn("parsing application failed: " + err.Error())
+			return
+		}
+	}
+	if wide {
+		internal.MarshalWide = true
 	}
 	if err := general.Tidy(p, file); err != nil {
 		log.Warn("tidying failed: " + err.Error())

--- a/cmd/application/tidy.go
+++ b/cmd/application/tidy.go
@@ -66,6 +66,7 @@ func tidy(file string) {
 			if _, err = os.Stdout.Write(contents); err != nil {
 				log.Warn("failed to write contents")
 			}
+			return
 		}
 	} else {
 		p, err = application.Open(file)

--- a/cmd/profile/tidy.go
+++ b/cmd/profile/tidy.go
@@ -65,6 +65,7 @@ func tidy(file string) {
 			if _, err = os.Stdout.Write(contents); err != nil {
 				log.Warn("failed to write contents")
 			}
+			return
 		}
 	} else {
 		p, err = profile.Open(file)

--- a/cmd/profile/tidy.go
+++ b/cmd/profile/tidy.go
@@ -1,17 +1,52 @@
 package profile
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/profile"
 )
+
+var (
+	wide         bool
+	ignoreErrors bool
+)
+
+func init() {
+	TidyCmd.Flags().BoolVarP(&wide, "wide", "w", false, "flatten into wide format")
+	TidyCmd.Flags().BoolVarP(&ignoreErrors, "ignore-errors", "i", false, "ignore errors")
+}
 
 var TidyCmd = &cobra.Command{
 	Use:   "tidy [flags] [filename]...",
 	Short: "Tidy profile metadata",
-	Args:  cobra.MinimumNArgs(1),
+	Long: `
+Tidy profile metadata.
+
+	The --wide and --ignore-errors flags can be used to help manage
+	Profile metadata stored in a git repository.
+
+	Configure clean and smudge git filters to use force-md:
+	$ git config --local filter.salesforce-profile.clean 'force-md profile tidy --wide --ignore-errors -'
+	$ git config --local filter.salesforce-profile.smudge 'force-md profile tidy --ignore-errors -'
+
+	Update .gitattributes to use the salesforce-profile filter:
+	*.profile-meta.xml filter=salesforce-profile
+
+	The --wide flag will cause the Profile metadata to be stored in a
+	flattened format that makes it easier to resolve merge conflicts.  If a child
+	of a fieldPermissions element changes, for example, the entire
+	fieldPermissions element will show up as changed because it's stored on a single line.
+
+	The smudge filter will cause the metadata to be unflattened so it's available
+	in the normal "long" format in the working copy.
+
+`,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, file := range args {
 			tidy(file)
@@ -20,10 +55,26 @@ var TidyCmd = &cobra.Command{
 }
 
 func tidy(file string) {
-	p, err := profile.Open(file)
-	if err != nil {
-		log.Warn("parsing profile failed: " + err.Error())
-		return
+	var p *profile.Profile
+	var err error
+	if ignoreErrors {
+		p = &profile.Profile{}
+		contents, err := internal.ParseMetadataXmlIfPossible(p, file)
+		if err != nil {
+			log.Warn("parse failure. leaving content unchanged.")
+			if _, err = os.Stdout.Write(contents); err != nil {
+				log.Warn("failed to write contents")
+			}
+		}
+	} else {
+		p, err = profile.Open(file)
+		if err != nil {
+			log.Warn("parsing profile failed: " + err.Error())
+			return
+		}
+	}
+	if wide {
+		internal.MarshalWide = true
 	}
 	if err := general.Tidy(p, file); err != nil {
 		log.Warn("tidying failed: " + err.Error())

--- a/internal/marshall.go
+++ b/internal/marshall.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"encoding/xml"
+	"reflect"
+)
+
+var MarshalWide = false
+
+func MarshalXml(o any, e *xml.Encoder, start xml.StartElement) error {
+	var err error
+	val := reflect.ValueOf(o)
+	lt := reflect.TypeOf(o)
+	if reflect.Zero(lt) == val {
+		return nil
+	}
+	e.EncodeToken(start)
+	if MarshalWide {
+		DisableIndent(e)
+	}
+
+	for _, field := range reflect.VisibleFields(lt) {
+		if alias, ok := field.Tag.Lookup("xml"); ok {
+			if err = e.EncodeElement(val.FieldByName(field.Name).Interface(), xml.StartElement{Name: xml.Name{Local: alias}}); err != nil {
+				return err
+			}
+		}
+	}
+
+	if MarshalWide {
+		EnableIndent(e)
+	}
+	e.EncodeToken(start.End())
+	e.Flush()
+	return err
+}

--- a/internal/write.go
+++ b/internal/write.go
@@ -14,10 +14,24 @@ var ConvertNumericXMLEntities = true
 
 const declaration = `<?xml version="1.0" encoding="UTF-8"?>`
 
+func DisableIndent(e *xml.Encoder) {
+	e.Indent("", "")
+}
+
+func EnableIndent(e *xml.Encoder) {
+	e.Indent("", "    ")
+}
+
 func WriteToFile(t interface{}, fileName string) error {
-	f, err := os.Create(fileName)
-	if err != nil {
-		return errors.Wrap(err, "opening file")
+	var f *os.File
+	var err error
+	if fileName == "-" {
+		f = os.Stdout
+	} else {
+		f, err = os.Create(fileName)
+		if err != nil {
+			return errors.Wrap(err, "opening file")
+		}
 	}
 	defer f.Close()
 	fmt.Fprintln(f, declaration)

--- a/permissionset/marshal.go
+++ b/permissionset/marshal.go
@@ -1,0 +1,23 @@
+package permissionset
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+func (o FieldPermissions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o ObjectPermissions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o PageAccess) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o UserPermission) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}

--- a/profile/marshal.go
+++ b/profile/marshal.go
@@ -1,0 +1,23 @@
+package profile
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+func (o ApplicationVisibility) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o LayoutAssignment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o RecordTypeVisibility) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}
+
+func (o TabVisibility) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return internal.MarshalXml(o, e, start)
+}


### PR DESCRIPTION
Add `--wide` option to `profile tidy` and `application tidy` to flatten CustomApplication and Profile metadata so that the high-level elements such as profileActionOverrides and fieldPermissions are stored on a single line along with their children.

Grouping related elements into a single line makes it easier to resolve merge conflicts when the metadata is stored in git.

Add `--ignore-errors` option to leave tidied metadata unchanged if it can't be parsed.  This allows tidy to fail gracefully when there are conflict markers in the metadata.

These two options can be combined to store metadata in a flattened, wide format in git, but keep it in the normal, long format in your working copy.

To use with git, configure clean and smudge git filters to use force-md:

```
$ git config --local filter.salesforce-application.clean 'force-md application tidy --wide --ignore-errors -'
$ git config --local filter.salesforce-application.smudge 'force-md application tidy --ignore-errors -'
$ git config --local filter.salesforce-profile.clean 'force-md profile tidy --wide --ignore-errors -'
$ git config --local filter.salesforce-profile.smudge 'force-md profile tidy --ignore-errors -'
```

Update .gitattributes to use the filters:

```
*.app-meta.xml filter=salesforce-application
*.profile-meta.xml filter=salesforce-profile
```