### PR TITLE
Add `--warn` Flag to `objects tidy`

### DIFF
--- a/objects/field/field.go
+++ b/objects/field/field.go
@@ -139,16 +139,12 @@ type Field struct {
 				Text string `xml:",chardata"`
 			} `xml:"sorted"`
 			Value []struct {
-				FullName struct {
-					Text string `xml:",innerxml"`
-				} `xml:"fullName"`
-				Default struct {
+				FullName string `xml:"fullName"`
+				Default  struct {
 					Text string `xml:",chardata"`
 				} `xml:"default"`
-				IsActive *struct {
-					Text string `xml:",chardata"`
-				} `xml:"isActive"`
-				Label struct {
+				IsActive *BooleanText `xml:"isActive"`
+				Label    struct {
 					Text string `xml:",innerxml"`
 				} `xml:"label"`
 				Color *struct {

--- a/objects/fields.go
+++ b/objects/fields.go
@@ -59,7 +59,7 @@ func (o *CustomObject) ListPicklistOptions(fieldName string) ([]string, error) {
 	}
 	var options []string
 	for _, o := range picklistField.ValueSet.ValueSetDefinition.Value {
-		options = append(options, o.FullName.Text)
+		options = append(options, o.FullName)
 	}
 	return options, nil
 }


### PR DESCRIPTION
Add `--warn` flag to `objects tidy` command to check for metadata
issues.  It will output a warning if active picklist options are not
assigned to any Record Types.
