### PR TITLE
Add `tidy` Command For Multiple Types of Metadata

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "CustomApplication"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type ProfileActionOverride struct {
 	ActionName        string  `xml:"actionName"`
 	Content           *string `xml:"content"`
@@ -110,6 +116,10 @@ type CustomApplication struct {
 
 func (c *CustomApplication) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *CustomApplication) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*CustomApplication, error) {

--- a/cmd/tidy.go
+++ b/cmd/tidy.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	_ "github.com/ForceCLI/force-md/flow"
+
+	"github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	tidyCmd.Flags().BoolP("list", "l", false, "list files that need tidying")
+
+	RootCmd.AddCommand(tidyCmd)
+}
+
+var tidyCmd = &cobra.Command{
+	Use:   "tidy",
+	Short: "Tidy Metadata",
+	Example: `
+$ force-md tidy sfdx/main/default/objects/*/{fields,validationRules}/* sfdx/main/default/flows/*
+
+$ force-md tidy src/objects/*
+`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, file := range args {
+			_, err := internal.Metadata.Open(file)
+			if err != nil {
+				return fmt.Errorf("invalid file %s: %w", file, err)
+			}
+		}
+		changes := false
+		list, _ := cmd.Flags().GetBool("list")
+		for _, t := range internal.Metadata.Types() {
+			for _, m := range internal.Metadata.Items(t) {
+				file := m.GetMetadataInfo().Path()
+				o, ok := m.(general.Tidyable)
+				if !ok {
+					log.Warnf("file %s of type %T is not tidyable", file, m)
+					continue
+				}
+				if list {
+					orig := m.GetMetadataInfo().Contents()
+					needsTidying := checkIfChanged(o, orig)
+					if needsTidying {
+						fmt.Println(file)
+					}
+					changes = needsTidying || changes
+				} else {
+					if err := general.Tidy(o, file); err != nil {
+						log.Warnf("tidying failed: %s", err.Error())
+					}
+				}
+			}
+		}
+		if changes {
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func checkIfChanged(o general.Tidyable, orig []byte) (changed bool) {
+	o.Tidy()
+	newContents, err := internal.Marshal(o)
+	if err != nil {
+		log.Warn("serializing failed: " + err.Error())
+		return false
+	}
+	if !bytes.Equal(orig, newContents) {
+		return true
+	}
+	return false
+}

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "Flow"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type ElementName string
 
 type Start struct {
@@ -16,37 +22,28 @@ type Start struct {
 	LocationY struct {
 		Text string `xml:",chardata"`
 	} `xml:"locationY"`
-	Connector struct {
+	Connector *struct {
 		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"connector"`
-	FilterLogic struct {
+	DoesRequireRecordChangedToMeetCriteria *struct {
 		Text string `xml:",chardata"`
-	} `xml:"filterLogic"`
-	Filters []struct {
+	} `xml:"doesRequireRecordChangedToMeetCriteria"`
+	FilterLogic   *string      `xml:"filterLogic"`
+	FilterFormula *TextLiteral `xml:"filterFormula"`
+	Filters       []struct {
 		Field struct {
 			Text string `xml:",chardata"`
 		} `xml:"field"`
 		Operator struct {
 			Text string `xml:",chardata"`
 		} `xml:"operator"`
-		Value struct {
-			StringValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"stringValue"`
-			BooleanValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"booleanValue"`
-			DateTimeValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"dateTimeValue"`
-		} `xml:"value"`
+		Value *Value `xml:"value"`
 	} `xml:"filters"`
-	Object            string `xml:"object"`
-	RecordTriggerType struct {
+	Object            *string `xml:"object"`
+	RecordTriggerType *struct {
 		Text string `xml:",chardata"`
 	} `xml:"recordTriggerType"`
-	TriggerType string `xml:"triggerType"`
-	Schedule    struct {
+	Schedule *struct {
 		Frequency struct {
 			Text string `xml:",chardata"`
 		} `xml:"frequency"`
@@ -58,14 +55,34 @@ type Start struct {
 		} `xml:"startTime"`
 	} `xml:"schedule"`
 	ScheduledPaths []struct {
+		Name *struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
 		Connector struct {
+			IsGoTo *struct {
+				Text string `xml:",chardata"`
+			} `xml:"isGoTo"`
 			TargetReference ElementName `xml:"targetReference"`
 		} `xml:"connector"`
-		PathType string `xml:"pathType"`
+		Label *struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		MaxBatchSize *struct {
+			Text string `xml:",chardata"`
+		} `xml:"maxBatchSize"`
+		OffsetNumber *struct {
+			Text string `xml:",chardata"`
+		} `xml:"offsetNumber"`
+		OffsetUnit *struct {
+			Text string `xml:",chardata"`
+		} `xml:"offsetUnit"`
+		PathType    *string `xml:"pathType"`
+		RecordField *string `xml:"recordField"`
+		TimeSource  *struct {
+			Text string `xml:",chardata"`
+		} `xml:"timeSource"`
 	} `xml:"scheduledPaths"`
-	DoesRequireRecordChangedToMeetCriteria struct {
-		Text string `xml:",chardata"`
-	} `xml:"doesRequireRecordChangedToMeetCriteria"`
+	TriggerType *string `xml:"triggerType"`
 }
 
 type Rule struct {
@@ -76,22 +93,26 @@ type Rule struct {
 	Conditions     []struct {
 		LeftValueReference string `xml:"leftValueReference"`
 		Operator           string `xml:"operator"`
-		RightValue         Value  `xml:"rightValue"`
+		RightValue         *Value `xml:"rightValue"`
 	} `xml:"conditions"`
-	Connector struct {
-		TargetReference ElementName `xml:"targetReference"`
-		IsGoTo          struct {
+	Connector *struct {
+		IsGoTo *struct {
 			Text string `xml:",chardata"`
 		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"connector"`
+	DoesRequireRecordChangedToMeetCriteria *struct {
+		Text string `xml:",chardata"`
+	} `xml:"doesRequireRecordChangedToMeetCriteria"`
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 }
 
 type Decision struct {
-	Name  ElementName `xml:"name"`
-	Label struct {
+	Description *TextLiteral `xml:"description"`
+	Name        ElementName  `xml:"name"`
+	Label       struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 	LocationX struct {
@@ -100,26 +121,25 @@ type Decision struct {
 	LocationY struct {
 		Text string `xml:",chardata"`
 	} `xml:"locationY"`
+	DefaultConnector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"defaultConnector"`
 	DefaultConnectorLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"defaultConnectorLabel"`
-	Rules            []Rule `xml:"rules"`
-	DefaultConnector struct {
-		TargetReference ElementName `xml:"targetReference"`
-	} `xml:"defaultConnector"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
+	Rules []Rule `xml:"rules"`
 }
 
 type Value struct {
 	ElementReference *struct {
 		Text string `xml:",chardata"`
 	} `xml:"elementReference"`
-	StringValue *struct {
-		Text string `xml:",chardata"`
-	} `xml:"stringValue"`
-	NumberValue *struct {
+	StringValue   *TextLiteral `xml:"stringValue"`
+	DateTimeValue *TextLiteral `xml:"dateTimeValue"`
+	NumberValue   *struct {
 		Text string `xml:",chardata"`
 	} `xml:"numberValue"`
 	BooleanValue *BooleanText `xml:"booleanValue"`
@@ -139,6 +159,9 @@ func (v Value) String() string {
 }
 
 type RecordLookup struct {
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	Name  ElementName `xml:"name"`
 	Label struct {
 		Text string `xml:",chardata"`
@@ -153,30 +176,26 @@ type RecordLookup struct {
 	Connector                        struct {
 		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"connector"`
-	FilterLogic string `xml:"filterLogic"`
+	FaultConnector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"faultConnector"`
+	FilterLogic *string `xml:"filterLogic"`
 	Filters     []struct {
 		Field    string `xml:"field"`
 		Operator string `xml:"operator"`
-		Value    Value  `xml:"value"`
+		Value    *Value `xml:"value"`
 	} `xml:"filters"`
-	GetFirstRecordOnly       BooleanText `xml:"getFirstRecordOnly"`
-	Object                   string      `xml:"object"`
-	StoreOutputAutomatically BooleanText `xml:"storeOutputAutomatically"`
-	FaultConnector           struct {
-		TargetReference ElementName `xml:"targetReference"`
-		IsGoTo          struct {
-			Text string `xml:",chardata"`
-		} `xml:"isGoTo"`
-	} `xml:"faultConnector"`
-	OutputReference struct {
+	GetFirstRecordOnly *BooleanText `xml:"getFirstRecordOnly"`
+	Object             string       `xml:"object"`
+	OutputReference    *struct {
 		Text string `xml:",chardata"`
 	} `xml:"outputReference"`
 	QueriedFields []struct {
 		Text string `xml:",chardata"`
 	} `xml:"queriedFields"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 	OutputAssignments []struct {
 		AssignToReference struct {
 			Text string `xml:",chardata"`
@@ -185,12 +204,90 @@ type RecordLookup struct {
 			Text string `xml:",chardata"`
 		} `xml:"field"`
 	} `xml:"outputAssignments"`
-	SortField struct {
+	SortField *struct {
 		Text string `xml:",chardata"`
 	} `xml:"sortField"`
-	SortOrder struct {
+	SortOrder *struct {
 		Text string `xml:",chardata"`
 	} `xml:"sortOrder"`
+	StoreOutputAutomatically *BooleanText `xml:"storeOutputAutomatically"`
+}
+
+type RecordRollback struct {
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	LocationX struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationX"`
+	LocationY struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationY"`
+	Connector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"connector"`
+}
+
+type RecordCreate struct {
+	Description *TextLiteral `xml:"description"`
+	Name        struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	LocationX struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationX"`
+	LocationY struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationY"`
+	AssignRecordIdToReference *struct {
+		Text string `xml:",chardata"`
+	} `xml:"assignRecordIdToReference"`
+	Connector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"connector"`
+	FaultConnector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"faultConnector"`
+	InputReference *struct {
+		Text string `xml:",chardata"`
+	} `xml:"inputReference"`
+	InputAssignments []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Value struct {
+			BooleanValue *struct {
+				Text string `xml:",chardata"`
+			} `xml:"booleanValue"`
+			ElementReference *struct {
+				Text string `xml:",chardata"`
+			} `xml:"elementReference"`
+			StringValue *struct {
+				Text string `xml:",chardata"`
+			} `xml:"stringValue"`
+		} `xml:"value"`
+	} `xml:"inputAssignments"`
+	Object *struct {
+		Text string `xml:",chardata"`
+	} `xml:"object"`
+	StoreOutputAutomatically *struct {
+		Text string `xml:",chardata"`
+	} `xml:"storeOutputAutomatically"`
 }
 
 type RecordDelete struct {
@@ -204,69 +301,135 @@ type RecordDelete struct {
 	LocationY struct {
 		Text string `xml:",chardata"`
 	} `xml:"locationY"`
-	Connector struct {
+	Connector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
 		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"connector"`
-	FaultConnector struct {
-		IsGoTo struct {
+	FaultConnector *struct {
+		IsGoTo *struct {
 			Text string `xml:",chardata"`
 		} `xml:"isGoTo"`
 		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"faultConnector"`
-	InputReference struct {
+	FilterLogic *string `xml:"filterLogic"`
+	Filters     []struct {
+		Field    string `xml:"field"`
+		Operator string `xml:"operator"`
+		Value    *Value `xml:"value"`
+	} `xml:"filters"`
+	Object         *string `xml:"object"`
+	InputReference *struct {
+		Text string `xml:",chardata"`
+	} `xml:"inputReference"`
+}
+
+type RecordUpdate struct {
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	LocationX struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationX"`
+	LocationY struct {
+		Text string `xml:",chardata"`
+	} `xml:"locationY"`
+	Connector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"connector"`
+	FaultConnector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"faultConnector"`
+	FilterLogic *string `xml:"filterLogic"`
+	Filters     []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Operator struct {
+			Text string `xml:",chardata"`
+		} `xml:"operator"`
+		Value *Value `xml:"value"`
+	} `xml:"filters"`
+	InputAssignments []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Value *Value `xml:"value"`
+	} `xml:"inputAssignments"`
+	Object *struct {
+		Text string `xml:",chardata"`
+	} `xml:"object"`
+	InputReference *struct {
 		Text string `xml:",chardata"`
 	} `xml:"inputReference"`
 }
 
 type Field struct {
-	Name            string  `xml:"name"`
-	ExtensionName   string  `xml:"extensionName"`
+	ProcessMetadataValues []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Value *Value `xml:"value"`
+	} `xml:"processMetadataValues"`
+	Name                           *string  `xml:"name"`
+	ChoiceReferences               []string `xml:"choiceReferences"`
+	DataType                       *string  `xml:"dataType"`
+	DefaultSelectedChoiceReference *struct {
+		Text string `xml:",chardata"`
+	} `xml:"defaultSelectedChoiceReference"`
+	DefaultValue     *Value `xml:"defaultValue"`
+	DataTypeMappings []struct {
+		TypeName struct {
+			Text string `xml:",chardata"`
+		} `xml:"typeName"`
+		TypeValue struct {
+			Text string `xml:",chardata"`
+		} `xml:"typeValue"`
+	} `xml:"dataTypeMappings"`
+	ExtensionName   *string `xml:"extensionName"`
+	FieldText       *string `xml:"fieldText"`
 	FieldType       string  `xml:"fieldType"`
 	Fields          []Field `xml:"fields"`
 	InputParameters []struct {
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
-		Value struct {
-			ElementReference struct {
-				Text string `xml:",chardata"`
-			} `xml:"elementReference"`
-			StringValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"stringValue"`
-			BooleanValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"booleanValue"`
-		} `xml:"value"`
+		Value Value `xml:"value"`
 	} `xml:"inputParameters"`
-	InputsOnNextNavToAssocScrn struct {
+	HelpText *struct {
+		Text string `xml:",chardata"`
+	} `xml:"helpText"`
+	InputsOnNextNavToAssocScrn *struct {
 		Text string `xml:",chardata"`
 	} `xml:"inputsOnNextNavToAssocScrn"`
-	IsRequired struct {
+	IsRequired *struct {
 		Text string `xml:",chardata"`
 	} `xml:"isRequired"`
-	StoreOutputAutomatically struct {
+	StoreOutputAutomatically *struct {
 		Text string `xml:",chardata"`
 	} `xml:"storeOutputAutomatically"`
-	FieldText    string `xml:"fieldText"`
-	DataType     string `xml:"dataType"`
-	DefaultValue struct {
-		ElementReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"elementReference"`
-		StringValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"stringValue"`
-	} `xml:"defaultValue"`
-	ValidationRule struct {
+	Scale *struct {
+		Text string `xml:",chardata"`
+	} `xml:"scale"`
+	ValidationRule *struct {
 		ErrorMessage struct {
 			Text string `xml:",chardata"`
 		} `xml:"errorMessage"`
-		FormulaExpression struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaExpression"`
+		FormulaExpression TextLiteral `xml:"formulaExpression"`
 	} `xml:"validationRule"`
-	ChoiceReferences []string `xml:"choiceReferences"`
 	OutputParameters []struct {
 		AssignToReference struct {
 			Text string `xml:",chardata"`
@@ -275,41 +438,32 @@ type Field struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 	} `xml:"outputParameters"`
-	HelpText struct {
+	RegionContainerType *struct {
 		Text string `xml:",chardata"`
-	} `xml:"helpText"`
-	VisibilityRule struct {
+	} `xml:"regionContainerType"`
+	VisibilityRule *struct {
 		ConditionLogic struct {
 			Text string `xml:",chardata"`
 		} `xml:"conditionLogic"`
-		Conditions struct {
+		Conditions []struct {
 			LeftValueReference struct {
 				Text string `xml:",chardata"`
 			} `xml:"leftValueReference"`
 			Operator struct {
 				Text string `xml:",chardata"`
 			} `xml:"operator"`
-			RightValue struct {
-				BooleanValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"booleanValue"`
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-			} `xml:"rightValue"`
+			RightValue *Value `xml:"rightValue"`
 		} `xml:"conditions"`
 	} `xml:"visibilityRule"`
-	ObjectFieldReference struct {
+	ObjectFieldReference *struct {
 		Text string `xml:",chardata"`
 	} `xml:"objectFieldReference"`
-	Scale struct {
-		Text string `xml:",chardata"`
-	} `xml:"scale"`
 }
 
 type Screen struct {
-	Name  ElementName `xml:"name"`
-	Label struct {
+	Description *TextLiteral `xml:"description"`
+	Name        ElementName  `xml:"name"`
+	Label       struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 	LocationX struct {
@@ -325,61 +479,50 @@ type Screen struct {
 	AllowPause  struct {
 		Text string `xml:",chardata"`
 	} `xml:"allowPause"`
-	Fields     []Field `xml:"fields"`
+	Connector *struct {
+		IsGoTo *struct {
+			Text string `xml:",chardata"`
+		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
+	} `xml:"connector"`
+	Fields                  []Field      `xml:"fields"`
+	HelpText                *TextLiteral `xml:"helpText"`
+	NextOrFinishButtonLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"nextOrFinishButtonLabel"`
+	PausedText *struct {
+		Text string `xml:",chardata"`
+	} `xml:"pausedText"`
 	ShowFooter struct {
 		Text string `xml:",chardata"`
 	} `xml:"showFooter"`
 	ShowHeader struct {
 		Text string `xml:",chardata"`
 	} `xml:"showHeader"`
-	Connector struct {
-		TargetReference ElementName `xml:"targetReference"`
-	} `xml:"connector"`
-	NextOrFinishButtonLabel struct {
-		Text string `xml:",chardata"`
-	} `xml:"nextOrFinishButtonLabel"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	HelpText struct {
-		Text string `xml:",chardata"`
-	} `xml:"helpText"`
-	PausedText struct {
-		Text string `xml:",chardata"`
-	} `xml:"pausedText"`
 }
 
 type Variable struct {
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
-	Name         string `xml:"name"`
-	DataType     string `xml:"dataType"`
-	IsCollection struct {
-		Text string `xml:",chardata"`
-	} `xml:"isCollection"`
-	IsInput    BooleanText `xml:"isInput"`
-	IsOutput   BooleanText `xml:"isOutput"`
-	ObjectType struct {
+	Name         string      `xml:"name"`
+	DataType     string      `xml:"dataType"`
+	IsCollection BooleanText `xml:"isCollection"`
+	IsInput      BooleanText `xml:"isInput"`
+	IsOutput     BooleanText `xml:"isOutput"`
+	ObjectType   *struct {
 		Text string `xml:",chardata"`
 	} `xml:"objectType"`
-	Scale struct {
+	Scale *struct {
 		Text string `xml:",chardata"`
 	} `xml:"scale"`
-	Value struct {
-		StringValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"stringValue"`
-		ElementReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"elementReference"`
-		BooleanValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"booleanValue"`
-	} `xml:"value"`
+	Value *Value `xml:"value"`
 }
 
 type Assignment struct {
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	Name  ElementName `xml:"name"`
 	Label struct {
 		Text string `xml:",chardata"`
@@ -393,364 +536,24 @@ type Assignment struct {
 	AssignmentItems []struct {
 		AssignToReference string `xml:"assignToReference"`
 		Operator          string `xml:"operator"`
-		Value             Value  `xml:"value"`
+		Value             *Value `xml:"value"`
 	} `xml:"assignmentItems"`
-	Connector struct {
-		TargetReference ElementName `xml:"targetReference"`
-		IsGoTo          struct {
+	Connector *struct {
+		IsGoTo *struct {
 			Text string `xml:",chardata"`
 		} `xml:"isGoTo"`
+		TargetReference ElementName `xml:"targetReference"`
 	} `xml:"connector"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 type Flow struct {
 	internal.MetadataInfo
-	XMLName    xml.Name `xml:"Flow"`
-	Xmlns      string   `xml:"xmlns,attr"`
-	Xsi        string   `xml:"xsi,attr"`
-	ApiVersion struct {
-		Text string `xml:",chardata"`
-	} `xml:"apiVersion"`
-	Environments struct {
-		Text string `xml:",chardata"`
-	} `xml:"environments"`
-	Formulas []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		DataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"dataType"`
-		Expression struct {
-			Text string `xml:",chardata"`
-		} `xml:"expression"`
-		Description struct {
-			Text string `xml:",chardata"`
-		} `xml:"description"`
-	} `xml:"formulas"`
-	InterviewLabel struct {
-		Text string `xml:",chardata"`
-	} `xml:"interviewLabel"`
-	Label struct {
-		Text string `xml:",chardata"`
-	} `xml:"label"`
-	ProcessMetadataValues []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Value struct {
-			StringValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"stringValue"`
-			BooleanValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"booleanValue"`
-		} `xml:"value"`
-	} `xml:"processMetadataValues"`
-	ProcessType struct {
-		Text string `xml:",chardata"`
-	} `xml:"processType"`
-	Start  Start `xml:"start"`
-	Status struct {
-		Text string `xml:",chardata"`
-	} `xml:"status"`
-	Subflows []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		FlowName struct {
-			Text string `xml:",chardata"`
-		} `xml:"flowName"`
-		InputAssignments []struct {
-			Name struct {
-				Text string `xml:",chardata"`
-			} `xml:"name"`
-			Value struct {
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-			} `xml:"value"`
-		} `xml:"inputAssignments"`
-		Connector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"connector"`
-		OutputAssignments []struct {
-			AssignToReference struct {
-				Text string `xml:",chardata"`
-			} `xml:"assignToReference"`
-			Name struct {
-				Text string `xml:",chardata"`
-			} `xml:"name"`
-		} `xml:"outputAssignments"`
-	} `xml:"subflows"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Loops struct {
-		Description struct {
-			Text string `xml:",chardata"`
-		} `xml:"description"`
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		CollectionReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"collectionReference"`
-		IterationOrder struct {
-			Text string `xml:",chardata"`
-		} `xml:"iterationOrder"`
-		NextValueConnector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"nextValueConnector"`
-		NoMoreValuesConnector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"noMoreValuesConnector"`
-	} `xml:"loops"`
-	RecordUpdates []struct {
-		Description struct {
-			Text string `xml:",chardata"`
-		} `xml:"description"`
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		Connector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"connector"`
-		FilterLogic struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterLogic"`
-		Filters []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Operator struct {
-				Text string `xml:",chardata"`
-			} `xml:"operator"`
-			Value struct {
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-				StringValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"stringValue"`
-				BooleanValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"booleanValue"`
-			} `xml:"value"`
-		} `xml:"filters"`
-		InputAssignments []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Value struct {
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-				BooleanValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"booleanValue"`
-				StringValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"stringValue"`
-			} `xml:"value"`
-		} `xml:"inputAssignments"`
-		Object struct {
-			Text string `xml:",chardata"`
-		} `xml:"object"`
-		InputReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"inputReference"`
-		FaultConnector struct {
-			IsGoTo struct {
-				Text string `xml:",chardata"`
-			} `xml:"isGoTo"`
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"faultConnector"`
-	} `xml:"recordUpdates"`
-	Variables     []Variable     `xml:"variables"`
-	Decisions     []Decision     `xml:"decisions"`
-	Screens       []Screen       `xml:"screens"`
-	RecordLookups []RecordLookup `xml:"recordLookups"`
-	Assignments   []Assignment   `xml:"assignments"`
-	Constants     struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		DataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"dataType"`
-		Value struct {
-			StringValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"stringValue"`
-		} `xml:"value"`
-	} `xml:"constants"`
-	DynamicChoiceSets []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		DataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"dataType"`
-		DisplayField struct {
-			Text string `xml:",chardata"`
-			Nil  string `xml:"nil,attr"`
-		} `xml:"displayField"`
-		Object struct {
-			Text string `xml:",chardata"`
-			Nil  string `xml:"nil,attr"`
-		} `xml:"object"`
-		PicklistField struct {
-			Text string `xml:",chardata"`
-		} `xml:"picklistField"`
-		PicklistObject struct {
-			Text string `xml:",chardata"`
-		} `xml:"picklistObject"`
-		FilterLogic struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterLogic"`
-		Filters []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Operator struct {
-				Text string `xml:",chardata"`
-			} `xml:"operator"`
-			Value struct {
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-				StringValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"stringValue"`
-			} `xml:"value"`
-		} `xml:"filters"`
-		SortField struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortField"`
-		SortOrder struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortOrder"`
-		ValueField struct {
-			Text string `xml:",chardata"`
-		} `xml:"valueField"`
-		OutputAssignments struct {
-			AssignToReference struct {
-				Text string `xml:",chardata"`
-			} `xml:"assignToReference"`
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-		} `xml:"outputAssignments"`
-		CollectionReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"collectionReference"`
-		Description struct {
-			Text string `xml:",chardata"`
-		} `xml:"description"`
-	} `xml:"dynamicChoiceSets"`
-	RecordCreates []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		Connector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"connector"`
-		FaultConnector struct {
-			IsGoTo struct {
-				Text string `xml:",chardata"`
-			} `xml:"isGoTo"`
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"faultConnector"`
-		InputReference struct {
-			Text string `xml:",chardata"`
-		} `xml:"inputReference"`
-		InputAssignments []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			Value struct {
-				BooleanValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"booleanValue"`
-				ElementReference struct {
-					Text string `xml:",chardata"`
-				} `xml:"elementReference"`
-				StringValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"stringValue"`
-			} `xml:"value"`
-		} `xml:"inputAssignments"`
-		Object struct {
-			Text string `xml:",chardata"`
-		} `xml:"object"`
-		StoreOutputAutomatically struct {
-			Text string `xml:",chardata"`
-		} `xml:"storeOutputAutomatically"`
-	} `xml:"recordCreates"`
-	RunInMode struct {
-		Text string `xml:",chardata"`
-	} `xml:"runInMode"`
-	Choices []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		ChoiceText struct {
-			Text string `xml:",chardata"`
-		} `xml:"choiceText"`
-		DataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"dataType"`
-		Value struct {
-			StringValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"stringValue"`
-			NumberValue struct {
-				Text string `xml:",chardata"`
-			} `xml:"numberValue"`
-		} `xml:"value"`
-	} `xml:"choices"`
+	XMLName     xml.Name `xml:"Flow"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Xsi         string   `xml:"xmlns:xsi,attr,omitempty"`
 	ActionCalls []struct {
-		Name struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 		Label struct {
@@ -768,10 +571,16 @@ type Flow struct {
 		ActionType struct {
 			Text string `xml:",chardata"`
 		} `xml:"actionType"`
-		Connector struct {
+		Connector *struct {
+			IsGoTo *struct {
+				Text string `xml:",chardata"`
+			} `xml:"isGoTo"`
 			TargetReference ElementName `xml:"targetReference"`
 		} `xml:"connector"`
-		FaultConnector struct {
+		FaultConnector *struct {
+			IsGoTo *struct {
+				Text string `xml:",chardata"`
+			} `xml:"isGoTo"`
 			TargetReference ElementName `xml:"targetReference"`
 		} `xml:"faultConnector"`
 		FlowTransactionModel struct {
@@ -782,21 +591,21 @@ type Flow struct {
 				Text string `xml:",chardata"`
 			} `xml:"name"`
 			Value struct {
-				ElementReference struct {
+				ElementReference *struct {
 					Text string `xml:",chardata"`
 				} `xml:"elementReference"`
-				StringValue struct {
+				StringValue *struct {
 					Text string `xml:",chardata"`
 				} `xml:"stringValue"`
-				BooleanValue struct {
+				BooleanValue *struct {
 					Text string `xml:",chardata"`
 				} `xml:"booleanValue"`
 			} `xml:"value"`
 		} `xml:"inputParameters"`
-		NameSegment struct {
+		NameSegment *struct {
 			Text string `xml:",chardata"`
 		} `xml:"nameSegment"`
-		OutputParameters struct {
+		OutputParameters []struct {
 			AssignToReference struct {
 				Text string `xml:",chardata"`
 			} `xml:"assignToReference"`
@@ -804,83 +613,30 @@ type Flow struct {
 				Text string `xml:",chardata"`
 			} `xml:"name"`
 		} `xml:"outputParameters"`
-		VersionSegment struct {
-			Text string `xml:",chardata"`
-		} `xml:"versionSegment"`
-		StoreOutputAutomatically struct {
+		StoreOutputAutomatically *struct {
 			Text string `xml:",chardata"`
 		} `xml:"storeOutputAutomatically"`
+		VersionSegment *struct {
+			Text string `xml:",chardata"`
+		} `xml:"versionSegment"`
 	} `xml:"actionCalls"`
-	RecordDeletes         []RecordDelete `xml:"recordDeletes"`
-	StartElementReference struct {
+	ApiVersion *struct {
 		Text string `xml:",chardata"`
-	} `xml:"startElementReference"`
-	TextTemplates []struct {
+	} `xml:"apiVersion"`
+	Assignments []Assignment `xml:"assignments"`
+	Choices     []struct {
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
-		IsViewedAsPlainText struct {
+		ChoiceText struct {
 			Text string `xml:",chardata"`
-		} `xml:"isViewedAsPlainText"`
-		Text struct {
+		} `xml:"choiceText"`
+		DataType struct {
 			Text string `xml:",chardata"`
-		} `xml:"text"`
-	} `xml:"textTemplates"`
-	RecordRollbacks struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		Connector struct {
-			TargetReference ElementName `xml:"targetReference"`
-		} `xml:"connector"`
-	} `xml:"recordRollbacks"`
-	Waits struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		ElementSubtype struct {
-			Text string `xml:",chardata"`
-		} `xml:"elementSubtype"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		LocationX struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationX"`
-		LocationY struct {
-			Text string `xml:",chardata"`
-		} `xml:"locationY"`
-		DefaultConnectorLabel struct {
-			Text string `xml:",chardata"`
-		} `xml:"defaultConnectorLabel"`
-		WaitEvents struct {
-			ConditionLogic struct {
-				Text string `xml:",chardata"`
-			} `xml:"conditionLogic"`
-			Connector struct {
-				TargetReference ElementName `xml:"targetReference"`
-			} `xml:"connector"`
-			Label struct {
-				Text string `xml:",chardata"`
-			} `xml:"label"`
-			Offset struct {
-				Text string `xml:",chardata"`
-			} `xml:"offset"`
-			OffsetUnit struct {
-				Text string `xml:",chardata"`
-			} `xml:"offsetUnit"`
-		} `xml:"waitEvents"`
-	} `xml:"waits"`
-	CollectionProcessors struct {
+		} `xml:"dataType"`
+		Value *Value `xml:"value"`
+	} `xml:"choices"`
+	CollectionProcessors []struct {
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
@@ -915,20 +671,281 @@ type Flow struct {
 			Operator struct {
 				Text string `xml:",chardata"`
 			} `xml:"operator"`
-			RightValue struct {
-				StringValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"stringValue"`
-			} `xml:"rightValue"`
+			RightValue *Value `xml:"rightValue"`
 		} `xml:"conditions"`
 		Connector struct {
+			IsGoTo *struct {
+				Text string `xml:",chardata"`
+			} `xml:"isGoTo"`
 			TargetReference ElementName `xml:"targetReference"`
 		} `xml:"connector"`
 	} `xml:"collectionProcessors"`
+	CustomErrors []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		LocationX struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationX"`
+		LocationY struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationY"`
+		CustomErrorMessages struct {
+			ErrorMessage struct {
+				Text string `xml:",chardata"`
+			} `xml:"errorMessage"`
+			IsFieldError struct {
+				Text string `xml:",chardata"`
+			} `xml:"isFieldError"`
+		} `xml:"customErrorMessages"`
+	} `xml:"customErrors"`
+	Constants []struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		DataType struct {
+			Text string `xml:",chardata"`
+		} `xml:"dataType"`
+		Value Value `xml:"value"`
+	} `xml:"constants"`
+	Decisions         []Decision   `xml:"decisions"`
+	Description       *TextLiteral `xml:"description"`
+	DynamicChoiceSets []struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		CollectionReference *struct {
+			Text string `xml:",chardata"`
+		} `xml:"collectionReference"`
+		DataType struct {
+			Text string `xml:",chardata"`
+		} `xml:"dataType"`
+		DisplayField struct {
+			Text string `xml:",chardata"`
+			Nil  string `xml:"xsi:nil,attr,omitempty"`
+		} `xml:"displayField"`
+		FilterLogic *string `xml:"filterLogic"`
+		Filters     []struct {
+			Field struct {
+				Text string `xml:",chardata"`
+			} `xml:"field"`
+			Operator struct {
+				Text string `xml:",chardata"`
+			} `xml:"operator"`
+			Value *Value `xml:"value"`
+		} `xml:"filters"`
+		Limit *struct {
+			Text string `xml:",chardata"`
+		} `xml:"limit"`
+		Object struct {
+			Text string `xml:",chardata"`
+			Nil  string `xml:"xsi:nil,attr,omitempty"`
+		} `xml:"object"`
+		OutputAssignments *struct {
+			AssignToReference struct {
+				Text string `xml:",chardata"`
+			} `xml:"assignToReference"`
+			Field struct {
+				Text string `xml:",chardata"`
+			} `xml:"field"`
+		} `xml:"outputAssignments"`
+		PicklistField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"picklistField"`
+		PicklistObject *struct {
+			Text string `xml:",chardata"`
+		} `xml:"picklistObject"`
+		SortField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortField"`
+		SortOrder *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortOrder"`
+		ValueField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"valueField"`
+	} `xml:"dynamicChoiceSets"`
+	Environments *struct {
+		Text string `xml:",chardata"`
+	} `xml:"environments"`
+	Formulas []struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		DataType struct {
+			Text string `xml:",chardata"`
+		} `xml:"dataType"`
+		Expression *TextLiteral `xml:"expression"`
+		Scale      *struct {
+			Text string `xml:",chardata"`
+		} `xml:"scale"`
+	} `xml:"formulas"`
+	InterviewLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"interviewLabel"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	Loops []struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		LocationX struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationX"`
+		LocationY struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationY"`
+		CollectionReference struct {
+			Text string `xml:",chardata"`
+		} `xml:"collectionReference"`
+		IterationOrder struct {
+			Text string `xml:",chardata"`
+		} `xml:"iterationOrder"`
+		NextValueConnector struct {
+			TargetReference ElementName `xml:"targetReference"`
+		} `xml:"nextValueConnector"`
+		NoMoreValuesConnector *struct {
+			TargetReference ElementName `xml:"targetReference"`
+		} `xml:"noMoreValuesConnector"`
+	} `xml:"loops"`
+	ProcessMetadataValues []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Value *Value `xml:"value"`
+	} `xml:"processMetadataValues"`
+	ProcessType struct {
+		Text string `xml:",chardata"`
+	} `xml:"processType"`
+	RecordCreates   []RecordCreate   `xml:"recordCreates"`
+	RecordDeletes   []RecordDelete   `xml:"recordDeletes"`
+	RecordLookups   []RecordLookup   `xml:"recordLookups"`
+	RecordRollbacks []RecordRollback `xml:"recordRollbacks"`
+	RecordUpdates   []RecordUpdate   `xml:"recordUpdates"`
+	RunInMode       *struct {
+		Text string `xml:",chardata"`
+	} `xml:"runInMode"`
+	Screens               []Screen `xml:"screens"`
+	Start                 *Start   `xml:"start"`
+	StartElementReference *struct {
+		Text string `xml:",chardata"`
+	} `xml:"startElementReference"`
+	Status struct {
+		Text string `xml:",chardata"`
+	} `xml:"status"`
+	Subflows []struct {
+		Description *TextLiteral `xml:"description"`
+		Name        struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		LocationX struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationX"`
+		LocationY struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationY"`
+		Connector *struct {
+			IsGoTo *struct {
+				Text string `xml:",chardata"`
+			} `xml:"isGoTo"`
+			TargetReference ElementName `xml:"targetReference"`
+		} `xml:"connector"`
+		FlowName struct {
+			Text string `xml:",chardata"`
+		} `xml:"flowName"`
+		InputAssignments []struct {
+			Name struct {
+				Text string `xml:",chardata"`
+			} `xml:"name"`
+			Value Value `xml:"value"`
+		} `xml:"inputAssignments"`
+		OutputAssignments []struct {
+			AssignToReference struct {
+				Text string `xml:",chardata"`
+			} `xml:"assignToReference"`
+			Name struct {
+				Text string `xml:",chardata"`
+			} `xml:"name"`
+		} `xml:"outputAssignments"`
+		StoreOutputAutomatically *struct {
+			Text string `xml:",chardata"`
+		} `xml:"storeOutputAutomatically"`
+	} `xml:"subflows"`
+	TextTemplates []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		IsViewedAsPlainText struct {
+			Text string `xml:",chardata"`
+		} `xml:"isViewedAsPlainText"`
+		Text TextLiteral `xml:"text"`
+	} `xml:"textTemplates"`
+	TriggerOrder *struct {
+		Text string `xml:",chardata"`
+	} `xml:"triggerOrder"`
+	Variables []Variable `xml:"variables"`
+	Waits     []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		ElementSubtype struct {
+			Text string `xml:",chardata"`
+		} `xml:"elementSubtype"`
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		LocationX struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationX"`
+		LocationY struct {
+			Text string `xml:",chardata"`
+		} `xml:"locationY"`
+		DefaultConnectorLabel struct {
+			Text string `xml:",chardata"`
+		} `xml:"defaultConnectorLabel"`
+		WaitEvents struct {
+			ConditionLogic struct {
+				Text string `xml:",chardata"`
+			} `xml:"conditionLogic"`
+			Connector struct {
+				IsGoTo *struct {
+					Text string `xml:",chardata"`
+				} `xml:"isGoTo"`
+				TargetReference ElementName `xml:"targetReference"`
+			} `xml:"connector"`
+			Label struct {
+				Text string `xml:",chardata"`
+			} `xml:"label"`
+			Offset struct {
+				Text string `xml:",chardata"`
+			} `xml:"offset"`
+			OffsetUnit struct {
+				Text string `xml:",chardata"`
+			} `xml:"offsetUnit"`
+		} `xml:"waitEvents"`
+	} `xml:"waits"`
 }
 
 func (c *Flow) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *Flow) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*Flow, error) {

--- a/flow/tidy.go
+++ b/flow/tidy.go
@@ -1,0 +1,28 @@
+package flow
+
+import (
+	"fmt"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/octoberswimmer/sformula/formatter"
+	log "github.com/sirupsen/logrus"
+)
+
+func (f Flow) Tidy() {
+	for i, formula := range f.Formulas {
+		formatted, err := formatter.FormatFlowFormula(formula.Expression.String())
+		if err != nil {
+			log.Warn(fmt.Sprintf("error formatting %s: %s", formula.Name, err.Error()))
+		} else {
+			f.Formulas[i].Expression.Text = internal.FormulaEscaper.Replace(formatted)
+		}
+	}
+	if f.Start != nil && f.Start.FilterFormula != nil {
+		formatted, err := formatter.FormatFlowFormula(f.Start.FilterFormula.String())
+		if err != nil {
+			log.Warn(fmt.Sprintf("error formatting Start filter formula: %s", err.Error()))
+		} else {
+			f.Start.FilterFormula.Text = internal.FormulaEscaper.Replace(formatted)
+		}
+	}
+}

--- a/globalvalueset/globalvalueset.go
+++ b/globalvalueset/globalvalueset.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "GlobalValueSet"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type ValueFilter func(CustomValue) bool
 
 type CustomValue struct {
@@ -38,6 +44,10 @@ func (c *GlobalValueSet) SetMetadata(m internal.MetadataInfo) {
 func Open(path string) (*GlobalValueSet, error) {
 	p := &GlobalValueSet{}
 	return p, internal.ParseMetadataXml(p, path)
+}
+
+func (c *GlobalValueSet) Type() internal.MetadataType {
+	return NAME
 }
 
 func (p *GlobalValueSet) Tidy() {

--- a/go.mod
+++ b/go.mod
@@ -19,12 +19,14 @@ require (
 
 require (
 	github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf
-	github.com/octoberswimmer/sformula v0.0.0-20241015005810-357c4b6ee93f
+	github.com/octoberswimmer/sformula v0.0.0-20241113172509-810abc6955f9
 )
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -75,10 +79,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf h1:DaAn+3RP17Q2KGe+pXDAni2lBA6dyfHlDvf+6mYgtTA=
 github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf/go.mod h1:990JnYmJZFrx1vI1TALoD6/fCqnWlTx2FrPbYy2wi5I=
-github.com/octoberswimmer/sformula v0.0.0-20241014120858-4c7f6304b0a8 h1:8z/b5jgvuSgs9V2RI3kL/IrNU1C8A/aaFogDTfgJj7U=
-github.com/octoberswimmer/sformula v0.0.0-20241014120858-4c7f6304b0a8/go.mod h1:zwekR5PTdbSvpi/Mq5SmXrs9XbQ+AyjxvNVyH4RCRD0=
-github.com/octoberswimmer/sformula v0.0.0-20241015005810-357c4b6ee93f h1:S5oMt+ypfSj5biMJY8CilqM0W4CgTAA+6zdROXnaliQ=
-github.com/octoberswimmer/sformula v0.0.0-20241015005810-357c4b6ee93f/go.mod h1:zwekR5PTdbSvpi/Mq5SmXrs9XbQ+AyjxvNVyH4RCRD0=
+github.com/octoberswimmer/sformula v0.0.0-20241113172509-810abc6955f9 h1:5/qrBXRAjOVbzvFK271LK3b/+QZDtaoHkhEDbVGI1hk=
+github.com/octoberswimmer/sformula v0.0.0-20241113172509-810abc6955f9/go.mod h1:isuBo3KPKaHf+TzZ9fNVl0MSmH2z35uLixmjfXmjp+Q=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=

--- a/internal/metadata.go
+++ b/internal/metadata.go
@@ -1,0 +1,142 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var NotXMLError = errors.New("Could not parse as XML")
+var MetadataFileNotFound = errors.New("Could not identify metadata type")
+
+type RelativePath = string
+type AbsolutePath = string
+type ForceMetadataFiles map[RelativePath][]byte
+
+// Map relative paths to filesystem paths
+type ForceMetadataFilePaths map[RelativePath]AbsolutePath
+
+type MetadataType = string
+
+// If the file in path contains metadata, return it.  Otherwise, try to find
+// the corresponding file that contains metadata.
+func metadataFileFromPath(path string) (string, error) {
+	if IsMetadataFile(path) {
+		return path, nil
+	}
+	if IsMetadataFile(path + "-meta.xml") {
+		return path + "-meta.xml", nil
+	}
+	// Static Resources in Source Format
+	resourceMetadata := strings.TrimSuffix(path, filepath.Ext(path)) + ".resource-meta.xml"
+	if IsMetadataFile(resourceMetadata) {
+		return resourceMetadata, nil
+	}
+	if m := metadataFileInSameFolder(path); m != "" && IsMetadataFile(m) {
+		return m, nil
+	}
+	return "", fmt.Errorf("%w: %s", MetadataFileNotFound, path)
+}
+
+// Look for a metadata file in the same folder as path to support bundled
+// metadata (Aura and LWC)
+func metadataFileInSameFolder(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if info.IsDir() {
+		return ""
+	}
+	dirName := filepath.Dir(path)
+	pattern := dirName + string(os.PathSeparator) + "*-meta.xml"
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return ""
+	}
+	if len(files) == 1 {
+		return files[0]
+	}
+	return ""
+}
+
+func MetadataFromPath(path string) (RegisterableMetadata, error) {
+	path, err := metadataFileFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	_, err = os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	element, err := getRootElementName(path)
+	if err != nil {
+		return nil, err
+	}
+	if open, ok := TypeRegistry[element]; ok {
+		return open(path)
+	}
+	return nil, fmt.Errorf("Could not find metadata")
+}
+
+func IsMetadataFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+	element, err := getRootElementName(path)
+	if err != nil {
+		return false
+	}
+	if _, ok := TypeRegistry[element]; ok {
+		return ok
+	}
+	return false
+}
+
+func RootElementName(xmlData []byte) (string, error) {
+	decoder := xml.NewDecoder(io.NopCloser(bytes.NewReader(xmlData)))
+
+	foundXML := false
+	for {
+		t, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("Error while parsing XML: %w", err)
+		}
+
+		switch element := t.(type) {
+		case xml.ProcInst:
+			// Check for the XML declaration and return the version if found
+			if element.Target == "xml" {
+				foundXML = true
+			}
+		case xml.StartElement:
+			if !foundXML {
+				return "", fmt.Errorf("%w: No XML declaration found", NotXMLError)
+			}
+			// Return the name of the root element
+			return element.Name.Local, nil
+		}
+	}
+	return "", fmt.Errorf("%w: No XML elements found", NotXMLError)
+}
+
+func getRootElementName(file string) (string, error) {
+	xmlData, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("Could not read XML file: %w", err)
+	}
+
+	return RootElementName(xmlData)
+}

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -1,0 +1,18 @@
+package internal
+
+var TypeRegistry metadataTypeRegistry
+
+func init() {
+	TypeRegistry = make(metadataTypeRegistry)
+}
+
+type OpenMetadataFunc func(path string) (RegisterableMetadata, error)
+
+type metadataTypeRegistry map[string]OpenMetadataFunc
+
+func (r *metadataTypeRegistry) Register(metadataType string, openFunc OpenMetadataFunc) {
+	if _, ok := (*r)[metadataType]; ok {
+		panic("Duplicate metadata registration for " + metadataType)
+	}
+	(*r)[metadataType] = openFunc
+}

--- a/internal/repo.go
+++ b/internal/repo.go
@@ -1,0 +1,48 @@
+package internal
+
+import "fmt"
+
+var Metadata *repo
+
+func init() {
+	Metadata = &repo{
+		openMetadata: make(map[MetadataType]*MetadataByName),
+	}
+}
+
+type MetadataByName map[string]RegisterableMetadata
+
+type repo struct {
+	openMetadata map[MetadataType]*MetadataByName
+}
+
+func (o *repo) Types() []MetadataType {
+	var types []string
+	for i := range o.openMetadata {
+		types = append(types, i)
+	}
+	return types
+}
+
+func (o *repo) Items(t MetadataType) MetadataByName {
+	if _, ok := o.openMetadata[t]; !ok {
+		return make(MetadataByName)
+	}
+	return *(*o).openMetadata[t]
+}
+
+func (o *repo) Open(file string) (MetadataPointer, error) {
+	m, err := MetadataFromPath(file)
+	if err != nil {
+		return m, fmt.Errorf("invalid file %s: %w", file, err)
+	}
+	metadataType := m.Type()
+	name := m.GetMetadataInfo().Name()
+	if _, ok := o.openMetadata[metadataType]; !ok {
+		items := make(MetadataByName)
+		o.openMetadata[metadataType] = &items
+	}
+	items := o.openMetadata[metadataType]
+	(*items)[name] = m
+	return m, nil
+}

--- a/objects/field/field.go
+++ b/objects/field/field.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "CustomField"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type FieldFilter func(Field) bool
 
 type CustomField struct {
@@ -35,6 +41,7 @@ type Field struct {
 	DisplayLocationInDecimal *struct {
 		Text string `xml:",chardata"`
 	} `xml:"displayLocationInDecimal"`
+	EncryptionScheme   *TextLiteral `xml:"encryptionScheme"`
 	ExternalId         *BooleanText `xml:"externalId"`
 	FieldManageability *struct {
 		Text string `xml:",chardata"`
@@ -169,6 +176,10 @@ type Field struct {
 
 func (c *CustomField) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *CustomField) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*CustomField, error) {

--- a/objects/field/tidy.go
+++ b/objects/field/tidy.go
@@ -1,0 +1,20 @@
+package field
+
+import (
+	"fmt"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/octoberswimmer/sformula/formatter"
+	log "github.com/sirupsen/logrus"
+)
+
+func (f Field) Tidy() {
+	if f.Formula != nil {
+		formatted, err := formatter.Format(f.Formula.String())
+		if err != nil {
+			log.Warn(fmt.Sprintf("error formatting %s: %s", f.FullName, err.Error()))
+		} else {
+			f.Formula.Text = internal.FormulaEscaper.Replace(formatted)
+		}
+	}
+}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -18,6 +18,12 @@ import (
 	"github.com/ForceCLI/force-md/objects/weblink"
 )
 
+const NAME = "CustomObject"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type FieldList []field.Field
 type IndexList []index.BigObjectIndex
 type ListViewList []listview.ListView
@@ -185,6 +191,10 @@ type CustomObject struct {
 
 func (c *CustomObject) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *CustomObject) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*CustomObject, error) {

--- a/objects/validationrule/tidy.go
+++ b/objects/validationrule/tidy.go
@@ -22,3 +22,12 @@ func (rules ValidationRuleList) Tidy() {
 		}
 	}
 }
+
+func (f ValidationRule) Tidy() {
+	formatted, err := formatter.Format(f.ErrorConditionFormula.String())
+	if err != nil {
+		log.Warn(fmt.Sprintf("error formatting %s: %s", f.FullName, err.Error()))
+	} else {
+		f.ErrorConditionFormula.Text = internal.FormulaEscaper.Replace(formatted)
+	}
+}

--- a/objects/validationrule/validationrule.go
+++ b/objects/validationrule/validationrule.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "ValidationRule"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type ValidationRule struct {
 	internal.MetadataInfo
 	XMLName xml.Name `xml:"ValidationRule"`
@@ -35,6 +41,10 @@ type Rule struct {
 
 func (c *ValidationRule) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *ValidationRule) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*ValidationRule, error) {

--- a/permissionset/permissionset.go
+++ b/permissionset/permissionset.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "PermissionSet"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type Description struct {
 	Text string `xml:",innerxml"`
 }
@@ -145,6 +151,10 @@ type PermissionSet struct {
 
 func (c *PermissionSet) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *PermissionSet) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*PermissionSet, error) {

--- a/pkg/package.go
+++ b/pkg/package.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "Package"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type Member string
 
 func (n Member) GetName() string {
@@ -43,6 +49,10 @@ func (c *Package) SetMetadata(m internal.MetadataInfo) {
 func Open(path string) (*Package, error) {
 	p := &Package{}
 	return p, internal.ParseMetadataXml(p, path)
+}
+
+func (c *Package) Type() internal.MetadataType {
+	return NAME
 }
 
 func (p *Package) Tidy() {

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ForceCLI/force-md/permissionset"
 )
 
+const NAME = "Profile"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type ApplicationVisibilityList []ApplicationVisibility
 
 type TabVisibilityList []TabVisibility
@@ -115,6 +121,10 @@ func NewBooleanText(val string) BooleanText {
 
 func (c *Profile) SetMetadata(m internal.MetadataInfo) {
 	c.MetadataInfo = m
+}
+
+func (c *Profile) Type() internal.MetadataType {
+	return NAME
 }
 
 func Open(path string) (*Profile, error) {

--- a/sharingrules/sharingrules.go
+++ b/sharingrules/sharingrules.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 )
 
+const NAME = "SharingRules"
+
+func init() {
+	internal.TypeRegistry.Register(NAME, func(path string) (internal.RegisterableMetadata, error) { return Open(path) })
+}
+
 type CriteriaRuleList []CriteriaRule
 
 type CriteriaRule struct {
@@ -118,6 +124,10 @@ func (c *SharingRules) SetMetadata(m internal.MetadataInfo) {
 func Open(path string) (*SharingRules, error) {
 	p := &SharingRules{}
 	return p, internal.ParseMetadataXml(p, path)
+}
+
+func (c *SharingRules) Type() internal.MetadataType {
+	return NAME
 }
 
 func (s *SharingRules) GetOwnerRules() []OwnerRule {


### PR DESCRIPTION
Add `tidy` command that supports multiple types of metadata.  It also
formats formulas in Custom Fields, Validation Rules, and Flows.
