### PR TITLE
Add `objects index write` Command

### DIFF
--- a/cmd/objects.go
+++ b/cmd/objects.go
@@ -8,6 +8,7 @@ import (
 
 func init() {
 	objectsCmd.AddCommand(objects.FieldCmd)
+	objectsCmd.AddCommand(objects.IndexCmd)
 	objectsCmd.AddCommand(objects.FieldSetCmd)
 	objectsCmd.AddCommand(objects.RecordTypeCmd)
 	objectsCmd.AddCommand(objects.TidyCmd)

--- a/cmd/objects/index.go
+++ b/cmd/objects/index.go
@@ -1,0 +1,60 @@
+package objects
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/objects"
+	"github.com/ForceCLI/force-md/objects/index"
+)
+
+var (
+	indexesDir string
+)
+
+func init() {
+	writeIndexesCmd.Flags().StringVarP(&indexesDir, "directory", "d", "", "directory where indexes should be output")
+	writeIndexesCmd.MarkFlagRequired("directory")
+
+	IndexCmd.AddCommand(writeIndexesCmd)
+}
+
+var IndexCmd = &cobra.Command{
+	Use:                   "index",
+	Short:                 "Manage big object index metadata",
+	DisableFlagsInUseLine: true,
+}
+
+var writeIndexesCmd = &cobra.Command{
+	Use:                   "write -d directory [filename]...",
+	Short:                 "Split object indexes into separate files",
+	Long:                  "Split object indexes into separate metadata files to match sfdx's source format",
+	Args:                  cobra.MinimumNArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range args {
+			writeIndexes(file, indexesDir)
+		}
+	},
+}
+
+func writeIndexes(file string, indexesDir string) {
+	o, err := objects.Open(file)
+	if err != nil {
+		log.Warn("parsing object failed: " + err.Error())
+		return
+	}
+	indexes := o.GetIndexes()
+	for _, i := range indexes {
+		idx := index.Index{
+			BigObjectIndex: i,
+			Xmlns:          o.Xmlns,
+		}
+		err = internal.WriteToFile(idx, indexesDir+"/"+i.FullName+".index-meta.xml")
+		if err != nil {
+			log.Warn("write failed: " + err.Error())
+			return
+		}
+	}
+}

--- a/objects/index/index.go
+++ b/objects/index/index.go
@@ -1,0 +1,31 @@
+package index
+
+import (
+	"encoding/xml"
+
+	"github.com/ForceCLI/force-md/internal"
+)
+
+type IndexFilter func(BigObjectIndex) bool
+
+type Index struct {
+	XMLName xml.Name `xml:"Index"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	BigObjectIndex
+}
+
+type BigObjectIndex struct {
+	FullName string `xml:"fullName"`
+	Fields   []struct {
+		Name          string `xml:"name"`
+		SortDirection string `xml:"sortDirection"`
+	} `xml:"fields"`
+	Label string `xml:"label"`
+}
+
+func (p *Index) MetaCheck() {}
+
+func Open(path string) (*Index, error) {
+	p := &Index{}
+	return p, internal.ParseMetadataXml(p, path)
+}

--- a/objects/indexes.go
+++ b/objects/indexes.go
@@ -1,0 +1,17 @@
+package objects
+
+import "github.com/ForceCLI/force-md/objects/index"
+
+func (o *CustomObject) GetIndexes(filters ...index.IndexFilter) []index.BigObjectIndex {
+	var indexes []index.BigObjectIndex
+INDEXES:
+	for _, i := range o.Indexes {
+		for _, filter := range filters {
+			if !filter(i) {
+				continue INDEXES
+			}
+		}
+		indexes = append(indexes, i)
+	}
+	return indexes
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ForceCLI/force-md/objects/compactlayout"
 	"github.com/ForceCLI/force-md/objects/field"
 	"github.com/ForceCLI/force-md/objects/fieldset"
+	"github.com/ForceCLI/force-md/objects/index"
 	"github.com/ForceCLI/force-md/objects/listview"
 	"github.com/ForceCLI/force-md/objects/recordtype"
 	"github.com/ForceCLI/force-md/objects/sharingreason"
@@ -18,6 +19,7 @@ import (
 )
 
 type FieldList []field.Field
+type IndexList []index.BigObjectIndex
 type ListViewList []listview.ListView
 
 type ActionOverride struct {
@@ -94,6 +96,7 @@ type CustomObject struct {
 	} `xml:"externalSharingModel"`
 	FieldSets []fieldset.FieldSet `xml:"fieldSets"`
 	Fields    FieldList           `xml:"fields"`
+	Indexes   IndexList           `xml:"indexes"`
 	Label     *struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`


### PR DESCRIPTION
Add initial support for Big Object Index metadata with `objects index
write` command to write out indexes in source format files.
