### PR TITLE
Add `--table` Option to `reporttype fields delete`

### DIFF
--- a/cmd/reportType/fields.go
+++ b/cmd/reportType/fields.go
@@ -25,6 +25,7 @@ func init() {
 	addFieldCmd.MarkFlagRequired("section")
 
 	deleteFieldCmd.Flags().StringVarP(&fieldName, "field", "f", "", "field name")
+	deleteFieldCmd.Flags().StringVarP(&tableName, "table", "t", "", "table name")
 	deleteFieldCmd.MarkFlagRequired("field")
 
 	FieldCmd.AddCommand(listFieldsCmd)
@@ -69,7 +70,7 @@ var deleteFieldCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, file := range args {
-			deleteField(file, fieldName)
+			deleteField(file, fieldName, tableName)
 		}
 	},
 }
@@ -104,13 +105,13 @@ func addField(file string, section, tableName, fieldName string) {
 	}
 }
 
-func deleteField(file string, fieldName string) {
+func deleteField(file string, fieldName string, tableName string) {
 	o, err := reportType.Open(file)
 	if err != nil {
 		log.Warn("parsing report type failed: " + err.Error())
 		return
 	}
-	err = o.DeleteField(fieldName)
+	err = o.DeleteField(fieldName, tableName)
 	if err != nil {
 		log.Warn(fmt.Sprintf("update failed for %s: %s", file, err.Error()))
 		return

--- a/reportType/fields.go
+++ b/reportType/fields.go
@@ -38,12 +38,14 @@ func (o *ReportType) AddField(sectionName, table, field string) error {
 	return fmt.Errorf("section not found: %s", sectionName)
 }
 
-func (o *ReportType) DeleteField(field string) error {
+func (o *ReportType) DeleteField(field, table string) error {
 	found := false
 	for s, section := range o.Sections {
 		newFields := section.Columns[:0]
 		for _, f := range section.Columns {
-			if strings.ToLower(f.Field) != strings.ToLower(field) {
+			fieldMatch := strings.ToLower(f.Field) == strings.ToLower(field)
+			tableMatch := table == "" || strings.ToLower(f.Table) == strings.ToLower(table)
+			if !fieldMatch || !tableMatch {
 				newFields = append(newFields, f)
 			} else {
 				found = true

--- a/reportType/reportType.go
+++ b/reportType/reportType.go
@@ -40,12 +40,6 @@ type ReportType struct {
 	} `xml:"description"`
 	Join *struct {
 		Join *struct {
-			OuterJoin struct {
-				Text string `xml:",chardata"`
-			} `xml:"outerJoin"`
-			Relationship struct {
-				Text string `xml:",chardata"`
-			} `xml:"relationship"`
 			Join *struct {
 				OuterJoin struct {
 					Text string `xml:",chardata"`
@@ -54,6 +48,12 @@ type ReportType struct {
 					Text string `xml:",chardata"`
 				} `xml:"relationship"`
 			} `xml:"join"`
+			OuterJoin struct {
+				Text string `xml:",chardata"`
+			} `xml:"outerJoin"`
+			Relationship struct {
+				Text string `xml:",chardata"`
+			} `xml:"relationship"`
 		} `xml:"join"`
 		OuterJoin struct {
 			Text string `xml:",chardata"`


### PR DESCRIPTION
Add option to filter fields to delete from Report Types by `table`, the
name of the relationship relative to the Report Type's base object.
