### PR TITLE
Fix XML Parsing Regression

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -2,9 +2,10 @@ package metadata
 
 import (
 	"bytes"
-	"encoding/xml"
 	"io"
 	"os"
+
+	"github.com/nbio/xml"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/html/charset"


### PR DESCRIPTION
Restore use of github.com/nbio/xml to parse metadata, introduced in
6c8a5d3c176fbd9cb23a9ac0e458d7f85bcc5f78, which fixes parsing attributes
containing namespaces.  This fixes parsing the xsi:type attributes from
Custom Metadata value elements so types of xsd:double, for example, are
preserved.
