### PR TITLE
Move CustomObject Sub-Components Into Separate Packages

### DIFF
--- a/cmd/objects/fields.go
+++ b/cmd/objects/fields.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/objects"
+	"github.com/ForceCLI/force-md/objects/field"
 )
 
 var (
@@ -235,15 +236,15 @@ var alwaysRequired map[string]bool = map[string]bool{
 	"OwnerId": true,
 }
 
-func listFields(file string, attributes objects.Field) {
+func listFields(file string, attributes field.Field) {
 	o, err := objects.Open(file)
 	if err != nil {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
 	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
-	var filters []objects.FieldFilter
-	requiredFilter := func(f objects.Field) bool {
+	var filters []field.FieldFilter
+	requiredFilter := func(f field.Field) bool {
 		isRequired := alwaysRequired[f.FullName] || (f.Required != nil && f.Required.Text == "true")
 		isMasterDetail := f.Type != nil && f.Type.Text == "MasterDetail"
 		return isRequired || isMasterDetail
@@ -252,40 +253,40 @@ func listFields(file string, attributes objects.Field) {
 		filters = append(filters, requiredFilter)
 	}
 	if attributes.Required.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !requiredFilter(f) })
+		filters = append(filters, func(f field.Field) bool { return !requiredFilter(f) })
 	}
 	if attributes.TrackHistory.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackHistory.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackTrending.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackTrending.ToBool() })
 	}
 	if attributes.TrackTrending.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackTrending.ToBool() })
 	}
 	if formulaField {
-		filters = append(filters, func(f objects.Field) bool { return f.Formula != nil })
+		filters = append(filters, func(f field.Field) bool { return f.Formula != nil })
 	}
 	if filteredLookup {
-		filters = append(filters, func(f objects.Field) bool { return f.LookupFilter != nil })
+		filters = append(filters, func(f field.Field) bool { return f.LookupFilter != nil })
 	}
 	if attributes.ExternalId.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.ExternalId.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.ExternalId.ToBool() })
 	}
 	if attributes.ExternalId.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.ExternalId.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.ExternalId.ToBool() })
 	}
 	if attributes.Unique.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.Unique.ToBool() })
 	}
 	if attributes.Unique.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.Unique.ToBool() })
 	}
 	if len(fieldTypes) != 0 {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			for _, t := range fieldTypes {
 				t = strings.ToLower(t)
 				if f.Type != nil && strings.ToLower(f.Type.Text) == t {
@@ -296,13 +297,13 @@ func listFields(file string, attributes objects.Field) {
 		})
 	}
 	if references != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			r := strings.ToLower(references)
 			return f.ReferenceTo != nil && strings.ToLower(f.ReferenceTo.Text) == r
 		})
 	}
 	if label != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			l := strings.ToLower(label)
 			return f.Label != nil && strings.ToLower(f.Label.Text) == l
 		})
@@ -313,15 +314,15 @@ func listFields(file string, attributes objects.Field) {
 	}
 }
 
-func graphFields(file string, attributes objects.Field, objectsOnly bool) {
+func graphFields(file string, attributes field.Field, objectsOnly bool) {
 	o, err := objects.Open(file)
 	if err != nil {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
 	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
-	var filters []objects.FieldFilter
-	requiredFilter := func(f objects.Field) bool {
+	var filters []field.FieldFilter
+	requiredFilter := func(f field.Field) bool {
 		isRequired := alwaysRequired[f.FullName] || (f.Required != nil && f.Required.Text == "true")
 		isMasterDetail := f.Type != nil && f.Type.Text == "MasterDetail"
 		return isRequired || isMasterDetail
@@ -330,34 +331,34 @@ func graphFields(file string, attributes objects.Field, objectsOnly bool) {
 		filters = append(filters, requiredFilter)
 	}
 	if attributes.Required.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !requiredFilter(f) })
+		filters = append(filters, func(f field.Field) bool { return !requiredFilter(f) })
 	}
 	if attributes.TrackHistory.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackHistory.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackTrending.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackTrending.ToBool() })
 	}
 	if attributes.TrackTrending.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackTrending.ToBool() })
 	}
 	if formulaField {
-		filters = append(filters, func(f objects.Field) bool { return f.Formula != nil })
+		filters = append(filters, func(f field.Field) bool { return f.Formula != nil })
 	}
 	if filteredLookup {
-		filters = append(filters, func(f objects.Field) bool { return f.LookupFilter != nil })
+		filters = append(filters, func(f field.Field) bool { return f.LookupFilter != nil })
 	}
 	if attributes.Unique.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.Unique.ToBool() })
 	}
 	if attributes.Unique.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.Unique.ToBool() })
 	}
 	if len(fieldTypes) != 0 {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			for _, t := range fieldTypes {
 				t = strings.ToLower(t)
 				if f.Type != nil && strings.ToLower(f.Type.Text) == t {
@@ -368,13 +369,13 @@ func graphFields(file string, attributes objects.Field, objectsOnly bool) {
 		})
 	}
 	if references != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			r := strings.ToLower(references)
 			return f.ReferenceTo != nil && strings.ToLower(f.ReferenceTo.Text) == r
 		})
 	}
 	if label != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			l := strings.ToLower(label)
 			return f.Label != nil && strings.ToLower(f.Label.Text) == l
 		})
@@ -392,9 +393,9 @@ func graphFields(file string, attributes objects.Field, objectsOnly bool) {
 	}
 }
 
-func tableFields(files []string, attributes objects.Field) {
-	var filters []objects.FieldFilter
-	requiredFilter := func(f objects.Field) bool {
+func tableFields(files []string, attributes field.Field) {
+	var filters []field.FieldFilter
+	requiredFilter := func(f field.Field) bool {
 		isRequired := alwaysRequired[f.FullName] || (f.Required != nil && f.Required.Text == "true")
 		isMasterDetail := f.Type != nil && f.Type.Text == "MasterDetail"
 		return isRequired || isMasterDetail
@@ -403,40 +404,40 @@ func tableFields(files []string, attributes objects.Field) {
 		filters = append(filters, requiredFilter)
 	}
 	if attributes.Required.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !requiredFilter(f) })
+		filters = append(filters, func(f field.Field) bool { return !requiredFilter(f) })
 	}
 	if attributes.TrackHistory.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackHistory.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackHistory.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackHistory.ToBool() })
 	}
 	if attributes.TrackTrending.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.TrackTrending.ToBool() })
 	}
 	if attributes.TrackTrending.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.TrackTrending.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.TrackTrending.ToBool() })
 	}
 	if formulaField {
-		filters = append(filters, func(f objects.Field) bool { return f.Formula != nil })
+		filters = append(filters, func(f field.Field) bool { return f.Formula != nil })
 	}
 	if filteredLookup {
-		filters = append(filters, func(f objects.Field) bool { return f.LookupFilter != nil })
+		filters = append(filters, func(f field.Field) bool { return f.LookupFilter != nil })
 	}
 	if attributes.ExternalId.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.ExternalId.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.ExternalId.ToBool() })
 	}
 	if attributes.ExternalId.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.ExternalId.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.ExternalId.ToBool() })
 	}
 	if attributes.Unique.IsTrue() {
-		filters = append(filters, func(f objects.Field) bool { return f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return f.Unique.ToBool() })
 	}
 	if attributes.Unique.IsFalse() {
-		filters = append(filters, func(f objects.Field) bool { return !f.Unique.ToBool() })
+		filters = append(filters, func(f field.Field) bool { return !f.Unique.ToBool() })
 	}
 	if len(fieldTypes) != 0 {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			for _, t := range fieldTypes {
 				t = strings.ToLower(t)
 				if f.Type != nil && strings.ToLower(f.Type.Text) == t {
@@ -447,13 +448,13 @@ func tableFields(files []string, attributes objects.Field) {
 		})
 	}
 	if references != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			r := strings.ToLower(references)
 			return f.ReferenceTo != nil && strings.ToLower(f.ReferenceTo.Text) == r
 		})
 	}
 	if label != "" {
-		filters = append(filters, func(f objects.Field) bool {
+		filters = append(filters, func(f field.Field) bool {
 			l := strings.ToLower(label)
 			return f.Label != nil && strings.ToLower(f.Label.Text) == l
 		})
@@ -509,7 +510,7 @@ func addField(file string, fieldName string) {
 	}
 }
 
-func updateField(file string, fieldUpdates objects.Field) {
+func updateField(file string, fieldUpdates field.Field) {
 	o, err := objects.Open(file)
 	if err != nil {
 		log.Warn("parsing object failed: " + err.Error())
@@ -537,7 +538,7 @@ func showField(file string, fieldName string) {
 	}
 	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
 	fieldName = strings.ToLower(strings.TrimPrefix(fieldName, objectName+"."))
-	fields := o.GetFields(func(f objects.Field) bool {
+	fields := o.GetFields(func(f field.Field) bool {
 		return strings.ToLower(f.FullName) == fieldName
 	})
 	if len(fields) == 0 {
@@ -586,7 +587,7 @@ func writeFields(file string, fieldsDir string) {
 	}
 	fields := o.GetFields()
 	for _, f := range fields {
-		customField := objects.CustomField{
+		customField := field.CustomField{
 			Field: f,
 			Xmlns: o.Xmlns,
 		}
@@ -598,8 +599,8 @@ func writeFields(file string, fieldsDir string) {
 	}
 }
 
-func setFields(cmd *cobra.Command) objects.Field {
-	field := objects.Field{}
+func setFields(cmd *cobra.Command) field.Field {
+	field := field.Field{}
 	field.Label = TextValue(cmd, "label")
 	field.Unique = BooleanTextValue(cmd, "unique")
 	field.ExternalId = BooleanTextValue(cmd, "external-id")

--- a/cmd/objects/recordtype.go
+++ b/cmd/objects/recordtype.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/objects"
+	rt "github.com/ForceCLI/force-md/objects/recordtype"
 )
 
 var (
@@ -138,15 +139,15 @@ var writeRecordTypesCmd = &cobra.Command{
 	},
 }
 
-func listRecordType(file string, filter objects.RecordType) {
+func listRecordType(file string, filter rt.RecordType) {
 	o, err := objects.Open(file)
 	if err != nil {
 		log.Warn("parsing object failed: " + err.Error())
 		return
 	}
 	objectName := internal.TrimSuffixToEnd(path.Base(file), ".object")
-	var filters []objects.RecordTypeFilter
-	filters = append(filters, func(r objects.RecordType) bool {
+	var filters []rt.RecordTypeFilter
+	filters = append(filters, func(r rt.RecordType) bool {
 		if filter.Active.Text != "" && filter.Active.ToBool() != r.Active.ToBool() {
 			return false
 		}
@@ -199,14 +200,14 @@ func assignPicklistValueToRecordType(file string) {
 	}
 }
 
-func tableRecordType(files []string, filter objects.RecordType) {
+func tableRecordType(files []string, filter rt.RecordType) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Object", "Record Type", "Active"})
 	table.SetAutoMergeCells(true)
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
 	table.SetRowLine(true)
-	var filters []objects.RecordTypeFilter
-	filters = append(filters, func(r objects.RecordType) bool {
+	var filters []rt.RecordTypeFilter
+	filters = append(filters, func(r rt.RecordType) bool {
 		if filter.Active.Text != "" && filter.Active.ToBool() != r.Active.ToBool() {
 			return false
 		}
@@ -277,7 +278,7 @@ func writeRecordTypes(file string, recordTypesDir string) {
 	}
 	recordTypes := o.GetRecordTypes()
 	for _, f := range recordTypes {
-		recordType := objects.RecordTypeMetadata{
+		recordType := rt.RecordTypeMetadata{
 			RecordType: f,
 			Xmlns:      o.Xmlns,
 		}
@@ -289,8 +290,8 @@ func writeRecordTypes(file string, recordTypesDir string) {
 	}
 }
 
-func recordTypeVisibilityFromFlags(cmd *cobra.Command) objects.RecordType {
-	perms := objects.RecordType{}
+func recordTypeVisibilityFromFlags(cmd *cobra.Command) rt.RecordType {
+	perms := rt.RecordType{}
 	perms.Active = textValue(cmd, "active")
 	return perms
 }

--- a/cmd/objects/validationrule.go
+++ b/cmd/objects/validationrule.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/objects"
+	"github.com/ForceCLI/force-md/objects/validationrule"
 )
 
 var (
@@ -111,7 +112,7 @@ func writeRules(file string, rulesDir string) {
 	}
 	rules := o.GetValidationRules()
 	for _, f := range rules {
-		rule := objects.ValidationRule{
+		rule := validationrule.ValidationRule{
 			Rule:  f,
 			Xmlns: o.Xmlns,
 		}

--- a/general/types.go
+++ b/general/types.go
@@ -4,7 +4,11 @@ import (
 	"html"
 	"strconv"
 	"strings"
+
+	"github.com/ForceCLI/force-md/internal"
 )
+
+type Metadata = internal.MetadataPointer
 
 type TextLiteral struct {
 	Text string `xml:",innerxml"`

--- a/objects/businessprocess/businessprocess.go
+++ b/objects/businessprocess/businessprocess.go
@@ -1,0 +1,40 @@
+package businessprocess
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type BusinessProcessMetadata struct {
+	XMLName xml.Name `xml:"BusinessProcess"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	BusinessProcess
+}
+
+type BusinessProcess struct {
+	FullName struct {
+		Text string `xml:",chardata"`
+	} `xml:"fullName"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	IsActive struct {
+		Text string `xml:",chardata"`
+	} `xml:"isActive"`
+	Values []struct {
+		FullName struct {
+			Text string `xml:",chardata"`
+		} `xml:"fullName"`
+		Default struct {
+			Text string `xml:",chardata"`
+		} `xml:"default"`
+	} `xml:"values"`
+}
+
+func (p *BusinessProcessMetadata) MetaCheck() {}
+
+func Open(path string) (*BusinessProcessMetadata, error) {
+	p := &BusinessProcessMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/compactlayout/compactlayout.go
+++ b/objects/compactlayout/compactlayout.go
@@ -1,0 +1,32 @@
+package compactlayout
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type CompactLayoutMetadata struct {
+	XMLName xml.Name `xml:"CompactLayout"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	CompactLayout
+}
+
+type CompactLayout struct {
+	FullName struct {
+		Text string `xml:",chardata"`
+	} `xml:"fullName"`
+	Fields []struct {
+		Text string `xml:",chardata"`
+	} `xml:"fields"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+}
+
+func (p *CompactLayoutMetadata) MetaCheck() {}
+
+func Open(path string) (*CompactLayoutMetadata, error) {
+	p := &CompactLayoutMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/field/field.go
+++ b/objects/field/field.go
@@ -1,0 +1,180 @@
+package field
+
+import (
+	"encoding/xml"
+
+	. "github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type FieldFilter func(Field) bool
+
+type CustomField struct {
+	XMLName xml.Name `xml:"CustomField"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Field
+}
+
+type Field struct {
+	FullName          string       `xml:"fullName"`
+	BusinessStatus    *TextLiteral `xml:"businessStatus"`
+	BusinessOwnerUser *TextLiteral `xml:"businessOwnerUser"`
+	CaseSensitive     *struct {
+		Text string `xml:",chardata"`
+	} `xml:"caseSensitive"`
+	DefaultValue     *TextLiteral `xml:"defaultValue"`
+	DeleteConstraint *struct {
+		Text string `xml:",chardata"`
+	} `xml:"deleteConstraint"`
+	Deprecated    *TextLiteral `xml:"deprecated"`
+	Description   *TextLiteral `xml:"description"`
+	DisplayFormat *struct {
+		Text string `xml:",chardata"`
+	} `xml:"displayFormat"`
+	DisplayLocationInDecimal *struct {
+		Text string `xml:",chardata"`
+	} `xml:"displayLocationInDecimal"`
+	ExternalId         *BooleanText `xml:"externalId"`
+	FieldManageability *struct {
+		Text string `xml:",chardata"`
+	} `xml:"fieldManageability"`
+	Formula *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"formula"`
+	FormulaTreatBlanksAs *struct {
+		Text string `xml:",chardata"`
+	} `xml:"formulaTreatBlanksAs"`
+	InlineHelpText      *TextLiteral `xml:"inlineHelpText"`
+	IsFilteringDisabled *BooleanText `xml:"isFilteringDisabled"`
+	IsNameField         *BooleanText `xml:"isNameField"`
+	IsSortingDisabled   *BooleanText `xml:"isSortingDisabled"`
+	Label               *TextLiteral `xml:"label"`
+	LookupFilter        *struct {
+		Active struct {
+			Text string `xml:",chardata"`
+		} `xml:"active"`
+		BooleanFilter *TextLiteral `xml:"booleanFilter"`
+		ErrorMessage  *struct {
+			Text string `xml:",innerxml"`
+		} `xml:"errorMessage"`
+		FilterItems []struct {
+			Field struct {
+				Text string `xml:",chardata"`
+			} `xml:"field"`
+			Operation struct {
+				Text string `xml:",chardata"`
+			} `xml:"operation"`
+			Value *struct {
+				Text string `xml:",chardata"`
+			} `xml:"value"`
+			ValueField *struct {
+				Text string `xml:",chardata"`
+			} `xml:"valueField"`
+		} `xml:"filterItems"`
+		InfoMessage *TextLiteral `xml:"infoMessage"`
+		IsOptional  struct {
+			Text string `xml:",chardata"`
+		} `xml:"isOptional"`
+	} `xml:"lookupFilter"`
+	Precision              *IntegerText `xml:"precision"`
+	Length                 *IntegerText `xml:"length"`
+	MaskChar               *TextLiteral `xml:"maskChar"`
+	MaskType               *TextLiteral `xml:"maskType"`
+	ReferenceTo            *TextLiteral `xml:"referenceTo"`
+	RelationshipLabel      *TextLiteral `xml:"relationshipLabel"`
+	RelationshipName       *TextLiteral `xml:"relationshipName"`
+	RestrictedAdminField   *TextLiteral `xml:"restrictedAdminField"`
+	Required               *BooleanText `xml:"required"`
+	Scale                  *IntegerText `xml:"scale"`
+	SecurityClassification *TextLiteral `xml:"securityClassification"`
+	TrackFeedHistory       *struct {
+		Text string `xml:",chardata"`
+	} `xml:"trackFeedHistory"`
+	SummarizedField *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summarizedField"`
+	SummaryFilterItems []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Operation struct {
+			Text string `xml:",chardata"`
+		} `xml:"operation"`
+		Value struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"summaryFilterItems"`
+	SummaryForeignKey *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summaryForeignKey"`
+	SummaryOperation *struct {
+		Text string `xml:",chardata"`
+	} `xml:"summaryOperation"`
+	RelationshipOrder *struct {
+		Text string `xml:",chardata"`
+	} `xml:"relationshipOrder"`
+	ReparentableMasterDetail *struct {
+		Text string `xml:",chardata"`
+	} `xml:"reparentableMasterDetail"`
+	MetadataRelationshipControllingField *struct {
+		Text string `xml:",chardata"`
+	} `xml:"metadataRelationshipControllingField"`
+	TrackHistory            *BooleanText `xml:"trackHistory"`
+	TrackTrending           *BooleanText `xml:"trackTrending"`
+	Type                    *TextLiteral `xml:"type"`
+	Unique                  *BooleanText `xml:"unique"`
+	WriteRequiresMasterRead *struct {
+		Text string `xml:",chardata"`
+	} `xml:"writeRequiresMasterRead"`
+	ValueSet *struct {
+		ControllingField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"controllingField"`
+		Restricted *struct {
+			Text string `xml:",chardata"`
+		} `xml:"restricted"`
+		ValueSetDefinition *struct {
+			Sorted struct {
+				Text string `xml:",chardata"`
+			} `xml:"sorted"`
+			Value []struct {
+				FullName struct {
+					Text string `xml:",innerxml"`
+				} `xml:"fullName"`
+				Default struct {
+					Text string `xml:",chardata"`
+				} `xml:"default"`
+				IsActive *struct {
+					Text string `xml:",chardata"`
+				} `xml:"isActive"`
+				Label struct {
+					Text string `xml:",innerxml"`
+				} `xml:"label"`
+				Color *struct {
+					Text string `xml:",chardata"`
+				} `xml:"color"`
+			} `xml:"value"`
+		} `xml:"valueSetDefinition"`
+		ValueSetName *struct {
+			Text string `xml:",chardata"`
+		} `xml:"valueSetName"`
+		ValueSettings []struct {
+			ControllingFieldValue []struct {
+				Text string `xml:",innerxml"`
+			} `xml:"controllingFieldValue"`
+			ValueName struct {
+				Text string `xml:",chardata"`
+			} `xml:"valueName"`
+		} `xml:"valueSettings"`
+	} `xml:"valueSet"`
+	VisibleLines *struct {
+		Text string `xml:",chardata"`
+	} `xml:"visibleLines"`
+}
+
+func (p *CustomField) MetaCheck() {}
+
+func Open(path string) (*CustomField, error) {
+	p := &CustomField{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/fields.go
+++ b/objects/fields.go
@@ -7,19 +7,19 @@ import (
 	"github.com/pkg/errors"
 
 	. "github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/objects/field"
+	rt "github.com/ForceCLI/force-md/objects/recordtype"
 )
 
-type FieldFilter func(Field) bool
-
-func defaultField(name string) Field {
-	f := Field{
+func defaultField(name string) field.Field {
+	f := field.Field{
 		FullName: name,
 	}
 	return f
 }
 
-func (o *CustomObject) GetFields(filters ...FieldFilter) []Field {
-	var fields []Field
+func (o *CustomObject) GetFields(filters ...field.FieldFilter) []field.Field {
+	var fields []field.Field
 FIELDS:
 	for _, f := range o.Fields {
 		for _, filter := range filters {
@@ -44,7 +44,7 @@ func (o *CustomObject) AddField(fieldName string) error {
 	return nil
 }
 
-func (o *CustomObject) UpdateField(fieldName string, updates Field) error {
+func (o *CustomObject) UpdateField(fieldName string, updates field.Field) error {
 	found := false
 	for i, f := range o.Fields {
 		if strings.ToLower(f.FullName) == strings.ToLower(fieldName) {
@@ -98,7 +98,7 @@ func (o *CustomObject) AddFieldPicklistValue(fieldName string, recordType string
 		if strings.ToLower(f.FullName) != strings.ToLower(recordType) {
 			continue
 		}
-		option := ValueSetOption{FullName: picklistValue, Default: FalseText}
+		option := rt.ValueSetOption{FullName: picklistValue, Default: FalseText}
 		for j, p := range f.PicklistValues {
 			if strings.ToLower(p.Picklist) != strings.ToLower(fieldName) {
 				continue
@@ -113,9 +113,9 @@ func (o *CustomObject) AddFieldPicklistValue(fieldName string, recordType string
 			o.RecordTypes[i].PicklistValues[j].Values.Tidy()
 		}
 		if !found {
-			o.RecordTypes[i].PicklistValues = append(o.RecordTypes[i].PicklistValues, Picklist{
+			o.RecordTypes[i].PicklistValues = append(o.RecordTypes[i].PicklistValues, rt.Picklist{
 				Picklist: fieldName,
-				Values:   []ValueSetOption{option},
+				Values:   []rt.ValueSetOption{option},
 			})
 			found = true
 		}

--- a/objects/fieldset.go
+++ b/objects/fieldset.go
@@ -2,9 +2,11 @@ package objects
 
 import (
 	"github.com/pkg/errors"
+
+	"github.com/ForceCLI/force-md/objects/fieldset"
 )
 
-func (o *CustomObject) GetFieldSets() []FieldSet {
+func (o *CustomObject) GetFieldSets() []fieldset.FieldSet {
 	return o.FieldSets
 }
 

--- a/objects/fieldset/fieldset.go
+++ b/objects/fieldset/fieldset.go
@@ -1,0 +1,52 @@
+package fieldset
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type FieldSetMetadata struct {
+	XMLName xml.Name `xml:"FieldSet"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	FieldSet
+}
+
+type FieldSet struct {
+	FullName        string `xml:"fullName"`
+	AvailableFields []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		IsFieldManaged struct {
+			Text string `xml:",chardata"`
+		} `xml:"isFieldManaged"`
+		IsRequired struct {
+			Text string `xml:",chardata"`
+		} `xml:"isRequired"`
+	} `xml:"availableFields"`
+	Description struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	DisplayedFields []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		IsFieldManaged struct {
+			Text string `xml:",chardata"`
+		} `xml:"isFieldManaged"`
+		IsRequired struct {
+			Text string `xml:",chardata"`
+		} `xml:"isRequired"`
+	} `xml:"displayedFields"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+}
+
+func (p *FieldSetMetadata) MetaCheck() {}
+
+func Open(path string) (*FieldSetMetadata, error) {
+	p := &FieldSetMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/listview/listview.go
+++ b/objects/listview/listview.go
@@ -1,0 +1,69 @@
+package listview
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type ListViewMetadata struct {
+	XMLName xml.Name `xml:"ListView"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	ListView
+}
+
+type ListView struct {
+	FullName struct {
+		Text string `xml:",chardata"`
+	} `xml:"fullName"`
+	BooleanFilter *struct {
+		Text string `xml:",chardata"`
+	} `xml:"booleanFilter"`
+	Columns []struct {
+		Text string `xml:",chardata"`
+	} `xml:"columns"`
+	FilterScope struct {
+		Text string `xml:",chardata"`
+	} `xml:"filterScope"`
+	Filters []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Operation struct {
+			Text string `xml:",chardata"`
+		} `xml:"operation"`
+		Value *struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"filters"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	Queue *struct {
+		Text string `xml:",chardata"`
+	} `xml:"queue"`
+	SharedTo *struct {
+		Group []struct {
+			Text string `xml:",chardata"`
+		} `xml:"group"`
+		Rol []struct {
+			Text string `xml:",chardata"`
+		} `xml:"role"`
+		RoleAndSubordinates []struct {
+			Text string `xml:",chardata"`
+		} `xml:"roleAndSubordinates"`
+		AllInternalUsers *struct {
+			Text string `xml:",chardata"`
+		} `xml:"allInternalUsers"`
+	} `xml:"sharedTo"`
+	Language *struct {
+		Text string `xml:",chardata"`
+	} `xml:"language"`
+}
+
+func (p *ListViewMetadata) MetaCheck() {}
+
+func Open(path string) (*ListViewMetadata, error) {
+	p := &ListViewMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -5,330 +5,20 @@ import (
 
 	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
+
+	"github.com/ForceCLI/force-md/objects/businessprocess"
+	"github.com/ForceCLI/force-md/objects/compactlayout"
+	"github.com/ForceCLI/force-md/objects/field"
+	"github.com/ForceCLI/force-md/objects/fieldset"
+	"github.com/ForceCLI/force-md/objects/listview"
+	"github.com/ForceCLI/force-md/objects/recordtype"
+	"github.com/ForceCLI/force-md/objects/sharingreason"
+	"github.com/ForceCLI/force-md/objects/validationrule"
+	"github.com/ForceCLI/force-md/objects/weblink"
 )
 
-type FieldList []Field
-
-type CustomField struct {
-	XMLName xml.Name `xml:"CustomField"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	Field
-}
-
-type RecordTypeMetadata struct {
-	XMLName xml.Name `xml:"RecordType"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	RecordType
-}
-
-type ValidationRule struct {
-	XMLName xml.Name `xml:"ValidationRule"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	Rule
-}
-
-type Rule struct {
-	FullName string `xml:"fullName"`
-	Active   struct {
-		Text string `xml:",chardata"`
-	} `xml:"active"`
-	Description *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"description"`
-	ErrorConditionFormula struct {
-		Text string `xml:",innerxml"`
-	} `xml:"errorConditionFormula"`
-	ErrorDisplayField *struct {
-		Text string `xml:",chardata"`
-	} `xml:"errorDisplayField"`
-	ErrorMessage struct {
-		Text string `xml:",innerxml"`
-	} `xml:"errorMessage"`
-}
-type Field struct {
-	FullName          string       `xml:"fullName"`
-	BusinessStatus    *TextLiteral `xml:"businessStatus"`
-	BusinessOwnerUser *TextLiteral `xml:"businessOwnerUser"`
-	CaseSensitive     *struct {
-		Text string `xml:",chardata"`
-	} `xml:"caseSensitive"`
-	DefaultValue     *TextLiteral `xml:"defaultValue"`
-	DeleteConstraint *struct {
-		Text string `xml:",chardata"`
-	} `xml:"deleteConstraint"`
-	Deprecated    *TextLiteral `xml:"deprecated"`
-	Description   *TextLiteral `xml:"description"`
-	DisplayFormat *struct {
-		Text string `xml:",chardata"`
-	} `xml:"displayFormat"`
-	DisplayLocationInDecimal *struct {
-		Text string `xml:",chardata"`
-	} `xml:"displayLocationInDecimal"`
-	ExternalId         *BooleanText `xml:"externalId"`
-	FieldManageability *struct {
-		Text string `xml:",chardata"`
-	} `xml:"fieldManageability"`
-	Formula *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"formula"`
-	FormulaTreatBlanksAs *struct {
-		Text string `xml:",chardata"`
-	} `xml:"formulaTreatBlanksAs"`
-	InlineHelpText      *TextLiteral `xml:"inlineHelpText"`
-	IsFilteringDisabled *BooleanText `xml:"isFilteringDisabled"`
-	IsNameField         *BooleanText `xml:"isNameField"`
-	IsSortingDisabled   *BooleanText `xml:"isSortingDisabled"`
-	Label               *TextLiteral `xml:"label"`
-	LookupFilter        *struct {
-		Active struct {
-			Text string `xml:",chardata"`
-		} `xml:"active"`
-		BooleanFilter *TextLiteral `xml:"booleanFilter"`
-		ErrorMessage  *struct {
-			Text string `xml:",innerxml"`
-		} `xml:"errorMessage"`
-		FilterItems []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Operation struct {
-				Text string `xml:",chardata"`
-			} `xml:"operation"`
-			Value *struct {
-				Text string `xml:",chardata"`
-			} `xml:"value"`
-			ValueField *struct {
-				Text string `xml:",chardata"`
-			} `xml:"valueField"`
-		} `xml:"filterItems"`
-		InfoMessage *TextLiteral `xml:"infoMessage"`
-		IsOptional  struct {
-			Text string `xml:",chardata"`
-		} `xml:"isOptional"`
-	} `xml:"lookupFilter"`
-	Precision              *IntegerText `xml:"precision"`
-	Length                 *IntegerText `xml:"length"`
-	MaskChar               *TextLiteral `xml:"maskChar"`
-	MaskType               *TextLiteral `xml:"maskType"`
-	ReferenceTo            *TextLiteral `xml:"referenceTo"`
-	RelationshipLabel      *TextLiteral `xml:"relationshipLabel"`
-	RelationshipName       *TextLiteral `xml:"relationshipName"`
-	RestrictedAdminField   *TextLiteral `xml:"restrictedAdminField"`
-	Required               *BooleanText `xml:"required"`
-	Scale                  *IntegerText `xml:"scale"`
-	SecurityClassification *TextLiteral `xml:"securityClassification"`
-	TrackFeedHistory       *struct {
-		Text string `xml:",chardata"`
-	} `xml:"trackFeedHistory"`
-	SummarizedField *struct {
-		Text string `xml:",chardata"`
-	} `xml:"summarizedField"`
-	SummaryFilterItems []struct {
-		Field struct {
-			Text string `xml:",chardata"`
-		} `xml:"field"`
-		Operation struct {
-			Text string `xml:",chardata"`
-		} `xml:"operation"`
-		Value struct {
-			Text string `xml:",chardata"`
-		} `xml:"value"`
-	} `xml:"summaryFilterItems"`
-	SummaryForeignKey *struct {
-		Text string `xml:",chardata"`
-	} `xml:"summaryForeignKey"`
-	SummaryOperation *struct {
-		Text string `xml:",chardata"`
-	} `xml:"summaryOperation"`
-	RelationshipOrder *struct {
-		Text string `xml:",chardata"`
-	} `xml:"relationshipOrder"`
-	ReparentableMasterDetail *struct {
-		Text string `xml:",chardata"`
-	} `xml:"reparentableMasterDetail"`
-	MetadataRelationshipControllingField *struct {
-		Text string `xml:",chardata"`
-	} `xml:"metadataRelationshipControllingField"`
-	TrackHistory            *BooleanText `xml:"trackHistory"`
-	TrackTrending           *BooleanText `xml:"trackTrending"`
-	Type                    *TextLiteral `xml:"type"`
-	Unique                  *BooleanText `xml:"unique"`
-	WriteRequiresMasterRead *struct {
-		Text string `xml:",chardata"`
-	} `xml:"writeRequiresMasterRead"`
-	ValueSet *struct {
-		ControllingField *struct {
-			Text string `xml:",chardata"`
-		} `xml:"controllingField"`
-		Restricted *struct {
-			Text string `xml:",chardata"`
-		} `xml:"restricted"`
-		ValueSetDefinition *struct {
-			Sorted struct {
-				Text string `xml:",chardata"`
-			} `xml:"sorted"`
-			Value []struct {
-				FullName struct {
-					Text string `xml:",innerxml"`
-				} `xml:"fullName"`
-				Default struct {
-					Text string `xml:",chardata"`
-				} `xml:"default"`
-				IsActive *struct {
-					Text string `xml:",chardata"`
-				} `xml:"isActive"`
-				Label struct {
-					Text string `xml:",innerxml"`
-				} `xml:"label"`
-				Color *struct {
-					Text string `xml:",chardata"`
-				} `xml:"color"`
-			} `xml:"value"`
-		} `xml:"valueSetDefinition"`
-		ValueSetName *struct {
-			Text string `xml:",chardata"`
-		} `xml:"valueSetName"`
-		ValueSettings []struct {
-			ControllingFieldValue []struct {
-				Text string `xml:",innerxml"`
-			} `xml:"controllingFieldValue"`
-			ValueName struct {
-				Text string `xml:",chardata"`
-			} `xml:"valueName"`
-		} `xml:"valueSettings"`
-	} `xml:"valueSet"`
-	VisibleLines *struct {
-		Text string `xml:",chardata"`
-	} `xml:"visibleLines"`
-}
-
-type WebLink struct {
-	FullName     string `xml:"fullName"`
-	Availability struct {
-		Text string `xml:",chardata"`
-	} `xml:"availability"`
-	Description *struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	DisplayType struct {
-		Text string `xml:",chardata"`
-	} `xml:"displayType"`
-	EncodingKey *struct {
-		Text string `xml:",chardata"`
-	} `xml:"encodingKey"`
-	HasMenubar *struct {
-		Text string `xml:",chardata"`
-	} `xml:"hasMenubar"`
-	HasScrollbars *struct {
-		Text string `xml:",chardata"`
-	} `xml:"hasScrollbars"`
-	HasToolbar *struct {
-		Text string `xml:",chardata"`
-	} `xml:"hasToolbar"`
-	Height *struct {
-		Text string `xml:",chardata"`
-	} `xml:"height"`
-	IsResizable *struct {
-		Text string `xml:",chardata"`
-	} `xml:"isResizable"`
-	LinkType struct {
-		Text string `xml:",chardata"`
-	} `xml:"linkType"`
-	MasterLabel struct {
-		Text string `xml:",chardata"`
-	} `xml:"masterLabel"`
-	OpenType struct {
-		Text string `xml:",chardata"`
-	} `xml:"openType"`
-	Page *struct {
-		Text string `xml:",chardata"`
-	} `xml:"page"`
-	Position *struct {
-		Text string `xml:",chardata"`
-	} `xml:"position"`
-	Protected struct {
-		Text string `xml:",chardata"`
-	} `xml:"protected"`
-	RequireRowSelection *struct {
-		Text string `xml:",chardata"`
-	} `xml:"requireRowSelection"`
-	ShowsLocation *struct {
-		Text string `xml:",chardata"`
-	} `xml:"showsLocation"`
-	ShowsStatus *struct {
-		Text string `xml:",chardata"`
-	} `xml:"showsStatus"`
-	URL *struct {
-		Text string `xml:",innerxml"`
-	} `xml:"url"`
-	Width *struct {
-		Text string `xml:",chardata"`
-	} `xml:"width"`
-}
-
-type FieldSet struct {
-	FullName        string `xml:"fullName"`
-	AvailableFields []struct {
-		Field struct {
-			Text string `xml:",chardata"`
-		} `xml:"field"`
-		IsFieldManaged struct {
-			Text string `xml:",chardata"`
-		} `xml:"isFieldManaged"`
-		IsRequired struct {
-			Text string `xml:",chardata"`
-		} `xml:"isRequired"`
-	} `xml:"availableFields"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	DisplayedFields []struct {
-		Field struct {
-			Text string `xml:",chardata"`
-		} `xml:"field"`
-		IsFieldManaged struct {
-			Text string `xml:",chardata"`
-		} `xml:"isFieldManaged"`
-		IsRequired struct {
-			Text string `xml:",chardata"`
-		} `xml:"isRequired"`
-	} `xml:"displayedFields"`
-	Label struct {
-		Text string `xml:",chardata"`
-	} `xml:"label"`
-}
-
-type ValueSetOption struct {
-	FullName string      `xml:"fullName"`
-	Default  BooleanText `xml:"default"`
-}
-
-type ValueSetOptionList []ValueSetOption
-
-type Picklist struct {
-	Picklist string             `xml:"picklist"`
-	Values   ValueSetOptionList `xml:"values"`
-}
-
-type PicklistList []Picklist
-
-type RecordType struct {
-	FullName        string      `xml:"fullName"`
-	Active          BooleanText `xml:"active"`
-	BusinessProcess *struct {
-		Text string `xml:",chardata"`
-	} `xml:"businessProcess"`
-	CompactLayoutAssignment *struct {
-		Text string `xml:",chardata"`
-	} `xml:"compactLayoutAssignment"`
-	Description *struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Label struct {
-		Text string `xml:",chardata"`
-	} `xml:"label"`
-	PicklistValues PicklistList `xml:"picklistValues"`
-}
+type FieldList []field.Field
+type ListViewList []listview.ListView
 
 type ActionOverride struct {
 	ActionName           string       `xml:"actionName"`
@@ -346,39 +36,11 @@ type CustomObject struct {
 	AllowInChatterGroups *struct {
 		Text string `xml:",chardata"`
 	} `xml:"allowInChatterGroups"`
-	BusinessProcesses []struct {
-		FullName struct {
-			Text string `xml:",chardata"`
-		} `xml:"fullName"`
-		Description *struct {
-			Text string `xml:",chardata"`
-		} `xml:"description"`
-		IsActive struct {
-			Text string `xml:",chardata"`
-		} `xml:"isActive"`
-		Values []struct {
-			FullName struct {
-				Text string `xml:",chardata"`
-			} `xml:"fullName"`
-			Default struct {
-				Text string `xml:",chardata"`
-			} `xml:"default"`
-		} `xml:"values"`
-	} `xml:"businessProcesses"`
+	BusinessProcesses       []businessprocess.BusinessProcess `xml:"businessProcesses"`
 	CompactLayoutAssignment *struct {
 		Text string `xml:",chardata"`
 	} `xml:"compactLayoutAssignment"`
-	CompactLayouts []struct {
-		FullName struct {
-			Text string `xml:",chardata"`
-		} `xml:"fullName"`
-		Fields []struct {
-			Text string `xml:",chardata"`
-		} `xml:"fields"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-	} `xml:"compactLayouts"`
+	CompactLayouts []compactlayout.CompactLayout `xml:"compactLayouts"`
 	CustomHelpPage *struct {
 		Text string `xml:",chardata"`
 	} `xml:"customHelpPage"`
@@ -430,59 +92,12 @@ type CustomObject struct {
 	ExternalSharingModel *struct {
 		Text string `xml:",chardata"`
 	} `xml:"externalSharingModel"`
-	FieldSets []FieldSet `xml:"fieldSets"`
-	Fields    FieldList  `xml:"fields"`
+	FieldSets []fieldset.FieldSet `xml:"fieldSets"`
+	Fields    FieldList           `xml:"fields"`
 	Label     *struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	ListViews []struct {
-		FullName struct {
-			Text string `xml:",chardata"`
-		} `xml:"fullName"`
-		BooleanFilter *struct {
-			Text string `xml:",chardata"`
-		} `xml:"booleanFilter"`
-		Columns []struct {
-			Text string `xml:",chardata"`
-		} `xml:"columns"`
-		FilterScope struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterScope"`
-		Filters []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Operation struct {
-				Text string `xml:",chardata"`
-			} `xml:"operation"`
-			Value *struct {
-				Text string `xml:",chardata"`
-			} `xml:"value"`
-		} `xml:"filters"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		Queue *struct {
-			Text string `xml:",chardata"`
-		} `xml:"queue"`
-		SharedTo *struct {
-			Group []struct {
-				Text string `xml:",chardata"`
-			} `xml:"group"`
-			Rol []struct {
-				Text string `xml:",chardata"`
-			} `xml:"role"`
-			RoleAndSubordinates []struct {
-				Text string `xml:",chardata"`
-			} `xml:"roleAndSubordinates"`
-			AllInternalUsers *struct {
-				Text string `xml:",chardata"`
-			} `xml:"allInternalUsers"`
-		} `xml:"sharedTo"`
-		Language *struct {
-			Text string `xml:",chardata"`
-		} `xml:"language"`
-	} `xml:"listViews"`
+	ListViews ListViewList `xml:"listViews"`
 	NameField *struct {
 		DisplayFormat *struct {
 			Text string `xml:",chardata"`
@@ -520,7 +135,7 @@ type CustomObject struct {
 	RecordTypeTrackHistory *struct {
 		Text string `xml:",chardata"`
 	} `xml:"recordTypeTrackHistory"`
-	RecordTypes   []RecordType `xml:"recordTypes"`
+	RecordTypes   []recordtype.RecordType `xml:"recordTypes"`
 	SearchLayouts *struct {
 		CustomTabListAdditionalFields []struct {
 			Text string `xml:",chardata"`
@@ -553,18 +168,15 @@ type CustomObject struct {
 	SharingModel *struct {
 		Text string `xml:",chardata"`
 	} `xml:"sharingModel"`
-	SharingReasons []struct {
-		FullName string `xml:"fullName"`
-		Label    string `xml:"label"`
-	} `xml:"sharingReasons"`
-	StartsWith *struct {
+	SharingReasons []sharingreason.SharingReason `xml:"sharingReasons"`
+	StartsWith     *struct {
 		Text string `xml:",chardata"`
 	} `xml:"startsWith"`
-	ValidationRules []Rule `xml:"validationRules"`
+	ValidationRules []validationrule.Rule `xml:"validationRules"`
 	Visibility      *struct {
 		Text string `xml:",chardata"`
 	} `xml:"visibility"`
-	WebLinks []WebLink `xml:"webLinks"`
+	WebLinks []weblink.WebLink `xml:"webLinks"`
 }
 
 func (p *CustomObject) MetaCheck() {}

--- a/objects/recordtype.go
+++ b/objects/recordtype.go
@@ -1,11 +1,12 @@
 package objects
 
-import "github.com/pkg/errors"
+import (
+	recordtype "github.com/ForceCLI/force-md/objects/recordtype"
+	"github.com/pkg/errors"
+)
 
-type RecordTypeFilter func(RecordType) bool
-
-func (o *CustomObject) GetRecordTypes(filters ...RecordTypeFilter) []RecordType {
-	var recordTypes []RecordType
+func (o *CustomObject) GetRecordTypes(filters ...recordtype.RecordTypeFilter) []recordtype.RecordType {
+	var recordTypes []recordtype.RecordType
 RECORDTYPES:
 	for _, v := range o.RecordTypes {
 		for _, filter := range filters {

--- a/objects/recordtype/recordType.go
+++ b/objects/recordtype/recordType.go
@@ -1,0 +1,55 @@
+package recordtype
+
+import (
+	"encoding/xml"
+
+	. "github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type RecordTypeFilter func(RecordType) bool
+
+type RecordTypeMetadata struct {
+	XMLName xml.Name `xml:"RecordType"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	RecordType
+}
+
+type Picklist struct {
+	Picklist string             `xml:"picklist"`
+	Values   ValueSetOptionList `xml:"values"`
+}
+
+type PicklistList []Picklist
+
+type ValueSetOption struct {
+	FullName string      `xml:"fullName"`
+	Default  BooleanText `xml:"default"`
+}
+
+type ValueSetOptionList []ValueSetOption
+
+type RecordType struct {
+	FullName        string      `xml:"fullName"`
+	Active          BooleanText `xml:"active"`
+	BusinessProcess *struct {
+		Text string `xml:",chardata"`
+	} `xml:"businessProcess"`
+	CompactLayoutAssignment *struct {
+		Text string `xml:",chardata"`
+	} `xml:"compactLayoutAssignment"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	PicklistValues PicklistList `xml:"picklistValues"`
+}
+
+func (p *RecordTypeMetadata) MetaCheck() {}
+
+func Open(path string) (*RecordTypeMetadata, error) {
+	p := &RecordTypeMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/recordtype/tidy.go
+++ b/objects/recordtype/tidy.go
@@ -1,0 +1,15 @@
+package recordtype
+
+import "sort"
+
+func (values ValueSetOptionList) Tidy() {
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].FullName < values[j].FullName
+	})
+}
+
+func (picklists PicklistList) Tidy() {
+	sort.Slice(picklists, func(i, j int) bool {
+		return picklists[i].Picklist < picklists[j].Picklist
+	})
+}

--- a/objects/sharingreason/sharingreason.go
+++ b/objects/sharingreason/sharingreason.go
@@ -1,0 +1,25 @@
+package sharingreason
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type SharingReasonMetadata struct {
+	XMLName xml.Name `xml:"SharingReason"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	SharingReason
+}
+
+type SharingReason struct {
+	FullName string `xml:"fullName"`
+	Label    string `xml:"label"`
+}
+
+func (p *SharingReasonMetadata) MetaCheck() {}
+
+func Open(path string) (*SharingReasonMetadata, error) {
+	p := &SharingReasonMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/tidy.go
+++ b/objects/tidy.go
@@ -22,15 +22,3 @@ func (fields FieldList) Tidy() {
 		return fields[i].FullName < fields[j].FullName
 	})
 }
-
-func (values ValueSetOptionList) Tidy() {
-	sort.Slice(values, func(i, j int) bool {
-		return values[i].FullName < values[j].FullName
-	})
-}
-
-func (picklists PicklistList) Tidy() {
-	sort.Slice(picklists, func(i, j int) bool {
-		return picklists[i].Picklist < picklists[j].Picklist
-	})
-}

--- a/objects/validationrule.go
+++ b/objects/validationrule.go
@@ -2,9 +2,11 @@ package objects
 
 import (
 	"github.com/pkg/errors"
+
+	"github.com/ForceCLI/force-md/objects/validationrule"
 )
 
-func (p *CustomObject) GetValidationRules() []Rule {
+func (p *CustomObject) GetValidationRules() []validationrule.Rule {
 	return p.ValidationRules
 }
 

--- a/objects/validationrule/validationrule.go
+++ b/objects/validationrule/validationrule.go
@@ -1,0 +1,39 @@
+package validationrule
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type ValidationRule struct {
+	XMLName xml.Name `xml:"ValidationRule"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Rule
+}
+
+type Rule struct {
+	FullName string `xml:"fullName"`
+	Active   struct {
+		Text string `xml:",chardata"`
+	} `xml:"active"`
+	Description *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"description"`
+	ErrorConditionFormula struct {
+		Text string `xml:",innerxml"`
+	} `xml:"errorConditionFormula"`
+	ErrorDisplayField *struct {
+		Text string `xml:",chardata"`
+	} `xml:"errorDisplayField"`
+	ErrorMessage struct {
+		Text string `xml:",innerxml"`
+	} `xml:"errorMessage"`
+}
+
+func (p *ValidationRule) MetaCheck() {}
+
+func Open(path string) (*ValidationRule, error) {
+	p := &ValidationRule{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/weblink.go
+++ b/objects/weblink.go
@@ -2,9 +2,11 @@ package objects
 
 import (
 	"github.com/pkg/errors"
+
+	"github.com/ForceCLI/force-md/objects/weblink"
 )
 
-func (o *CustomObject) GetWebLinks() []WebLink {
+func (o *CustomObject) GetWebLinks() []weblink.WebLink {
 	return o.WebLinks
 }
 

--- a/objects/weblink/weblink.go
+++ b/objects/weblink/weblink.go
@@ -1,0 +1,84 @@
+package weblink
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type WebLinkMetadata struct {
+	XMLName xml.Name `xml:"WebLink"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	WebLink
+}
+
+type WebLink struct {
+	FullName     string `xml:"fullName"`
+	Availability struct {
+		Text string `xml:",chardata"`
+	} `xml:"availability"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	DisplayType struct {
+		Text string `xml:",chardata"`
+	} `xml:"displayType"`
+	EncodingKey *struct {
+		Text string `xml:",chardata"`
+	} `xml:"encodingKey"`
+	HasMenubar *struct {
+		Text string `xml:",chardata"`
+	} `xml:"hasMenubar"`
+	HasScrollbars *struct {
+		Text string `xml:",chardata"`
+	} `xml:"hasScrollbars"`
+	HasToolbar *struct {
+		Text string `xml:",chardata"`
+	} `xml:"hasToolbar"`
+	Height *struct {
+		Text string `xml:",chardata"`
+	} `xml:"height"`
+	IsResizable *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isResizable"`
+	LinkType struct {
+		Text string `xml:",chardata"`
+	} `xml:"linkType"`
+	MasterLabel struct {
+		Text string `xml:",chardata"`
+	} `xml:"masterLabel"`
+	OpenType struct {
+		Text string `xml:",chardata"`
+	} `xml:"openType"`
+	Page *struct {
+		Text string `xml:",chardata"`
+	} `xml:"page"`
+	Position *struct {
+		Text string `xml:",chardata"`
+	} `xml:"position"`
+	Protected struct {
+		Text string `xml:",chardata"`
+	} `xml:"protected"`
+	RequireRowSelection *struct {
+		Text string `xml:",chardata"`
+	} `xml:"requireRowSelection"`
+	ShowsLocation *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showsLocation"`
+	ShowsStatus *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showsStatus"`
+	URL *struct {
+		Text string `xml:",innerxml"`
+	} `xml:"url"`
+	Width *struct {
+		Text string `xml:",chardata"`
+	} `xml:"width"`
+}
+
+func (p *WebLinkMetadata) MetaCheck() {}
+
+func Open(path string) (*WebLinkMetadata, error) {
+	p := &WebLinkMetadata{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objecttranslation/field/field.go
+++ b/objecttranslation/field/field.go
@@ -1,0 +1,46 @@
+package field
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type CustomFieldTranslation struct {
+	XMLName xml.Name `xml:"CustomFieldTranslation"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Field
+}
+
+type Field struct {
+	CaseValues []struct {
+		Plural struct {
+			Text string `xml:",chardata"`
+		} `xml:"plural"`
+		Value struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"caseValues"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+	StartsWith struct {
+		Text string `xml:",chardata"`
+	} `xml:"startsWith"`
+	Label struct {
+	} `xml:"label"`
+	PicklistValues []struct {
+		MasterLabel struct {
+			Text string `xml:",chardata"`
+		} `xml:"masterLabel"`
+		Translation struct {
+		} `xml:"translation"`
+	} `xml:"picklistValues"`
+}
+
+func (p *CustomFieldTranslation) MetaCheck() {}
+
+func Open(path string) (*CustomFieldTranslation, error) {
+	p := &CustomFieldTranslation{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objecttranslation/objecttranslation.go
+++ b/objecttranslation/objecttranslation.go
@@ -1,0 +1,40 @@
+package objecttranslation
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/objecttranslation/field"
+)
+
+type FieldList []field.Field
+
+type CustomObjectTranslation struct {
+	XMLName     xml.Name `xml:"CustomObjectTranslation"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	RecordTypes []struct {
+		Description struct {
+			Text string `xml:",chardata"`
+		} `xml:"description"`
+		Label struct {
+		} `xml:"label"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+	} `xml:"recordTypes"`
+	Fields          FieldList `xml:"fields"`
+	ValidationRules []struct {
+		ErrorMessage struct {
+		} `xml:"errorMessage"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+	} `xml:"validationRules"`
+}
+
+func (p *CustomObjectTranslation) MetaCheck() {}
+
+func Open(path string) (*CustomObjectTranslation, error) {
+	p := &CustomObjectTranslation{}
+	return p, internal.ParseMetadataXml(p, path)
+}


### PR DESCRIPTION
Move BusinessProcess, CustomField, FieldSet, RecordType, ValidationRule,
CompactLayout, ListView, SharingReason, and WebLink metadata into
separate packages in preparation for better source-format support.

Add CustomObjectTranslation and CustomFieldTranslation types.
