### PR TITLE
Add `application action reset` Command

### DIFF
--- a/application/actions.go
+++ b/application/actions.go
@@ -39,3 +39,26 @@ ACTIONS:
 	o.ProfileActionOverrides = newActions
 	return nil
 }
+
+func (o *CustomApplication) ResetActionOverrides(filters ...ProfileActionOverrideFilter) error {
+	found := false
+	newActions := o.ProfileActionOverrides[:0]
+ACTIONS:
+	for _, a := range o.ProfileActionOverrides {
+		for _, filter := range filters {
+			if !filter(a) {
+				newActions = append(newActions, a)
+				continue ACTIONS
+			}
+		}
+		a.Content = nil
+		a.Type = "default"
+		newActions = append(newActions, a)
+		found = true
+	}
+	if !found {
+		return errors.New("no actions found")
+	}
+	o.ProfileActionOverrides = newActions
+	return nil
+}

--- a/application/application.go
+++ b/application/application.go
@@ -9,7 +9,7 @@ import (
 
 type ProfileActionOverride struct {
 	ActionName        string  `xml:"actionName"`
-	Content           string  `xml:"content"`
+	Content           *string `xml:"content"`
 	FormFactor        string  `xml:"formFactor"`
 	PageOrSobjectType string  `xml:"pageOrSobjectType"`
 	RecordType        *string `xml:"recordType"`

--- a/application/tidy.go
+++ b/application/tidy.go
@@ -26,6 +26,6 @@ func (pao ProfileActionOverrideList) Tidy() {
 		if pao[i].Type != pao[j].Type {
 			return pao[i].Type < pao[j].Type
 		}
-		return pao[i].Content < pao[j].Content
+		return *pao[i].Content < *pao[j].Content
 	})
 }


### PR DESCRIPTION
Add `application action reset` command to reset profileActionOverrides
in CustomApplication metadata.

From
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_profileactionoverride.htm:

   You can't delete custom app ProfileActionOverrides by deploying with
   destructiveChange.xml. To delete a ProfileActionOverride, retrieve
   the app. In the app definition file, find the
   <profileActionOverrides> section, and remove the <content> row. Then,
   change the <type> value in that same section to default instead of
   flexipage. Do this for every override you want to reset. After making
   the changes, rezip the folder and deploy.
