### PR TITLE
Edit Non-String Custom Metadata Fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
     steps:
       - checkout
       - run: go install github.com/mitchellh/gox@latest

--- a/cmd/custommetadata/edit.go
+++ b/cmd/custommetadata/edit.go
@@ -47,25 +47,12 @@ func editCustomMetadataValue(file string, field string, value string) {
 		log.Warn("parsing custom metadata failed: " + err.Error())
 		return
 	}
-	// Create new CustomMetadata element to deal with bugs
-	// marshaling/unmarshaling XML with namespaces
-	m := custommetadata.CustomMetadata{
-		Xmlns:     "http://soap.sforce.com/2006/04/metadata",
-		Xsi:       "http://www.w3.org/2001/XMLSchema-instance",
-		Xsd:       "http://www.w3.org/2001/XMLSchema",
-		Label:     p.Label,
-		Protected: p.Protected,
-	}
-	for _, v := range p.Values {
-		m.AddValue(v.Field, v.Value.Text)
-	}
-	m.Tidy()
-	err = m.UpdateFieldValue(field, value)
+	err = p.UpdateFieldValue(field, value)
 	if err != nil {
 		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
 		return
 	}
-	err = internal.WriteToFile(m, file)
+	err = internal.WriteToFile(p, file)
 	if err != nil {
 		log.Warn("update failed: " + err.Error())
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ForceCLI/force-md
 
-go 1.20
+go 1.21
+
+toolchain go1.22.5
 
 require (
 	github.com/antonmedv/expr v1.15.0
@@ -14,6 +16,8 @@ require (
 	github.com/thediveo/enumflag v0.10.1
 	golang.org/x/net v0.10.0
 )
+
+require github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf h1:DaAn+3RP17Q2KGe+pXDAni2lBA6dyfHlDvf+6mYgtTA=
+github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf/go.mod h1:990JnYmJZFrx1vI1TALoD6/fCqnWlTx2FrPbYy2wi5I=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -123,6 +125,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/thediveo/enumflag v0.10.1 h1:DB3Ag69VZ7BCv6jzKECrZ0ebZrHLzFRMIFYt96s4OxM=
 github.com/thediveo/enumflag v0.10.1/go.mod h1:KyVhQUPzreSw85oJi2uSjFM0ODLKXBH0rPod7zc2pmI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -2,9 +2,10 @@ package internal
 
 import (
 	"bytes"
-	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"os"
+
+	"github.com/nbio/xml"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/html/charset"
@@ -27,7 +28,7 @@ func ParseMetadataXmlIfPossible(i MetadataPointer, path string) ([]byte, error) 
 			return nil, errors.Wrap(err, "opening file")
 		}
 	}
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading file")
 	}


### PR DESCRIPTION
Fix editing non-string Custom Metadata fields.

Use github.com/nbio/xml to parse metadata, which fixes parsing
attributes containing namespaces.  This fixes parsing the xsi:type
attributes from Custom Metadata value elements so types of xsd:double,
for example, are preserved.
