### PR TITLE
Remove Duplicate Application Visibility

### DIFF
--- a/permissionset/permissionset.go
+++ b/permissionset/permissionset.go
@@ -93,6 +93,10 @@ type ApplicationVisibility struct {
 	Visible     BooleanText `xml:"visible"`
 }
 
+func (av ApplicationVisibility) GetName() string {
+	return av.Application
+}
+
 type ApplicationVisibilityList []ApplicationVisibility
 
 type ExternalCredentialPrincipalAccess struct {

--- a/permissionset/tidy.go
+++ b/permissionset/tidy.go
@@ -26,10 +26,14 @@ func (op ObjectPermissionsList) Tidy() {
 	})
 }
 
-func (av ApplicationVisibilityList) Tidy() {
-	sort.Slice(av, func(i, j int) bool {
-		return av[i].Application < av[j].Application
+func (av *ApplicationVisibilityList) Tidy() {
+	if len(*av) == 0 {
+		return
+	}
+	sort.Slice(*av, func(i, j int) bool {
+		return (*av)[i].Application < (*av)[j].Application
 	})
+	RemoveDuplicates(av)
 }
 
 func (ca ApexClassList) Tidy() {

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -50,6 +50,10 @@ type ApplicationVisibility struct {
 	Visible     BooleanText `xml:"visible"`
 }
 
+func (av ApplicationVisibility) GetName() string {
+	return av.Application
+}
+
 type RecordTypeVisibility struct {
 	Default              BooleanText  `xml:"default"`
 	PersonAccountDefault *BooleanText `xml:"personAccountDefault"`

--- a/profile/tidy.go
+++ b/profile/tidy.go
@@ -2,6 +2,8 @@ package profile
 
 import (
 	"sort"
+
+	. "github.com/ForceCLI/force-md/general"
 )
 
 func (p *Profile) Tidy() {
@@ -22,10 +24,14 @@ func (p *Profile) Tidy() {
 	p.UserPermissions.Tidy()
 }
 
-func (av ApplicationVisibilityList) Tidy() {
-	sort.Slice(av, func(i, j int) bool {
-		return av[i].Application < av[j].Application
+func (av *ApplicationVisibilityList) Tidy() {
+	if len(*av) == 0 {
+		return
+	}
+	sort.Slice(*av, func(i, j int) bool {
+		return (*av)[i].Application < (*av)[j].Application
 	})
+	RemoveDuplicates(av)
 }
 
 func (la LayoutAssignmentList) Tidy() {


### PR DESCRIPTION
Remove duplicate applicationVisibilities elements in Profiles and
Permission Sets when tidying
