### PR TITLE
Add copy Command with Metadata Format Conversion

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,0 +1,367 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/objectTranslations"
+	"github.com/ForceCLI/force-md/metadata/objects"
+	"github.com/ForceCLI/force-md/registry"
+	"github.com/ForceCLI/force-md/repo"
+)
+
+var (
+	targetDir  string
+	formatType string
+)
+
+func init() {
+	copyCmd.Flags().StringVarP(&targetDir, "target", "t", "", "target directory")
+	copyCmd.Flags().StringVarP(&formatType, "format", "f", "", "target format (source or metadata)")
+	copyCmd.MarkFlagRequired("target")
+	copyCmd.MarkFlagRequired("format")
+	RootCmd.AddCommand(copyCmd)
+}
+
+var copyCmd = &cobra.Command{
+	Use:   "copy [source directory]",
+	Short: "Copy metadata between source and metadata formats",
+	Long: `Copy and convert metadata between source format (SFDX) and metadata format (MDAPI).
+
+Examples:
+  force-md copy src -t sfdx -f source      # Convert from metadata to source format
+  force-md copy sfdx -t src -f metadata    # Convert from source to metadata format`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		sourceDir := args[0]
+
+		if formatType != "source" && formatType != "metadata" {
+			log.Fatal("Format must be either 'source' or 'metadata'")
+		}
+
+		if err := copyMetadata(sourceDir, targetDir, formatType); err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func copyMetadata(sourceDir, targetDir, format string) error {
+	// Convert format string to metadata.Format
+	var targetFormat metadata.Format
+	switch format {
+	case "source":
+		targetFormat = metadata.SourceFormat
+	case "metadata":
+		targetFormat = metadata.MetadataFormat
+	default:
+		return fmt.Errorf("invalid format: %s", format)
+	}
+
+	// Create a new repo and load all metadata from source directory
+	r := repo.NewRepo()
+
+	// Walk the source directory and add all metadata to the repo
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Try to open as metadata
+		_, err = r.Open(path)
+		if err != nil {
+			// Not a metadata file, skip it
+			log.Debugf("Skipping %s: %v", path, err)
+			return nil
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to read source directory: %w", err)
+	}
+
+	// Process metadata based on target format
+	if targetFormat == metadata.MetadataFormat {
+		// For metadata format, we need to handle CustomObject merging
+		return writeMetadataFormat(r, targetDir)
+	} else {
+		// For source format, process each type individually
+		return writeSourceFormat(r, targetDir)
+	}
+}
+
+// writeSourceFormat writes all metadata in source format
+func writeSourceFormat(r *repo.Repo, targetDir string) error {
+	for _, metadataType := range r.Types() {
+		items := r.Items(metadataType)
+		for _, metadataItem := range items {
+			name := metadataItem.GetMetadataInfo().Name()
+			files, err := getMetadataFiles(metadataItem, name, metadata.SourceFormat)
+			if err != nil {
+				return fmt.Errorf("failed to get files for %s %s: %w", metadataType, name, err)
+			}
+
+			// Write each file
+			for relativePath, content := range files {
+				targetPath := filepath.Join(targetDir, relativePath)
+
+				// Create the directory if needed
+				targetFileDir := filepath.Dir(targetPath)
+				if err := os.MkdirAll(targetFileDir, 0755); err != nil {
+					return fmt.Errorf("failed to create directory %s: %w", targetFileDir, err)
+				}
+
+				// Write the file
+				if err := os.WriteFile(targetPath, content, 0644); err != nil {
+					return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+				}
+
+				log.Debugf("Wrote %s", targetPath)
+			}
+		}
+	}
+	return nil
+}
+
+// writeMetadataFormat writes all metadata in metadata format (no -meta.xml suffix, merged objects)
+func writeMetadataFormat(r *repo.Repo, targetDir string) error {
+	// First, handle CustomObjects - merge components back together
+	processedObjects := make(map[string]bool)
+
+	// First, collect all object names from child components
+	allObjectNames := make(map[string]bool)
+
+	// Check existing CustomObject items
+	objectItems := r.Items("CustomObject")
+	for _, item := range objectItems {
+		objNameStr := string(item.GetMetadataInfo().Name())
+		allObjectNames[objNameStr] = true
+	}
+
+	// Check all child component types to find objects without base metadata
+	childTypes := []string{"CustomField", "RecordType", "ValidationRule", "BigObjectIndex",
+		"FieldSet", "WebLink", "CompactLayout", "SharingReason", "BusinessProcess", "ListView"}
+
+	for _, childType := range childTypes {
+		items := r.Items(childType)
+		for _, item := range items {
+			itemNameStr := string(item.GetMetadataInfo().Name())
+			// Extract object name from component name (e.g., "Account.Field1" -> "Account")
+			if dotIndex := strings.Index(itemNameStr, "."); dotIndex > 0 {
+				objName := itemNameStr[:dotIndex]
+				allObjectNames[objName] = true
+			}
+		}
+	}
+
+	// Process all objects (including those with only child components)
+	for objBaseName := range allObjectNames {
+		if processedObjects[objBaseName] {
+			continue
+		}
+		processedObjects[objBaseName] = true
+
+		// Use the ComposeFromChildren helper to create the merged object
+		mergedObj := objects.ComposeFromChildren(objBaseName, r)
+
+		// Write merged object
+		files, err := mergedObj.Files(metadata.MetadataFormat)
+		if err != nil {
+			return fmt.Errorf("failed to get files for CustomObject %s: %w", objBaseName, err)
+		}
+
+		for relativePath, content := range files {
+			targetPath := filepath.Join(targetDir, relativePath)
+			targetFileDir := filepath.Dir(targetPath)
+			if err := os.MkdirAll(targetFileDir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", targetFileDir, err)
+			}
+			if err := os.WriteFile(targetPath, content, 0644); err != nil {
+				return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+			}
+			log.Debugf("Wrote %s", targetPath)
+		}
+	}
+
+	// Handle CustomObjectTranslation - merge field translations back together
+	processedTranslations := make(map[string]bool)
+
+	// First, collect all object translation names from both base translations and field translations
+	allObjTransNames := make(map[string]bool)
+
+	// Check existing CustomObjectTranslation items
+	objectTranslationItems := r.Items("CustomObjectTranslation")
+	for _, item := range objectTranslationItems {
+		objTransNameStr := string(item.GetMetadataInfo().Name())
+		allObjTransNames[objTransNameStr] = true
+	}
+
+	// Check all child translations to find object translations without base metadata
+	childTranslationTypes := []string{"CustomFieldTranslation", "RecordTypeTranslation", "ValidationRuleTranslation"}
+	for _, childType := range childTranslationTypes {
+		childTranslations := r.Items(childType)
+		for _, childMeta := range childTranslations {
+			childNameStr := string(childMeta.GetMetadataInfo().Name())
+			// Extract object translation name from child translation name (e.g., "Account-en_US.Field1" -> "Account-en_US")
+			if dotIndex := strings.Index(childNameStr, "."); dotIndex > 0 {
+				objTransBaseName := childNameStr[:dotIndex]
+				allObjTransNames[objTransBaseName] = true
+			}
+		}
+	}
+
+	// Process all object translations (including those with only field translations)
+	for objTransBaseName := range allObjTransNames {
+		if processedTranslations[objTransBaseName] {
+			continue
+		}
+		processedTranslations[objTransBaseName] = true
+
+		// Use the ComposeFromChildren helper to create the merged object translation
+		mergedObjTrans := objectTranslations.ComposeFromChildren(objTransBaseName, r)
+
+		// Write merged object translation using default Files() method
+		files, err := getMetadataFiles(mergedObjTrans, metadata.MetadataObjectName(objTransBaseName), metadata.MetadataFormat)
+		if err != nil {
+			return fmt.Errorf("failed to get files for CustomObjectTranslation %s: %w", objTransBaseName, err)
+		}
+
+		for relativePath, content := range files {
+			targetPath := filepath.Join(targetDir, relativePath)
+			targetFileDir := filepath.Dir(targetPath)
+			if err := os.MkdirAll(targetFileDir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", targetFileDir, err)
+			}
+			if err := os.WriteFile(targetPath, content, 0644); err != nil {
+				return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+			}
+			log.Debugf("Wrote %s", targetPath)
+		}
+	}
+
+	// Process non-object and non-child types
+	for _, metadataType := range r.Types() {
+		if metadataType != "CustomObject" && metadataType != "CustomObjectTranslation" && !repo.IsChildType(metadataType) {
+			// For non-objects and non-child types, write normally using AllItems to avoid name collisions
+			items := r.Items(metadataType)
+			for _, metadataItem := range items {
+				name := metadataItem.GetMetadataInfo().Name()
+
+				// If the metadata item implements Tidyable, tidy it before writing
+				if tidyable, ok := metadataItem.(general.Tidyable); ok {
+					tidyable.Tidy()
+				}
+
+				files, err := getMetadataFiles(metadataItem, name, metadata.MetadataFormat)
+				if err != nil {
+					return fmt.Errorf("failed to get files for %s %s: %w", metadataType, name, err)
+				}
+
+				for relativePath, content := range files {
+					targetPath := filepath.Join(targetDir, relativePath)
+					targetFileDir := filepath.Dir(targetPath)
+					if err := os.MkdirAll(targetFileDir, 0755); err != nil {
+						return fmt.Errorf("failed to create directory %s: %w", targetFileDir, err)
+					}
+					if err := os.WriteFile(targetPath, content, 0644); err != nil {
+						return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+					}
+					log.Debugf("Wrote %s", targetPath)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// getMetadataFiles returns the files for a metadata item, either from its Files() method or a default implementation
+func getMetadataFiles(m metadata.RegisterableMetadata, name metadata.MetadataObjectName, format metadata.Format) (map[string][]byte, error) {
+	// Check if this metadata implements the FilesGenerator interface
+	if generator, ok := m.(metadata.FilesGenerator); ok {
+		return generator.Files(format)
+	}
+
+	// Default implementation for types without Files() method
+	return getDefaultFiles(m, name, format)
+}
+
+// getDefaultFiles provides a default implementation for metadata types that don't implement FilesGenerator
+func getDefaultFiles(m metadata.RegisterableMetadata, name metadata.MetadataObjectName, format metadata.Format) (map[string][]byte, error) {
+	metadataType := m.Type()
+	dirName := registry.GetCanonicalDirectoryName(metadataType)
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s: %w", metadataType, err)
+	}
+
+	files := make(map[string][]byte)
+	fileName := string(name)
+
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: add -meta.xml suffix
+		if !strings.HasSuffix(fileName, "-meta.xml") {
+			// Add the appropriate extension and -meta.xml
+			ext := registry.GetMetadataSuffix(metadataType)
+			if ext != "" {
+				fileName = strings.TrimSuffix(fileName, "."+ext)
+				fileName = fileName + "." + ext + "-meta.xml"
+			} else {
+				fileName = fileName + "-meta.xml"
+			}
+		}
+		files[filepath.Join(dirName, fileName)] = xmlContent
+
+	case metadata.MetadataFormat:
+		// Metadata format: no -meta.xml suffix
+		if strings.HasSuffix(fileName, "-meta.xml") {
+			fileName = strings.TrimSuffix(fileName, "-meta.xml")
+		}
+		// Ensure proper extension for metadata format
+		ext := registry.GetMetadataSuffix(metadataType)
+		if ext != "" && !strings.HasSuffix(fileName, "."+ext) {
+			fileName = fileName + "." + ext
+		}
+		files[filepath.Join(dirName, fileName)] = xmlContent
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	return files, nil
+}
+
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
+}

--- a/cmd/copy_objecttranslation_test.go
+++ b/cmd/copy_objecttranslation_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/repo"
+)
+
+func TestCopyObjectTranslationToMetadataFormat(t *testing.T) {
+	// Create a temporary source directory with CustomObjectTranslation in source format
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create objectTranslations directory structure (only fields subdirectory needed)
+	objTransDir := filepath.Join(sourceDir, "objectTranslations", "Account-en_US")
+	os.MkdirAll(objTransDir, 0755)
+
+	// Create base object translation file with recordTypes and validationRules inline (SFDX convention)
+	baseContent := `<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <recordTypes>
+        <description/>
+        <label>Business Account</label>
+        <name>Business</name>
+    </recordTypes>
+    <validationRules>
+        <errorMessage>Amount must be positive</errorMessage>
+        <name>Amount_Must_Be_Positive</name>
+    </validationRules>
+</CustomObjectTranslation>`
+	os.WriteFile(filepath.Join(objTransDir, "Account-en_US.objectTranslation-meta.xml"), []byte(baseContent), 0644)
+
+	// Create a field translation (fields are the only ones that get decomposed)
+	fieldContent := `<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Test Field</label>
+    <name>TestField__c</name>
+</CustomFieldTranslation>`
+	os.WriteFile(filepath.Join(objTransDir, "TestField__c.fieldTranslation-meta.xml"), []byte(fieldContent), 0644)
+
+	// First, let's check what metadata files we created in source
+	t.Log("Source files created:")
+	filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			t.Logf("  %s", path)
+		}
+		return nil
+	})
+
+	// Create a repo and check what it finds
+	testRepo := repo.NewRepo()
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			_, err := testRepo.Open(path)
+			if err != nil {
+				t.Logf("Failed to open %s: %v", path, err)
+			} else {
+				t.Logf("Successfully opened %s", path)
+			}
+		}
+		return nil
+	})
+
+	// Check what's in the repo - should only have CustomObjectTranslation and CustomFieldTranslation
+	t.Logf("Repo types: %v", testRepo.Types())
+	for _, typeName := range testRepo.Types() {
+		items := testRepo.Items(typeName)
+		t.Logf("  %s: %d items", typeName, len(items))
+		for _, item := range items {
+			if reg, ok := item.(metadata.RegisterableMetadata); ok {
+				t.Logf("    - Name: %s", reg.GetMetadataInfo().Name())
+			}
+		}
+	}
+
+	// Run the copy command
+	err = copyMetadata(sourceDir, targetDir, "metadata")
+	if err != nil {
+		t.Fatalf("Failed to copy metadata: %v", err)
+	}
+
+	// Also check what files were created
+	err = filepath.Walk(targetDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			t.Logf("Created file: %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Logf("Error walking target dir: %v", err)
+	}
+
+	// Read the resulting merged file
+	mergedPath := filepath.Join(targetDir, "objectTranslations", "Account-en_US.objectTranslation")
+	data, err := os.ReadFile(mergedPath)
+	if err != nil {
+		t.Fatalf("Failed to read merged file: %v", err)
+	}
+
+	content := string(data)
+
+	// Debug: print the merged content
+	t.Logf("Merged content:\n%s", content)
+
+	// Check that the field translation is included
+	if !strings.Contains(content, "TestField__c") {
+		t.Error("Merged object translation file does not contain the field translation")
+	}
+
+	// Check that the record type translation is included
+	if !strings.Contains(content, "Business") {
+		t.Error("Merged object translation file does not contain the record type translation")
+	}
+	if !strings.Contains(content, "Business Account") {
+		t.Error("Merged object translation file does not contain the record type label")
+	}
+
+	// Check that the validation rule translation is included
+	if !strings.Contains(content, "Amount_Must_Be_Positive") {
+		t.Error("Merged object translation file does not contain the validation rule translation")
+	}
+	if !strings.Contains(content, "Amount must be positive") {
+		t.Error("Merged object translation file does not contain the validation rule error message")
+	}
+}

--- a/cmd/copy_test.go
+++ b/cmd/copy_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/ForceCLI/force-md/general"
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/metadata/objects"
+	"github.com/ForceCLI/force-md/metadata/objects/field"
+)
+
+func TestCopyToSourceFormat(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "force-md-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "src")
+	targetDir := filepath.Join(tempDir, "sfdx")
+
+	if err := os.MkdirAll(filepath.Join(sourceDir, "objects"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	testObject := objects.CustomObject{
+		Xmlns: "http://soap.sforce.com/2006/04/metadata",
+		Fields: []field.Field{
+			{
+				FullName: "TestField__c",
+				Label:    &TextLiteral{Text: "Test Field"},
+				Type:     &TextLiteral{Text: "Text"},
+				Length:   &IntegerText{Text: "255"},
+			},
+		},
+	}
+
+	// In metadata format, no -meta.xml suffix
+	objectPath := filepath.Join(sourceDir, "objects", "TestObject__c.object")
+	if err := internal.WriteToFile(testObject, objectPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyMetadata(sourceDir, targetDir, "source"); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFieldPath := filepath.Join(targetDir, "objects", "TestObject__c", "fields", "TestField__c.field-meta.xml")
+	if _, err := os.Stat(expectedFieldPath); err != nil {
+		t.Errorf("Expected field file not created: %s", expectedFieldPath)
+	}
+
+	expectedObjectPath := filepath.Join(targetDir, "objects", "TestObject__c", "TestObject__c.object-meta.xml")
+	if _, err := os.Stat(expectedObjectPath); err != nil {
+		t.Errorf("Expected object file not created: %s", expectedObjectPath)
+	}
+}
+
+func TestCopyToMetadataFormat(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "force-md-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourceDir := filepath.Join(tempDir, "sfdx")
+	targetDir := filepath.Join(tempDir, "src")
+
+	objectDir := filepath.Join(sourceDir, "objects", "TestObject__c")
+	fieldsDir := filepath.Join(objectDir, "fields")
+
+	if err := os.MkdirAll(fieldsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyObject := objects.CustomObject{
+		Xmlns: "http://soap.sforce.com/2006/04/metadata",
+	}
+	objectPath := filepath.Join(objectDir, "TestObject__c.object-meta.xml")
+	if err := internal.WriteToFile(emptyObject, objectPath); err != nil {
+		t.Fatal(err)
+	}
+
+	testField := field.CustomField{
+		Xmlns: "http://soap.sforce.com/2006/04/metadata",
+		Field: field.Field{
+			FullName: "TestField__c",
+			Label:    &TextLiteral{Text: "Test Field"},
+			Type:     &TextLiteral{Text: "Text"},
+			Length:   &IntegerText{Text: "255"},
+		},
+	}
+	fieldPath := filepath.Join(fieldsDir, "TestField__c.field-meta.xml")
+	if err := internal.WriteToFile(testField, fieldPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyMetadata(sourceDir, targetDir, "metadata"); err != nil {
+		t.Fatal(err)
+	}
+
+	// In metadata format, the file should not have -meta.xml suffix
+	expectedObjectPath := filepath.Join(targetDir, "objects", "TestObject__c.object")
+	if _, err := os.Stat(expectedObjectPath); err != nil {
+		t.Errorf("Expected merged object file not created: %s", expectedObjectPath)
+	}
+
+	data, err := os.ReadFile(expectedObjectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "TestField__c") {
+		t.Logf("Object file contents: %s", string(data))
+		t.Error("Merged object file does not contain the field")
+	}
+}
+

--- a/cmd/labels/labels.go
+++ b/cmd/labels/labels.go
@@ -39,7 +39,7 @@ func tableCustomLabels(files []string) {
 	table.SetHeader([]string{"Name", "Categories", "Language", "Protected", "Description", "Value"})
 	table.SetRowLine(true)
 	for _, r := range rows {
-		row := []string{r.FullName, r.Categories, r.Language, r.Protected, r.ShortDescription, r.Value}
+		row := []string{r.FullName, *r.Categories, r.Language, r.Protected, r.ShortDescription, r.Value}
 		table.Append(row)
 	}
 	if table.NumLines() > 0 {

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,17 @@ require (
 require (
 	github.com/nbio/xml v0.0.0-20240718025449-4db9e55cd3bf
 	github.com/octoberswimmer/sformula v0.0.0-20241120234835-d6f4f835efd9
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/internal/write_test.go
+++ b/internal/write_test.go
@@ -8,27 +8,88 @@ import (
 
 func TestSelfClosing(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    []byte
 		expected []byte
 	}{
 		{
+			name:     "simple empty tag",
 			input:    []byte(`<x></x>`),
 			expected: []byte(`<x/>`),
 		},
 		{
+			name:     "empty tag with attributes",
 			input:    []byte(`<x attr="blah"></x>`),
 			expected: []byte(`<x attr="blah"/>`),
 		},
 		{
+			name:     "non-empty tag should not change",
 			input:    []byte(`<x>contents</x>`),
 			expected: []byte(`<x>contents</x>`),
+		},
+		{
+			name:     "empty tag with whitespace",
+			input:    []byte(`<tag>  </tag>`),
+			expected: []byte(`<tag/>`),
+		},
+		{
+			name:     "empty tag with newline",
+			input:    []byte("<tag>\n</tag>"),
+			expected: []byte(`<tag/>`),
+		},
+		{
+			name:     "tag with namespace",
+			input:    []byte(`<ns:tag></ns:tag>`),
+			expected: []byte(`<ns:tag/>`),
+		},
+		{
+			name:     "tag with namespace and attributes",
+			input:    []byte(`<ns:tag attr="value"></ns:tag>`),
+			expected: []byte(`<ns:tag attr="value"/>`),
+		},
+		{
+			name:     "tag with dots in name",
+			input:    []byte(`<tag.name></tag.name>`),
+			expected: []byte(`<tag.name/>`),
+		},
+		{
+			name:     "tag with dashes in name",
+			input:    []byte(`<tag-name></tag-name>`),
+			expected: []byte(`<tag-name/>`),
+		},
+		{
+			name:     "nested empty tags",
+			input:    []byte(`<outer><inner></inner></outer>`),
+			expected: []byte(`<outer><inner/></outer>`),
+		},
+		{
+			name:     "multiple empty tags",
+			input:    []byte(`<tag1></tag1><tag2></tag2>`),
+			expected: []byte(`<tag1/><tag2/>`),
+		},
+		{
+			name:     "real Salesforce example - description",
+			input:    []byte(`<description></description>`),
+			expected: []byte(`<description/>`),
+		},
+		{
+			name:     "real Salesforce example - masterLabel",
+			input:    []byte(`<masterLabel></masterLabel>`),
+			expected: []byte(`<masterLabel/>`),
+		},
+		{
+			name:     "real Salesforce example - groupingSortProperties",
+			input:    []byte(`<groupingSortProperties></groupingSortProperties>`),
+			expected: []byte(`<groupingSortProperties/>`),
 		},
 	}
 
 	for _, test := range tests {
-		result := SelfClosing(test.input)
-		if string(result) != string(test.expected) {
-			t.Errorf("Input: %s\nExpected: %s\nGot: %s", test.input, test.expected, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			result := SelfClosing(test.input)
+			if string(result) != string(test.expected) {
+				t.Errorf("Input: %s\nExpected: %s\nGot: %s", test.input, test.expected, result)
+			}
+		})
 	}
 }

--- a/metadata/assignmentRules/assignmentRule.go
+++ b/metadata/assignmentRules/assignmentRule.go
@@ -42,7 +42,7 @@ type AssignmentRules struct {
 					Text string `xml:",chardata"`
 				} `xml:"value"`
 			} `xml:"criteriaItems"`
-			Template struct {
+			Template *struct {
 				Text string `xml:",chardata"`
 			} `xml:"template"`
 		} `xml:"ruleEntry"`

--- a/metadata/aura/aura.go
+++ b/metadata/aura/aura.go
@@ -2,9 +2,14 @@ package aura
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "AuraDefinitionBundle"
@@ -23,9 +28,13 @@ type AuraDefinitionBundle struct {
 	Description struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
-	MasterLabel struct {
+	MasterLabel *struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
+
+	// Non-XML fields to store bundle files
+	BundleFiles map[string][]byte `xml:"-"` // filename -> content
+	SourcePath  string            `xml:"-"`
 }
 
 func (c *AuraDefinitionBundle) SetMetadata(m metadata.MetadataInfo) {
@@ -36,7 +45,128 @@ func (c *AuraDefinitionBundle) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *AuraDefinitionBundle) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the bundle name from metadata
+	bundleName := c.MetadataInfo.Name()
+	if bundleName == "" {
+		return nil, fmt.Errorf("bundle name is empty")
+	}
+
+	// Load bundle files if we haven't already
+	if err := c.loadBundleFiles(); err != nil {
+		return nil, fmt.Errorf("failed to load bundle files: %w", err)
+	}
+
+	// Get the directory name for aura
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	files := make(map[string][]byte)
+
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: bundle as a directory with multiple files
+		// First, add the -meta.xml file using internal.Marshal to get proper formatting
+		xmlContent, err := internal.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal aura bundle metadata: %w", err)
+		}
+
+		// Determine the main file extension (.cmp for components, .app for apps, .evt for events)
+		mainExt := ".cmp" // default to component
+		for fileName := range c.BundleFiles {
+			if strings.HasSuffix(fileName, ".app") {
+				mainExt = ".app"
+				break
+			} else if strings.HasSuffix(fileName, ".evt") {
+				mainExt = ".evt"
+				break
+			}
+		}
+
+		// Add the -meta.xml file
+		metaPath := filepath.Join(dirName, string(bundleName), string(bundleName)+mainExt+"-meta.xml")
+		files[metaPath] = xmlContent
+
+		// Add all bundle files
+		for fileName, content := range c.BundleFiles {
+			filePath := filepath.Join(dirName, string(bundleName), fileName)
+			files[filePath] = content
+		}
+
+	case metadata.MetadataFormat:
+		// Metadata format: bundle as a directory with multiple files (same as source format but without -meta.xml suffix)
+		xmlContent, err := internal.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal aura bundle metadata: %w", err)
+		}
+
+		// Determine the main file extension (.cmp for components, .app for apps, .evt for events)
+		mainExt := ".cmp" // default to component
+		for fileName := range c.BundleFiles {
+			if strings.HasSuffix(fileName, ".app") {
+				mainExt = ".app"
+				break
+			} else if strings.HasSuffix(fileName, ".evt") {
+				mainExt = ".evt"
+				break
+			}
+		}
+
+		// Add the -meta.xml file (in metadata format, it's still component.cmp-meta.xml)
+		metaPath := filepath.Join(dirName, string(bundleName), string(bundleName)+mainExt+"-meta.xml")
+		files[metaPath] = xmlContent
+
+		// Add all bundle files
+		for fileName, content := range c.BundleFiles {
+			filePath := filepath.Join(dirName, string(bundleName), fileName)
+			files[filePath] = content
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	return files, nil
+}
+
 func Open(path string) (*AuraDefinitionBundle, error) {
-	p := &AuraDefinitionBundle{}
-	return p, metadata.ParseMetadataXml(p, path)
+	p := &AuraDefinitionBundle{
+		BundleFiles: make(map[string][]byte),
+	}
+
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find bundle files
+	p.SourcePath = path
+
+	// Note: We intentionally don't load bundle files here.
+	// The Files() method will handle loading them when needed.
+	// This keeps Open() focused on just parsing the metadata XML.
+
+	return p, nil
+}
+
+// loadBundleFiles loads all the bundle files from the source directory
+func (c *AuraDefinitionBundle) loadBundleFiles() error {
+	if c.SourcePath == "" || len(c.BundleFiles) > 0 {
+		// No source path or files already loaded
+		return nil
+	}
+
+	files, err := helpers.LoadBundleFiles(c.SourcePath, "-meta.xml")
+	if err != nil {
+		return err
+	}
+
+	// Aura stores files with just the filename, not the relative path
+	if files != nil {
+		c.BundleFiles = make(map[string][]byte)
+		for path, content := range files {
+			fileName := filepath.Base(path)
+			c.BundleFiles[fileName] = content
+		}
+	}
+	return nil
 }

--- a/metadata/classes/apex.go
+++ b/metadata/classes/apex.go
@@ -2,9 +2,12 @@ package apexClass
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ApexClass"
@@ -17,14 +20,11 @@ type ApexClass struct {
 	metadata.MetadataInfo
 	XMLName    xml.Name `xml:"ApexClass"`
 	Xmlns      string   `xml:"xmlns,attr"`
-	Fqn        string   `xml:"fqn,attr"`
+	Fqn        *string  `xml:"fqn,attr"`
 	ApiVersion struct {
 		Text string `xml:",chardata"`
 	} `xml:"apiVersion"`
-	Status struct {
-		Text string `xml:",chardata"`
-	} `xml:"status"`
-	PackageVersions struct {
+	PackageVersions []struct {
 		MajorNumber struct {
 			Text string `xml:",chardata"`
 		} `xml:"majorNumber"`
@@ -35,6 +35,13 @@ type ApexClass struct {
 			Text string `xml:",chardata"`
 		} `xml:"namespace"`
 	} `xml:"packageVersions"`
+	Status struct {
+		Text string `xml:",chardata"`
+	} `xml:"status"`
+
+	// Non-XML field to store the actual class code
+	SourceCode []byte `xml:"-"`
+	SourcePath string `xml:"-"`
 }
 
 func (c *ApexClass) SetMetadata(m metadata.MetadataInfo) {
@@ -45,7 +52,44 @@ func (c *ApexClass) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *ApexClass) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the class name from metadata
+	className := c.MetadataInfo.Name()
+	if className == "" {
+		return nil, fmt.Errorf("class name is empty")
+	}
+
+	// Get the directory name for classes
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Load source code if we haven't already
+	if c.SourceCode == nil {
+		c.SourceCode = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".cls")
+	}
+
+	// Marshal the XML metadata using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal class metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for ApexClass
+		return helpers.GenerateMetadataFilePaths(dirName, string(className), ".cls-meta.xml", ".cls", xmlContent, c.SourceCode), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func Open(path string) (*ApexClass, error) {
 	p := &ApexClass{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated code files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/classes/apex_test.go
+++ b/metadata/classes/apex_test.go
@@ -1,0 +1,151 @@
+package apexClass
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApexClassOpen(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create a test metadata file
+	metaPath := filepath.Join(tmpDir, "MyClass.cls-meta.xml")
+	metaContent := `<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>`
+
+	err := os.WriteFile(metaPath, []byte(metaContent), 0644)
+	require.NoError(t, err)
+
+	// Test Open function
+	apexClass, err := Open(metaPath)
+	require.NoError(t, err)
+	assert.NotNil(t, apexClass)
+	assert.Equal(t, metaPath, apexClass.SourcePath)
+	assert.Equal(t, "58.0", apexClass.ApiVersion.Text)
+	assert.Equal(t, "Active", apexClass.Status.Text)
+	assert.Nil(t, apexClass.SourceCode) // Should not load code in Open
+}
+
+func TestApexClassFiles(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		setupFiles  map[string]string
+		sourcePath  string
+		format      metadata.Format
+		expectFiles map[string]bool // map of file path patterns to whether they should exist
+		expectCode  bool
+	}{
+		{
+			name: "Source format with code",
+			setupFiles: map[string]string{
+				"MyClass.cls":          "public class MyClass {}",
+				"MyClass.cls-meta.xml": `<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></ApexClass>`,
+			},
+			sourcePath: filepath.Join(tmpDir, "MyClass.cls-meta.xml"),
+			format:     metadata.SourceFormat,
+			expectFiles: map[string]bool{
+				"classes/MyClass.cls-meta.xml": true,
+				"classes/MyClass.cls":          true,
+			},
+			expectCode: true,
+		},
+		{
+			name: "Source format without code",
+			setupFiles: map[string]string{
+				"MyClass.cls-meta.xml": `<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></ApexClass>`,
+			},
+			sourcePath: filepath.Join(tmpDir, "MyClass.cls-meta.xml"),
+			format:     metadata.SourceFormat,
+			expectFiles: map[string]bool{
+				"classes/MyClass.cls-meta.xml": true,
+				"classes/MyClass.cls":          false,
+			},
+			expectCode: false,
+		},
+		{
+			name: "Metadata format with code",
+			setupFiles: map[string]string{
+				"MyClass.cls":          "public class MyClass {}",
+				"MyClass.cls-meta.xml": `<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></ApexClass>`,
+			},
+			sourcePath: filepath.Join(tmpDir, "MyClass.cls-meta.xml"),
+			format:     metadata.MetadataFormat,
+			expectFiles: map[string]bool{
+				"classes/MyClass.cls-meta.xml": true,
+				"classes/MyClass.cls":          true,
+			},
+			expectCode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test files
+			for filename, content := range tt.setupFiles {
+				filePath := filepath.Join(tmpDir, filename)
+				err := os.WriteFile(filePath, []byte(content), 0644)
+				require.NoError(t, err)
+			}
+
+			// Create ApexClass instance using Open to properly set metadata
+			apexClass, err := Open(tt.sourcePath)
+			require.NoError(t, err)
+
+			// Test Files method
+			files, err := apexClass.Files(tt.format)
+			require.NoError(t, err)
+
+			// Check expected files
+			for path, shouldExist := range tt.expectFiles {
+				if shouldExist {
+					assert.Contains(t, files, path)
+				} else {
+					assert.NotContains(t, files, path)
+				}
+			}
+
+			// Check if code was loaded
+			if tt.expectCode {
+				assert.NotNil(t, apexClass.SourceCode)
+				assert.Equal(t, "public class MyClass {}", string(apexClass.SourceCode))
+			}
+
+			// Cleanup test files
+			for filename := range tt.setupFiles {
+				os.Remove(filepath.Join(tmpDir, filename))
+			}
+		})
+	}
+}
+
+func TestApexClassFilesUnsupportedFormat(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	metaPath := filepath.Join(tmpDir, "MyClass.cls-meta.xml")
+	metaContent := `<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+</ApexClass>`
+	err := os.WriteFile(metaPath, []byte(metaContent), 0644)
+	require.NoError(t, err)
+
+	apexClass, err := Open(metaPath)
+	require.NoError(t, err)
+
+	// Test with an invalid format
+	_, err = apexClass.Files(metadata.Format("invalid"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+}

--- a/metadata/components/components.go
+++ b/metadata/components/components.go
@@ -2,9 +2,12 @@ package components
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ApexComponent"
@@ -23,9 +26,13 @@ type ApexComponent struct {
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
+
+	// Non-XML fields
+	ComponentCode []byte `xml:"-"` // The actual component code
+	SourcePath    string `xml:"-"`
 }
 
 func (c *ApexComponent) SetMetadata(m metadata.MetadataInfo) {
@@ -36,7 +43,44 @@ func (c *ApexComponent) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *ApexComponent) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the component name from metadata
+	componentName := c.MetadataInfo.Name()
+	if componentName == "" {
+		return nil, fmt.Errorf("component name is empty")
+	}
+
+	// Get the directory name for components
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Load component code if we haven't already
+	if c.ComponentCode == nil {
+		c.ComponentCode = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".component")
+	}
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal component metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for ApexComponent
+		return helpers.GenerateMetadataFilePaths(dirName, string(componentName), ".component-meta.xml", ".component", xmlContent, c.ComponentCode), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func Open(path string) (*ApexComponent, error) {
 	p := &ApexComponent{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated code files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/connectedApps/connectedApps.go
+++ b/metadata/connectedApps/connectedApps.go
@@ -20,6 +20,9 @@ type ConnectedApp struct {
 	ContactEmail struct {
 		Text string `xml:",chardata"`
 	} `xml:"contactEmail"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
@@ -57,10 +60,7 @@ type ConnectedApp struct {
 			Text string `xml:",chardata"`
 		} `xml:"refreshTokenPolicy"`
 	} `xml:"oauthPolicy"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	PermissionSetName struct {
+	PermissionSetName *struct {
 		Text string `xml:",chardata"`
 	} `xml:"permissionSetName"`
 }

--- a/metadata/contentassets/contentasset.go
+++ b/metadata/contentassets/contentasset.go
@@ -2,9 +2,14 @@ package contentasset
 
 import (
 	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ContentAsset"
@@ -51,6 +56,73 @@ func (c *ContentAsset) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *ContentAsset) Type() metadata.MetadataType {
 	return NAME
+}
+
+func (c *ContentAsset) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the asset name from metadata
+	assetName := c.MetadataInfo.Name()
+	if assetName == "" {
+		return nil, fmt.Errorf("asset name is empty")
+	}
+
+	// Get the directory name for content assets
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal content asset metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	// Get the original path from metadata info to find the asset file
+	originalPath := string(c.MetadataInfo.Path())
+	metadataDir := filepath.Dir(originalPath)
+
+	// Try to find and read the asset content file
+	var assetContent []byte
+	var assetPath string
+
+	if strings.HasSuffix(originalPath, "-meta.xml") {
+		// Source format: .asset-meta.xml -> .asset
+		assetPath = filepath.Join(metadataDir, string(assetName)+".asset")
+	} else if strings.HasSuffix(originalPath, ".xml") {
+		// Metadata format: might be .asset.xml -> .asset
+		assetPath = filepath.Join(metadataDir, string(assetName)+".asset")
+	}
+
+	// Try to read the asset content file
+	if assetPath != "" {
+		if content, err := ioutil.ReadFile(assetPath); err == nil {
+			assetContent = content
+		}
+	}
+
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: .asset-meta.xml for metadata
+		files[filepath.Join(dirName, string(assetName)+".asset-meta.xml")] = xmlContent
+
+		// Add the asset content if we found it
+		if assetContent != nil {
+			files[filepath.Join(dirName, string(assetName)+".asset")] = assetContent
+		}
+
+	case metadata.MetadataFormat:
+		// Metadata format: .asset-meta.xml for metadata (same as source format)
+		files[filepath.Join(dirName, string(assetName)+".asset-meta.xml")] = xmlContent
+
+		// Add the asset content if we found it
+		if assetContent != nil {
+			files[filepath.Join(dirName, string(assetName)+".asset")] = assetContent
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	return files, nil
 }
 
 func Open(path string) (*ContentAsset, error) {

--- a/metadata/customPermissions/customPermissions.go
+++ b/metadata/customPermissions/customPermissions.go
@@ -15,17 +15,17 @@ func init() {
 
 type CustomPermission struct {
 	metadata.MetadataInfo
-	XMLName    xml.Name `xml:"CustomPermission"`
-	Xmlns      string   `xml:"xmlns,attr"`
+	XMLName     xml.Name `xml:"CustomPermission"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	IsLicensed struct {
 		Text string `xml:",chardata"`
 	} `xml:"isLicensed"`
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 func (c *CustomPermission) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/dashboard/reports.go
+++ b/metadata/dashboard/reports.go
@@ -9,7 +9,7 @@ func (d *Dashboard) GetReports() []string {
 	var reports []string
 	if d.DashboardGridLayout != nil {
 		for _, c := range d.DashboardGridLayout.DashboardGridComponents {
-			reports = append(reports, c.DashboardComponent.Report)
+			reports = append(reports, *c.DashboardComponent.Report)
 		}
 	}
 	if d.LeftSection != nil {
@@ -35,7 +35,7 @@ func (d *Dashboard) DeleteReport(report string) error {
 	if d.DashboardGridLayout != nil {
 		newComponents := d.DashboardGridLayout.DashboardGridComponents[:0]
 		for _, f := range d.DashboardGridLayout.DashboardGridComponents {
-			if strings.ToLower(f.DashboardComponent.Report) == strings.ToLower(report) {
+			if strings.ToLower(*f.DashboardComponent.Report) == strings.ToLower(report) {
 				found = true
 			} else {
 				newComponents = append(newComponents, f)

--- a/metadata/delegateGroups/delegateGroup.go
+++ b/metadata/delegateGroups/delegateGroup.go
@@ -17,7 +17,10 @@ type DelegateGroup struct {
 	metadata.MetadataInfo
 	XMLName xml.Name `xml:"DelegateGroup"`
 	Xmlns   string   `xml:"xmlns,attr"`
-	Label   struct {
+	Groups  *struct {
+		Text string `xml:",chardata"`
+	} `xml:"groups"`
+	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 	LoginAccess struct {
@@ -26,9 +29,6 @@ type DelegateGroup struct {
 	Roles []struct {
 		Text string `xml:",chardata"`
 	} `xml:"roles"`
-	Groups struct {
-		Text string `xml:",chardata"`
-	} `xml:"groups"`
 }
 
 func (c *DelegateGroup) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/documentFolder/documentFolder.go
+++ b/metadata/documentFolder/documentFolder.go
@@ -2,9 +2,12 @@ package documentFolder
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "DocumentFolder"
@@ -34,6 +37,41 @@ func (c *DocumentFolder) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *DocumentFolder) Type() metadata.MetadataType {
 	return NAME
+}
+
+func (c *DocumentFolder) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the folder name from metadata
+	folderName := c.MetadataInfo.Name()
+	if folderName == "" {
+		return nil, fmt.Errorf("folder name is empty")
+	}
+
+	// Get the directory name for document folders
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal document folder metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	var fileName string
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: Document_Templates.documentFolder-meta.xml
+		fileName = string(folderName) + ".documentFolder-meta.xml"
+	case metadata.MetadataFormat:
+		// Metadata format: Document_Templates-meta.xml (no .documentFolder part)
+		fileName = string(folderName) + "-meta.xml"
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	files[filepath.Join(dirName, fileName)] = xmlContent
+
+	return files, nil
 }
 
 func Open(path string) (*DocumentFolder, error) {

--- a/metadata/documents/document.go
+++ b/metadata/documents/document.go
@@ -2,9 +2,15 @@ package document
 
 import (
 	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "Document"
@@ -15,23 +21,23 @@ func init() {
 
 type Document struct {
 	metadata.MetadataInfo
-	XMLName         xml.Name `xml:"Document"`
-	Xmlns           string   `xml:"xmlns,attr"`
-	InternalUseOnly struct {
+	XMLName         xml.Name     `xml:"Document"`
+	Xmlns           string       `xml:"xmlns,attr"`
+	Description     *TextLiteral `xml:"description"`
+	InternalUseOnly *struct {
 		Text string `xml:",chardata"`
-	} `xml:"metadata"`
+	} `xml:"internalUseOnly"`
+	Keywords *struct {
+		Text string `xml:",chardata"`
+	} `xml:"keywords"`
 	Name struct {
 		Text string `xml:",chardata"`
 	} `xml:"name"`
 	Public struct {
 		Text string `xml:",chardata"`
 	} `xml:"public"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Keywords struct {
-		Text string `xml:",chardata"`
-	} `xml:"keywords"`
+	DocumentContent []byte `xml:"-"`
+	DocumentExt     string `xml:"-"`
 }
 
 func (c *Document) SetMetadata(m metadata.MetadataInfo) {
@@ -42,7 +48,157 @@ func (c *Document) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *Document) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the original path from metadata info
+	originalPath := string(c.MetadataInfo.Path())
+
+	// Get the directory name for documents
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Extract the folder structure from the original path
+	var relativePath string
+	if strings.Contains(originalPath, "documents/") {
+		// Extract everything after "documents/"
+		parts := strings.Split(originalPath, "documents/")
+		if len(parts) > 1 {
+			relativePath = parts[1]
+		}
+	}
+
+	if relativePath == "" {
+		return nil, fmt.Errorf("could not extract document path from %s", originalPath)
+	}
+
+	// Get the directory part (e.g., "Images/")
+	documentDir := filepath.Dir(relativePath)
+
+	// Determine the base name and file extension based on the current path
+	fileName := filepath.Base(relativePath)
+	var baseName, actualFileExt string
+
+	if strings.HasSuffix(fileName, ".document-meta.xml") {
+		// Coming from source format: AEG_Transparent_Logo.document-meta.xml
+		baseName = strings.TrimSuffix(fileName, ".document-meta.xml")
+	} else if strings.HasSuffix(fileName, "-meta.xml") {
+		// Coming from metadata format: AEG_Transparent_Logo.gif-meta.xml
+		nameWithoutMeta := strings.TrimSuffix(fileName, "-meta.xml")
+		actualFileExt = filepath.Ext(nameWithoutMeta)
+		baseName = strings.TrimSuffix(nameWithoutMeta, actualFileExt)
+	} else {
+		return nil, fmt.Errorf("unrecognized document metadata file format: %s", fileName)
+	}
+
+	// Use the loaded document content and extension
+	actualFileContent := c.DocumentContent
+	if c.DocumentExt != "" {
+		actualFileExt = c.DocumentExt
+	}
+
+	if actualFileExt == "" {
+		return nil, fmt.Errorf("could not determine file extension for document %s", baseName)
+	}
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal document metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	var metadataFileName, documentFileName string
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: preserve folder structure
+		// Metadata: documents/Images/AEG_Transparent_Logo.document-meta.xml
+		// File: documents/Images/AEG_Transparent_Logo.gif
+		metadataFileName = baseName + ".document-meta.xml"
+		documentFileName = baseName + actualFileExt
+
+	case metadata.MetadataFormat:
+		// Metadata format: preserve folder structure
+		// Metadata: documents/Images/AEG_Transparent_Logo.gif-meta.xml
+		// File: documents/Images/AEG_Transparent_Logo.gif
+		metadataFileName = baseName + actualFileExt + "-meta.xml"
+		documentFileName = baseName + actualFileExt
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	// Add metadata file
+	if documentDir != "." && documentDir != "" {
+		metadataFileName = filepath.Join(documentDir, metadataFileName)
+	}
+	files[filepath.Join(dirName, metadataFileName)] = xmlContent
+
+	// Add actual document file if we found it
+	if actualFileContent != nil {
+		if documentDir != "." && documentDir != "" {
+			documentFileName = filepath.Join(documentDir, documentFileName)
+		}
+		files[filepath.Join(dirName, documentFileName)] = actualFileContent
+	}
+
+	return files, nil
+}
+
 func Open(path string) (*Document, error) {
 	p := &Document{}
-	return p, metadata.ParseMetadataXml(p, path)
+
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Load the document file if it exists
+	if strings.HasSuffix(path, "-meta.xml") {
+		// This is a source format file - look for the corresponding document file
+		metadataDir := filepath.Dir(path)
+		fileName := filepath.Base(path)
+
+		var baseName, actualFileExt string
+		if strings.HasSuffix(fileName, ".document-meta.xml") {
+			baseName = strings.TrimSuffix(fileName, ".document-meta.xml")
+		} else if strings.HasSuffix(fileName, "-meta.xml") {
+			// Format: DocumentName.ext-meta.xml
+			nameWithoutMeta := strings.TrimSuffix(fileName, "-meta.xml")
+			actualFileExt = filepath.Ext(nameWithoutMeta)
+			baseName = strings.TrimSuffix(nameWithoutMeta, actualFileExt)
+		}
+
+		// First try with known extension
+		if actualFileExt != "" {
+			documentFilePath := filepath.Join(metadataDir, baseName+actualFileExt)
+			if content, err := os.ReadFile(documentFilePath); err == nil {
+				p.DocumentContent = content
+				p.DocumentExt = actualFileExt
+			}
+		} else {
+			// Scan directory for the document file
+			if entries, err := os.ReadDir(metadataDir); err == nil {
+				for _, entry := range entries {
+					if entry.IsDir() {
+						continue
+					}
+
+					entryName := entry.Name()
+					entryBase := strings.TrimSuffix(entryName, filepath.Ext(entryName))
+
+					// Check if this is the document file (not the metadata file)
+					if entryBase == baseName && !strings.HasSuffix(entryName, "-meta.xml") && !strings.HasSuffix(entryName, ".document-meta.xml") {
+						actualFileExt = filepath.Ext(entryName)
+						actualFilePath := filepath.Join(metadataDir, entryName)
+						if content, err := os.ReadFile(actualFilePath); err == nil {
+							p.DocumentContent = content
+							p.DocumentExt = actualFileExt
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	// For metadata format, we typically don't have separate document files
+
+	return p, nil
 }

--- a/metadata/emailFolder/emailFolder.go
+++ b/metadata/emailFolder/emailFolder.go
@@ -2,9 +2,12 @@ package emailFolder
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "EmailFolder"
@@ -26,7 +29,7 @@ type EmailFolder struct {
 	PublicFolderAccess struct {
 		Text string `xml:",chardata"`
 	} `xml:"publicFolderAccess"`
-	SharedTo struct {
+	SharedTo []struct {
 	} `xml:"sharedTo"`
 }
 
@@ -36,6 +39,41 @@ func (c *EmailFolder) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *EmailFolder) Type() metadata.MetadataType {
 	return NAME
+}
+
+func (c *EmailFolder) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the folder name from metadata
+	folderName := c.MetadataInfo.Name()
+	if folderName == "" {
+		return nil, fmt.Errorf("folder name is empty")
+	}
+
+	// Get the directory name for email folders
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal email folder metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	var fileName string
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: Benefit_Verification_Templates.emailFolder-meta.xml
+		fileName = string(folderName) + ".emailFolder-meta.xml"
+	case metadata.MetadataFormat:
+		// Metadata format: Benefit_Verification_Templates-meta.xml (no .emailFolder part)
+		fileName = string(folderName) + "-meta.xml"
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	files[filepath.Join(dirName, fileName)] = xmlContent
+
+	return files, nil
 }
 
 func Open(path string) (*EmailFolder, error) {

--- a/metadata/emailTemplate/emailTemplate.go
+++ b/metadata/emailTemplate/emailTemplate.go
@@ -2,9 +2,15 @@ package emailTemplate
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"strings"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "EmailTemplate"
@@ -15,12 +21,15 @@ func init() {
 
 type EmailTemplate struct {
 	metadata.MetadataInfo
-	XMLName   xml.Name `xml:"EmailTemplate"`
-	Xmlns     string   `xml:"xmlns,attr"`
+	XMLName    xml.Name `xml:"EmailTemplate"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	ApiVersion *struct {
+		Text string `xml:",chardata"`
+	} `xml:"apiVersion"`
 	Available struct {
 		Text string `xml:",chardata"`
 	} `xml:"available"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 	EncodingKey struct {
@@ -35,18 +44,15 @@ type EmailTemplate struct {
 	Subject struct {
 		Text string `xml:",chardata"`
 	} `xml:"subject"`
+	TextOnly     *TextLiteral `xml:"textOnly"`
 	TemplateType struct {
 		Text string `xml:",chardata"`
 	} `xml:"type"`
-	TextOnly struct {
-		Text string `xml:",chardata"`
-	} `xml:"textOnly"`
-	UiType struct {
+	UiType *struct {
 		Text string `xml:",chardata"`
 	} `xml:"uiType"`
-	ApiVersion struct {
-		Text string `xml:",chardata"`
-	} `xml:"apiVersion"`
+	EmailContent []byte `xml:"-"`
+	SourcePath   string `xml:"-"`
 }
 
 func (c *EmailTemplate) SetMetadata(m metadata.MetadataInfo) {
@@ -57,7 +63,144 @@ func (c *EmailTemplate) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *EmailTemplate) Files(format metadata.Format) (map[string][]byte, error) {
+	// Load email content if we haven't already
+	if c.EmailContent == nil {
+		c.EmailContent = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".email")
+	}
+
+	// Get the original path from metadata info
+	originalPath := string(c.MetadataInfo.Path())
+
+	// Get the directory name for email templates
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Extract the folder structure from the original path
+	var relativePath string
+	if strings.Contains(originalPath, "/email/") {
+		// Extract everything after "/email/"
+		parts := strings.Split(originalPath, "/email/")
+		if len(parts) > 1 {
+			relativePath = parts[1]
+		}
+	} else if strings.HasPrefix(filepath.Base(filepath.Dir(originalPath)), "email") {
+		// Handle case where path is like "test-email/email/Health_Cloud/file.email-meta.xml"
+		// Extract relative path from the email directory
+		pathParts := strings.Split(originalPath, string(filepath.Separator))
+		emailIndex := -1
+		for i, part := range pathParts {
+			if part == "email" {
+				emailIndex = i
+				break
+			}
+		}
+		if emailIndex >= 0 && emailIndex < len(pathParts)-1 {
+			relativePath = strings.Join(pathParts[emailIndex+1:], string(filepath.Separator))
+		}
+	}
+
+	if relativePath == "" {
+		// Fallback: just use the filename if we can't determine the path structure
+		relativePath = filepath.Base(originalPath)
+	}
+
+	// Get the directory part (e.g., "Health_Cloud/")
+	emailDir := filepath.Dir(relativePath)
+
+	// Determine the base name based on the current path
+	fileName := filepath.Base(relativePath)
+	var baseName string
+
+	if strings.HasSuffix(fileName, ".email-meta.xml") {
+		// Coming from source format: Cancel_Admission_Notification.email-meta.xml
+		baseName = strings.TrimSuffix(fileName, ".email-meta.xml")
+	} else if strings.HasSuffix(fileName, ".email") {
+		// Coming from metadata format: Cancel_Admission_Notification.email
+		baseName = strings.TrimSuffix(fileName, ".email")
+	} else {
+		return nil, fmt.Errorf("unrecognized email template file format: %s", fileName)
+	}
+
+	// Use the loaded email content
+	emailContent := c.EmailContent
+
+	files := make(map[string][]byte)
+
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: preserve folder structure
+		// Metadata: email/Health_Cloud/Cancel_Admission_Notification.email-meta.xml
+		// Template: email/Health_Cloud/Cancel_Admission_Notification.email
+
+		// Marshal the metadata to XML using internal.Marshal to get proper formatting
+		xmlContent, err := internal.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal email template metadata: %w", err)
+		}
+
+		metadataFileName := baseName + ".email-meta.xml"
+		emailFileName := baseName + ".email"
+
+		if emailDir != "." && emailDir != "" {
+			metadataFileName = filepath.Join(emailDir, metadataFileName)
+			emailFileName = filepath.Join(emailDir, emailFileName)
+		}
+
+		files[filepath.Join(dirName, metadataFileName)] = xmlContent
+
+		// Add email template file if we found it
+		if emailContent != nil {
+			files[filepath.Join(dirName, emailFileName)] = emailContent
+		}
+
+	case metadata.MetadataFormat:
+		// Metadata format: preserve folder structure
+		// Create both files:
+		// - .email file with Visualforce content (HTML part)
+		// - .email-meta.xml file with metadata and text content
+
+		// Marshal the metadata to XML using internal.Marshal to get proper formatting
+		xmlContent, err := internal.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal email template metadata: %w", err)
+		}
+
+		metadataFileName := baseName + ".email-meta.xml"
+		emailFileName := baseName + ".email"
+
+		if emailDir != "." && emailDir != "" {
+			metadataFileName = filepath.Join(emailDir, metadataFileName)
+			emailFileName = filepath.Join(emailDir, emailFileName)
+		}
+
+		// Always create the metadata file
+		files[filepath.Join(dirName, metadataFileName)] = xmlContent
+
+		// Add email template file if we found Visualforce content
+		if emailContent != nil {
+			files[filepath.Join(dirName, emailFileName)] = emailContent
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	return files, nil
+}
+
 func Open(path string) (*EmailTemplate, error) {
 	p := &EmailTemplate{}
-	return p, metadata.ParseMetadataXml(p, path)
+
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find the email content file
+	p.SourcePath = path
+
+	// Note: We intentionally don't load the email content here.
+	// The Files() method will handle loading it when needed.
+	// This keeps Open() focused on just parsing the metadata XML.
+
+	return p, nil
 }

--- a/metadata/externalCredentials/externalCredential.go
+++ b/metadata/externalCredentials/externalCredential.go
@@ -21,18 +21,27 @@ type ExternalCredential struct {
 		Text string `xml:",chardata"`
 	} `xml:"authenticationProtocol"`
 	ExternalCredentialParameters []struct {
+		Certificate *struct {
+			Text string `xml:",chardata"`
+		} `xml:"certificate"`
+		Description *struct {
+			Text string `xml:",chardata"`
+		} `xml:"description"`
+		ParameterGroup *struct {
+			Text string `xml:",chardata"`
+		} `xml:"parameterGroup"`
 		ParameterName struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterName"`
 		ParameterType struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterType"`
-		SequenceNumber struct {
-			Text string `xml:",chardata"`
-		} `xml:"sequenceNumber"`
-		ParameterValue struct {
+		ParameterValue *struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterValue"`
+		SequenceNumber *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sequenceNumber"`
 	} `xml:"externalCredentialParameters"`
 	Label struct {
 		Text string `xml:",chardata"`

--- a/metadata/flexipages/flexipage.go
+++ b/metadata/flexipages/flexipage.go
@@ -15,22 +15,28 @@ func init() {
 
 type FlexiPage struct {
 	metadata.MetadataInfo
-	XMLName          xml.Name `xml:"FlexiPage"`
-	Xmlns            string   `xml:"xmlns,attr"`
+	XMLName     xml.Name `xml:"FlexiPage"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	FlexiPageRegions []struct {
 		ItemInstances []struct {
-			ComponentInstance struct {
+			ComponentInstance *struct {
 				ComponentInstanceProperties []struct {
 					Name struct {
 						Text string `xml:",chardata"`
 					} `xml:"name"`
-					ValueList struct {
+					Type *struct {
+						Text string `xml:",chardata"`
+					} `xml:"type"`
+					ValueList *struct {
 						ValueListItems []struct {
 							Value struct {
 								Text string `xml:",chardata"`
 							} `xml:"value"`
-							VisibilityRule struct {
-								BooleanFilter struct {
+							VisibilityRule *struct {
+								BooleanFilter *struct {
 									Text string `xml:",chardata"`
 								} `xml:"booleanFilter"`
 								Criteria []struct {
@@ -40,19 +46,16 @@ type FlexiPage struct {
 									Operator struct {
 										Text string `xml:",chardata"`
 									} `xml:"operator"`
-									RightValue struct {
+									RightValue *struct {
 										Text string `xml:",chardata"`
 									} `xml:"rightValue"`
 								} `xml:"criteria"`
 							} `xml:"visibilityRule"`
 						} `xml:"valueListItems"`
 					} `xml:"valueList"`
-					Value struct {
+					Value *struct {
 						Text string `xml:",chardata"`
 					} `xml:"value"`
-					Type struct {
-						Text string `xml:",chardata"`
-					} `xml:"type"`
 				} `xml:"componentInstanceProperties"`
 				ComponentName struct {
 					Text string `xml:",chardata"`
@@ -60,7 +63,10 @@ type FlexiPage struct {
 				Identifier struct {
 					Text string `xml:",chardata"`
 				} `xml:"identifier"`
-				VisibilityRule struct {
+				VisibilityRule *struct {
+					BooleanFilter *struct {
+						Text string `xml:",chardata"`
+					} `xml:"booleanFilter"`
 					Criteria []struct {
 						LeftValue struct {
 							Text string `xml:",chardata"`
@@ -68,17 +74,14 @@ type FlexiPage struct {
 						Operator struct {
 							Text string `xml:",chardata"`
 						} `xml:"operator"`
-						RightValue struct {
+						RightValue *struct {
 							Text string `xml:",chardata"`
 						} `xml:"rightValue"`
 					} `xml:"criteria"`
-					BooleanFilter struct {
-						Text string `xml:",chardata"`
-					} `xml:"booleanFilter"`
 				} `xml:"visibilityRule"`
 			} `xml:"componentInstance"`
-			FieldInstance struct {
-				FieldInstanceProperties struct {
+			FieldInstance *struct {
+				FieldInstanceProperties []struct {
 					Name struct {
 						Text string `xml:",chardata"`
 					} `xml:"name"`
@@ -92,7 +95,10 @@ type FlexiPage struct {
 				Identifier struct {
 					Text string `xml:",chardata"`
 				} `xml:"identifier"`
-				VisibilityRule struct {
+				VisibilityRule *struct {
+					BooleanFilter *struct {
+						Text string `xml:",chardata"`
+					} `xml:"booleanFilter"`
 					Criteria []struct {
 						LeftValue struct {
 							Text string `xml:",chardata"`
@@ -100,37 +106,37 @@ type FlexiPage struct {
 						Operator struct {
 							Text string `xml:",chardata"`
 						} `xml:"operator"`
-						RightValue struct {
+						RightValue *struct {
 							Text string `xml:",chardata"`
 						} `xml:"rightValue"`
 					} `xml:"criteria"`
-					BooleanFilter struct {
-						Text string `xml:",chardata"`
-					} `xml:"booleanFilter"`
 				} `xml:"visibilityRule"`
 			} `xml:"fieldInstance"`
 		} `xml:"itemInstances"`
+		Mode *struct {
+			Text string `xml:",chardata"`
+		} `xml:"mode"`
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 		Type struct {
 			Text string `xml:",chardata"`
 		} `xml:"type"`
-		Mode struct {
-			Text string `xml:",chardata"`
-		} `xml:"mode"`
 	} `xml:"flexiPageRegions"`
 	MasterLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
-	SobjectType struct {
+	ParentFlexiPage *struct {
+		Text string `xml:",chardata"`
+	} `xml:"parentFlexiPage"`
+	SobjectType *struct {
 		Text string `xml:",chardata"`
 	} `xml:"sobjectType"`
 	Template struct {
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
-		Properties struct {
+		Properties []struct {
 			Name struct {
 				Text string `xml:",chardata"`
 			} `xml:"name"`
@@ -142,12 +148,6 @@ type FlexiPage struct {
 	FlexiPageType struct {
 		Text string `xml:",chardata"`
 	} `xml:"type"`
-	ParentFlexiPage struct {
-		Text string `xml:",chardata"`
-	} `xml:"parentFlexiPage"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 func (c *FlexiPage) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/flow/flow.go
+++ b/metadata/flow/flow.go
@@ -404,10 +404,10 @@ type Field struct {
 			Text string `xml:",chardata"`
 		} `xml:"typeValue"`
 	} `xml:"dataTypeMappings"`
-	ExtensionName   *string `xml:"extensionName"`
-	FieldText       *string `xml:"fieldText"`
-	FieldType       string  `xml:"fieldType"`
-	Fields          []Field `xml:"fields"`
+	ExtensionName   *string      `xml:"extensionName"`
+	FieldText       *TextLiteral `xml:"fieldText"`
+	FieldType       string       `xml:"fieldType"`
+	Fields          []Field      `xml:"fields"`
 	InputParameters []struct {
 		Name struct {
 			Text string `xml:",chardata"`
@@ -420,6 +420,12 @@ type Field struct {
 	InputsOnNextNavToAssocScrn *struct {
 		Text string `xml:",chardata"`
 	} `xml:"inputsOnNextNavToAssocScrn"`
+	IsDisabled *struct {
+		ElementReference *struct {
+			Text string `xml:",chardata"`
+		} `xml:"elementReference"`
+		BooleanValue *BooleanText `xml:"booleanValue"`
+	} `xml:"isDisabled"`
 	IsRequired *struct {
 		Text string `xml:",chardata"`
 	} `xml:"isRequired"`
@@ -484,6 +490,9 @@ type Screen struct {
 	AllowPause  struct {
 		Text string `xml:",chardata"`
 	} `xml:"allowPause"`
+	BackButtonLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"backButtonLabel"`
 	Connector *struct {
 		IsGoTo *struct {
 			Text string `xml:",chardata"`

--- a/metadata/globalvalueset/globalvalueset.go
+++ b/metadata/globalvalueset/globalvalueset.go
@@ -20,8 +20,8 @@ type ValueFilter func(CustomValue) bool
 type CustomValue struct {
 	FullName string       `xml:"fullName"`
 	Default  BooleanText  `xml:"default"`
-	Label    string       `xml:"label"`
 	IsActive *BooleanText `xml:"isActive"`
+	Label    string       `xml:"label"`
 }
 
 type GlobalValueSet struct {

--- a/metadata/groups/group.go
+++ b/metadata/groups/group.go
@@ -15,8 +15,11 @@ func init() {
 
 type Group struct {
 	metadata.MetadataInfo
-	XMLName           xml.Name `xml:"Group"`
-	Xmlns             string   `xml:"xmlns,attr"`
+	XMLName     xml.Name `xml:"Group"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	DoesIncludeBosses struct {
 		Text string `xml:",chardata"`
 	} `xml:"doesIncludeBosses"`

--- a/metadata/helpers/multifile.go
+++ b/metadata/helpers/multifile.go
@@ -1,0 +1,130 @@
+package helpers
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadCompanionFile loads a companion file for metadata that has separate code files.
+// For example, ApexClass has .cls-meta.xml (metadata) and .cls (code).
+//
+// Parameters:
+//   - sourcePath: The path to the metadata file (e.g., "MyClass.cls-meta.xml")
+//   - metaSuffix: The metadata suffix to remove (e.g., "-meta.xml")
+//   - fileExt: The companion file extension (e.g., ".cls")
+//
+// Returns the file content or nil if the file doesn't exist.
+func LoadCompanionFile(sourcePath, metaSuffix, fileExt string) []byte {
+	if sourcePath == "" {
+		return nil
+	}
+
+	var companionPath string
+	if strings.HasSuffix(sourcePath, metaSuffix) {
+		// Source format: remove the meta suffix to get companion file
+		companionPath = strings.TrimSuffix(sourcePath, metaSuffix)
+	} else if strings.HasSuffix(sourcePath, ".xml") {
+		// Metadata format: could be .cls.xml or just .xml
+		base := strings.TrimSuffix(sourcePath, ".xml")
+		if strings.HasSuffix(base, fileExt) {
+			// It's already the right format (e.g., .cls.xml -> .cls)
+			companionPath = base
+		} else {
+			// Add the extension (e.g., MyClass.xml -> MyClass.cls)
+			companionPath = base + fileExt
+		}
+	}
+
+	if companionPath != "" {
+		if content, err := os.ReadFile(companionPath); err == nil {
+			return content
+		}
+		// File doesn't exist, that's okay
+	}
+	return nil
+}
+
+// LoadBundleFiles loads all files from a bundle directory (like LWC or Aura).
+//
+// Parameters:
+//   - sourcePath: The path to the metadata file (e.g., "myComponent.js-meta.xml")
+//   - skipPatterns: Patterns to skip (e.g., "__tests__", "-meta.xml")
+//
+// Returns a map of relative path to file content.
+func LoadBundleFiles(sourcePath string, skipPatterns ...string) (map[string][]byte, error) {
+	if sourcePath == "" || !strings.HasSuffix(sourcePath, "-meta.xml") {
+		return nil, nil
+	}
+
+	bundleDir := filepath.Dir(sourcePath)
+	files := make(map[string][]byte)
+
+	err := filepath.WalkDir(bundleDir, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get relative path from bundle directory
+		relPath, err := filepath.Rel(bundleDir, filePath)
+		if err != nil {
+			return err
+		}
+
+		// Check skip patterns
+		for _, pattern := range skipPatterns {
+			if strings.Contains(relPath, pattern) {
+				if d.IsDir() && pattern == "__tests__" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(filePath, pattern) {
+				return nil
+			}
+		}
+
+		// Skip directories
+		if d.IsDir() {
+			return nil
+		}
+
+		// Read the file content
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		// Store with relative path from bundle directory
+		files[relPath] = content
+		return nil
+	})
+
+	return files, err
+}
+
+// GenerateMetadataFilePaths generates the file paths for metadata and companion files.
+//
+// Parameters:
+//   - dirName: The canonical directory name (e.g., "classes")
+//   - baseName: The base file name without extension (e.g., "MyClass")
+//   - metaExt: The metadata file extension (e.g., ".cls-meta.xml")
+//   - codeExt: The code file extension (e.g., ".cls")
+//   - xmlContent: The marshalled XML content
+//   - codeContent: The code content (can be nil)
+//
+// Returns a map of file paths to content.
+func GenerateMetadataFilePaths(dirName, baseName, metaExt, codeExt string, xmlContent, codeContent []byte) map[string][]byte {
+	files := make(map[string][]byte)
+
+	// Add metadata file
+	files[filepath.Join(dirName, baseName+metaExt)] = xmlContent
+
+	// Add code file if present
+	if codeContent != nil {
+		files[filepath.Join(dirName, baseName+codeExt)] = codeContent
+	}
+
+	return files
+}

--- a/metadata/helpers/multifile_test.go
+++ b/metadata/helpers/multifile_test.go
@@ -1,0 +1,274 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCompanionFile(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		setupFiles    map[string]string
+		sourcePath    string
+		metaSuffix    string
+		fileExt       string
+		expectNil     bool
+		expectContent string
+	}{
+		{
+			name: "Source format - load companion file",
+			setupFiles: map[string]string{
+				"MyClass.cls":          "public class MyClass {}",
+				"MyClass.cls-meta.xml": "<ApexClass/>",
+			},
+			sourcePath:    filepath.Join(tmpDir, "MyClass.cls-meta.xml"),
+			metaSuffix:    "-meta.xml",
+			fileExt:       ".cls",
+			expectContent: "public class MyClass {}",
+		},
+		{
+			name: "Metadata format - .cls.xml to .cls",
+			setupFiles: map[string]string{
+				"MyClass.cls":     "public class MyClass {}",
+				"MyClass.cls.xml": "<ApexClass/>",
+			},
+			sourcePath:    filepath.Join(tmpDir, "MyClass.cls.xml"),
+			metaSuffix:    "-meta.xml",
+			fileExt:       ".cls",
+			expectContent: "public class MyClass {}",
+		},
+		{
+			name: "Metadata format - plain .xml to .cls",
+			setupFiles: map[string]string{
+				"MyClass.cls": "public class MyClass {}",
+				"MyClass.xml": "<ApexClass/>",
+			},
+			sourcePath:    filepath.Join(tmpDir, "MyClass.xml"),
+			metaSuffix:    "-meta.xml",
+			fileExt:       ".cls",
+			expectContent: "public class MyClass {}",
+		},
+		{
+			name: "Companion file doesn't exist",
+			setupFiles: map[string]string{
+				"MyClass.cls-meta.xml": "<ApexClass/>",
+			},
+			sourcePath: filepath.Join(tmpDir, "MyClass.cls-meta.xml"),
+			metaSuffix: "-meta.xml",
+			fileExt:    ".cls",
+			expectNil:  true,
+		},
+		{
+			name:       "Empty source path",
+			sourcePath: "",
+			metaSuffix: "-meta.xml",
+			fileExt:    ".cls",
+			expectNil:  true,
+		},
+		{
+			name: "Trigger file",
+			setupFiles: map[string]string{
+				"MyTrigger.trigger":          "trigger MyTrigger on Account {}",
+				"MyTrigger.trigger-meta.xml": "<ApexTrigger/>",
+			},
+			sourcePath:    filepath.Join(tmpDir, "MyTrigger.trigger-meta.xml"),
+			metaSuffix:    "-meta.xml",
+			fileExt:       ".trigger",
+			expectContent: "trigger MyTrigger on Account {}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test files
+			for filename, content := range tt.setupFiles {
+				filePath := filepath.Join(tmpDir, filename)
+				err := os.WriteFile(filePath, []byte(content), 0644)
+				require.NoError(t, err)
+			}
+
+			// Test LoadCompanionFile
+			result := LoadCompanionFile(tt.sourcePath, tt.metaSuffix, tt.fileExt)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expectContent, string(result))
+			}
+
+			// Cleanup test files
+			for filename := range tt.setupFiles {
+				os.Remove(filepath.Join(tmpDir, filename))
+			}
+		})
+	}
+}
+
+func TestLoadBundleFiles(t *testing.T) {
+	// Create a temporary directory structure for testing
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "myComponent")
+	require.NoError(t, os.MkdirAll(bundleDir, 0755))
+
+	// Create __tests__ directory
+	testsDir := filepath.Join(bundleDir, "__tests__")
+	require.NoError(t, os.MkdirAll(testsDir, 0755))
+
+	// Create test files
+	files := map[string]string{
+		"myComponent.js":          "export default class MyComponent extends LightningElement {}",
+		"myComponent.html":        "<template><div>Hello</div></template>",
+		"myComponent.css":         ".container { color: red; }",
+		"myComponent.js-meta.xml": "<LightningComponentBundle/>",
+		"__tests__/test.js":       "// test file",
+	}
+
+	for filename, content := range files {
+		filePath := filepath.Join(bundleDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name         string
+		sourcePath   string
+		skipPatterns []string
+		expectFiles  map[string]string
+		expectError  bool
+	}{
+		{
+			name:         "Load LWC bundle files",
+			sourcePath:   filepath.Join(bundleDir, "myComponent.js-meta.xml"),
+			skipPatterns: []string{"__tests__", "-meta.xml"},
+			expectFiles: map[string]string{
+				"myComponent.js":   "export default class MyComponent extends LightningElement {}",
+				"myComponent.html": "<template><div>Hello</div></template>",
+				"myComponent.css":  ".container { color: red; }",
+			},
+		},
+		{
+			name:         "Load all files except meta",
+			sourcePath:   filepath.Join(bundleDir, "myComponent.js-meta.xml"),
+			skipPatterns: []string{"-meta.xml"},
+			expectFiles: map[string]string{
+				"myComponent.js":    "export default class MyComponent extends LightningElement {}",
+				"myComponent.html":  "<template><div>Hello</div></template>",
+				"myComponent.css":   ".container { color: red; }",
+				"__tests__/test.js": "// test file",
+			},
+		},
+		{
+			name:         "Empty source path",
+			sourcePath:   "",
+			skipPatterns: []string{},
+			expectFiles:  nil,
+		},
+		{
+			name:         "Non-meta.xml file",
+			sourcePath:   filepath.Join(bundleDir, "myComponent.js"),
+			skipPatterns: []string{},
+			expectFiles:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := LoadBundleFiles(tt.sourcePath, tt.skipPatterns...)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				if tt.expectFiles == nil {
+					assert.Nil(t, result)
+				} else {
+					assert.Equal(t, len(tt.expectFiles), len(result))
+					for path, expectedContent := range tt.expectFiles {
+						assert.Equal(t, expectedContent, string(result[path]))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateMetadataFilePaths(t *testing.T) {
+	xmlContent := []byte("<ApexClass/>")
+	codeContent := []byte("public class MyClass {}")
+
+	tests := []struct {
+		name        string
+		dirName     string
+		baseName    string
+		metaExt     string
+		codeExt     string
+		xmlContent  []byte
+		codeContent []byte
+		expectPaths map[string]string
+	}{
+		{
+			name:        "ApexClass with code",
+			dirName:     "classes",
+			baseName:    "MyClass",
+			metaExt:     ".cls-meta.xml",
+			codeExt:     ".cls",
+			xmlContent:  xmlContent,
+			codeContent: codeContent,
+			expectPaths: map[string]string{
+				"classes/MyClass.cls-meta.xml": string(xmlContent),
+				"classes/MyClass.cls":          string(codeContent),
+			},
+		},
+		{
+			name:        "ApexClass without code",
+			dirName:     "classes",
+			baseName:    "MyClass",
+			metaExt:     ".cls-meta.xml",
+			codeExt:     ".cls",
+			xmlContent:  xmlContent,
+			codeContent: nil,
+			expectPaths: map[string]string{
+				"classes/MyClass.cls-meta.xml": string(xmlContent),
+			},
+		},
+		{
+			name:        "ApexTrigger with code",
+			dirName:     "triggers",
+			baseName:    "MyTrigger",
+			metaExt:     ".trigger-meta.xml",
+			codeExt:     ".trigger",
+			xmlContent:  xmlContent,
+			codeContent: []byte("trigger MyTrigger on Account {}"),
+			expectPaths: map[string]string{
+				"triggers/MyTrigger.trigger-meta.xml": string(xmlContent),
+				"triggers/MyTrigger.trigger":          "trigger MyTrigger on Account {}",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateMetadataFilePaths(
+				tt.dirName,
+				tt.baseName,
+				tt.metaExt,
+				tt.codeExt,
+				tt.xmlContent,
+				tt.codeContent,
+			)
+
+			assert.Equal(t, len(tt.expectPaths), len(result))
+			for path, content := range tt.expectPaths {
+				assert.Equal(t, content, string(result[path]))
+			}
+		})
+	}
+}

--- a/metadata/labels/labels.go
+++ b/metadata/labels/labels.go
@@ -2,6 +2,7 @@ package labels
 
 import (
 	"encoding/xml"
+	"sort"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
@@ -16,12 +17,12 @@ func init() {
 type CustomLabelList []CustomLabel
 
 type CustomLabel struct {
-	FullName         string `xml:"fullName"`
-	Categories       string `xml:"categories"`
-	Language         string `xml:"language"`
-	Protected        string `xml:"protected"`
-	ShortDescription string `xml:"shortDescription"`
-	Value            string `xml:"value"`
+	FullName         string  `xml:"fullName"`
+	Categories       *string `xml:"categories"`
+	Language         string  `xml:"language"`
+	Protected        string  `xml:"protected"`
+	ShortDescription string  `xml:"shortDescription"`
+	Value            string  `xml:"value"`
 }
 
 type CustomLabels struct {
@@ -37,6 +38,13 @@ func (c *CustomLabels) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *CustomLabels) Type() metadata.MetadataType {
 	return NAME
+}
+
+// Tidy sorts the labels by fullName
+func (c *CustomLabels) Tidy() {
+	sort.Slice(c.Labels, func(i, j int) bool {
+		return c.Labels[i].FullName < c.Labels[j].FullName
+	})
 }
 
 func Open(path string) (*CustomLabels, error) {

--- a/metadata/labels/labels_test.go
+++ b/metadata/labels/labels_test.go
@@ -1,0 +1,71 @@
+package labels
+
+import (
+	"testing"
+)
+
+func TestCustomLabels_Tidy(t *testing.T) {
+	labels := &CustomLabels{
+		Labels: CustomLabelList{
+			{
+				FullName:         "ZTestLabel",
+				Language:         "en_US",
+				Protected:        "false",
+				ShortDescription: "Z Test Label",
+				Value:            "Z Value",
+			},
+			{
+				FullName:         "ATestLabel",
+				Language:         "en_US",
+				Protected:        "false",
+				ShortDescription: "A Test Label",
+				Value:            "A Value",
+			},
+			{
+				FullName:         "MidTestLabel",
+				Language:         "en_US",
+				Protected:        "false",
+				ShortDescription: "Mid Test Label",
+				Value:            "Mid Value",
+			},
+		},
+	}
+
+	// Verify initial order (unsorted)
+	if labels.Labels[0].FullName != "ZTestLabel" {
+		t.Errorf("Expected first label to be ZTestLabel, got %s", labels.Labels[0].FullName)
+	}
+	if labels.Labels[1].FullName != "ATestLabel" {
+		t.Errorf("Expected second label to be ATestLabel, got %s", labels.Labels[1].FullName)
+	}
+	if labels.Labels[2].FullName != "MidTestLabel" {
+		t.Errorf("Expected third label to be MidTestLabel, got %s", labels.Labels[2].FullName)
+	}
+
+	// Tidy (sort)
+	labels.Tidy()
+
+	// Verify sorted order
+	if labels.Labels[0].FullName != "ATestLabel" {
+		t.Errorf("Expected first label after tidy to be ATestLabel, got %s", labels.Labels[0].FullName)
+	}
+	if labels.Labels[1].FullName != "MidTestLabel" {
+		t.Errorf("Expected second label after tidy to be MidTestLabel, got %s", labels.Labels[1].FullName)
+	}
+	if labels.Labels[2].FullName != "ZTestLabel" {
+		t.Errorf("Expected third label after tidy to be ZTestLabel, got %s", labels.Labels[2].FullName)
+	}
+}
+
+func TestCustomLabels_TidyEmptyLabels(t *testing.T) {
+	labels := &CustomLabels{
+		Labels: CustomLabelList{},
+	}
+
+	// Should not panic on empty labels
+	labels.Tidy()
+
+	if len(labels.Labels) != 0 {
+		t.Errorf("Expected labels to remain empty, got %d labels", len(labels.Labels))
+	}
+}

--- a/metadata/layouts/layout.go
+++ b/metadata/layouts/layout.go
@@ -15,8 +15,14 @@ func init() {
 
 type Layout struct {
 	metadata.MetadataInfo
-	XMLName        xml.Name `xml:"Layout"`
-	Xmlns          string   `xml:"xmlns,attr"`
+	XMLName       xml.Name `xml:"Layout"`
+	Xmlns         string   `xml:"xmlns,attr"`
+	CustomButtons []struct {
+		Text string `xml:",chardata"`
+	} `xml:"customButtons"`
+	EmailDefault *struct {
+		Text string `xml:",chardata"`
+	} `xml:"emailDefault"`
 	ExcludeButtons []struct {
 		Text string `xml:",chardata"`
 	} `xml:"excludeButtons"`
@@ -30,36 +36,36 @@ type Layout struct {
 		EditHeading struct {
 			Text string `xml:",chardata"`
 		} `xml:"editHeading"`
-		Label struct {
+		Label *struct {
 			Text string `xml:",chardata"`
 		} `xml:"label"`
 		LayoutColumns []struct {
 			LayoutItems []struct {
-				Behavior struct {
+				Behavior *struct {
 					Text string `xml:",chardata"`
 				} `xml:"behavior"`
-				Field struct {
+				Field *struct {
 					Text string `xml:",chardata"`
 				} `xml:"field"`
-				CustomLink struct {
+				CustomLink *struct {
 					Text string `xml:",chardata"`
 				} `xml:"customLink"`
-				EmptySpace struct {
+				EmptySpace *struct {
 					Text string `xml:",chardata"`
 				} `xml:"emptySpace"`
-				Height struct {
+				Height *struct {
 					Text string `xml:",chardata"`
 				} `xml:"height"`
-				Page struct {
+				Page *struct {
 					Text string `xml:",chardata"`
 				} `xml:"page"`
-				ShowLabel struct {
+				ShowLabel *struct {
 					Text string `xml:",chardata"`
 				} `xml:"showLabel"`
-				ShowScrollbars struct {
+				ShowScrollbars *struct {
 					Text string `xml:",chardata"`
 				} `xml:"showScrollbars"`
-				Width struct {
+				Width *struct {
 					Text string `xml:",chardata"`
 				} `xml:"width"`
 			} `xml:"layoutItems"`
@@ -68,7 +74,15 @@ type Layout struct {
 			Text string `xml:",chardata"`
 		} `xml:"style"`
 	} `xml:"layoutSections"`
-	PlatformActionList struct {
+	MultilineLayoutFields []struct {
+		Text string `xml:",chardata"`
+	} `xml:"multilineLayoutFields"`
+	MiniLayout *struct {
+		Fields []struct {
+			Text string `xml:",chardata"`
+		} `xml:"fields"`
+	} `xml:"miniLayout"`
+	PlatformActionList *struct {
 		ActionListContext struct {
 			Text string `xml:",chardata"`
 		} `xml:"actionListContext"`
@@ -84,77 +98,14 @@ type Layout struct {
 			} `xml:"sortOrder"`
 		} `xml:"platformActionListItems"`
 	} `xml:"platformActionList"`
-	RelatedLists []struct {
-		ExcludeButtons []struct {
-			Text string `xml:",chardata"`
-		} `xml:"excludeButtons"`
-		Fields []struct {
-			Text string `xml:",chardata"`
-		} `xml:"fields"`
-		RelatedList struct {
-			Text string `xml:",chardata"`
-		} `xml:"relatedList"`
-		SortField struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortField"`
-		SortOrder struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortOrder"`
-		CustomButtons struct {
-			Text string `xml:",chardata"`
-		} `xml:"customButtons"`
-	} `xml:"relatedLists"`
-	RelatedObjects []struct {
-		Text string `xml:",chardata"`
-	} `xml:"relatedObjects"`
-	ShowEmailCheckbox struct {
-		Text string `xml:",chardata"`
-	} `xml:"showEmailCheckbox"`
-	ShowHighlightsPanel struct {
-		Text string `xml:",chardata"`
-	} `xml:"showHighlightsPanel"`
-	ShowInteractionLogPanel struct {
-		Text string `xml:",chardata"`
-	} `xml:"showInteractionLogPanel"`
-	ShowRunAssignmentRulesCheckbox struct {
-		Text string `xml:",chardata"`
-	} `xml:"showRunAssignmentRulesCheckbox"`
-	ShowSubmitAndAttachButton struct {
-		Text string `xml:",chardata"`
-	} `xml:"showSubmitAndAttachButton"`
-	SummaryLayout struct {
-		MasterLabel struct {
-			Text string `xml:",chardata"`
-		} `xml:"masterLabel"`
-		SizeX struct {
-			Text string `xml:",chardata"`
-		} `xml:"sizeX"`
-		SizeY struct {
-			Text string `xml:",chardata"`
-		} `xml:"sizeY"`
-		SummaryLayoutStyle struct {
-			Text string `xml:",chardata"`
-		} `xml:"summaryLayoutStyle"`
-		SummaryLayoutItems []struct {
-			Field struct {
-				Text string `xml:",chardata"`
-			} `xml:"field"`
-			PosX struct {
-				Text string `xml:",chardata"`
-			} `xml:"posX"`
-			PosY struct {
-				Text string `xml:",chardata"`
-			} `xml:"posY"`
-		} `xml:"summaryLayoutItems"`
-	} `xml:"summaryLayout"`
-	QuickActionList struct {
+	QuickActionList *struct {
 		QuickActionListItems []struct {
 			QuickActionName struct {
 				Text string `xml:",chardata"`
 			} `xml:"quickActionName"`
 		} `xml:"quickActionListItems"`
 	} `xml:"quickActionList"`
-	RelatedContent struct {
+	RelatedContent *struct {
 		RelatedContentItems []struct {
 			LayoutItem struct {
 				Behavior struct {
@@ -166,29 +117,78 @@ type Layout struct {
 			} `xml:"layoutItem"`
 		} `xml:"relatedContentItems"`
 	} `xml:"relatedContent"`
-	CustomButtons []struct {
-		Text string `xml:",chardata"`
-	} `xml:"customButtons"`
-	EmailDefault struct {
-		Text string `xml:",chardata"`
-	} `xml:"emailDefault"`
-	RunAssignmentRulesDefault struct {
-		Text string `xml:",chardata"`
-	} `xml:"runAssignmentRulesDefault"`
-	ShowKnowledgeComponent struct {
-		Text string `xml:",chardata"`
-	} `xml:"showKnowledgeComponent"`
-	ShowSolutionSection struct {
-		Text string `xml:",chardata"`
-	} `xml:"showSolutionSection"`
-	MiniLayout struct {
+	RelatedLists []struct {
+		CustomButtons []struct {
+			Text string `xml:",chardata"`
+		} `xml:"customButtons"`
+		ExcludeButtons []struct {
+			Text string `xml:",chardata"`
+		} `xml:"excludeButtons"`
 		Fields []struct {
 			Text string `xml:",chardata"`
 		} `xml:"fields"`
-	} `xml:"miniLayout"`
-	MultilineLayoutFields []struct {
+		RelatedList struct {
+			Text string `xml:",chardata"`
+		} `xml:"relatedList"`
+		SortField *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortField"`
+		SortOrder *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortOrder"`
+	} `xml:"relatedLists"`
+	RelatedObjects []struct {
 		Text string `xml:",chardata"`
-	} `xml:"multilineLayoutFields"`
+	} `xml:"relatedObjects"`
+	RunAssignmentRulesDefault *struct {
+		Text string `xml:",chardata"`
+	} `xml:"runAssignmentRulesDefault"`
+	ShowEmailCheckbox struct {
+		Text string `xml:",chardata"`
+	} `xml:"showEmailCheckbox"`
+	ShowHighlightsPanel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showHighlightsPanel"`
+	ShowInteractionLogPanel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showInteractionLogPanel"`
+	ShowKnowledgeComponent *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showKnowledgeComponent"`
+	ShowRunAssignmentRulesCheckbox *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showRunAssignmentRulesCheckbox"`
+	ShowSolutionSection *struct {
+		Text string `xml:",chardata"`
+	} `xml:"showSolutionSection"`
+	ShowSubmitAndAttachButton struct {
+		Text string `xml:",chardata"`
+	} `xml:"showSubmitAndAttachButton"`
+	SummaryLayout *struct {
+		MasterLabel struct {
+			Text string `xml:",chardata"`
+		} `xml:"masterLabel"`
+		SizeX struct {
+			Text string `xml:",chardata"`
+		} `xml:"sizeX"`
+		SizeY struct {
+			Text string `xml:",chardata"`
+		} `xml:"sizeY"`
+		SummaryLayoutItems []struct {
+			Field struct {
+				Text string `xml:",chardata"`
+			} `xml:"field"`
+			PosX struct {
+				Text string `xml:",chardata"`
+			} `xml:"posX"`
+			PosY struct {
+				Text string `xml:",chardata"`
+			} `xml:"posY"`
+		} `xml:"summaryLayoutItems"`
+		SummaryLayoutStyle struct {
+			Text string `xml:",chardata"`
+		} `xml:"summaryLayoutStyle"`
+	} `xml:"summaryLayout"`
 }
 
 func (c *Layout) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/letterhead/letterhead.go
+++ b/metadata/letterhead/letterhead.go
@@ -34,6 +34,9 @@ type Letterhead struct {
 			Text string `xml:",chardata"`
 		} `xml:"height"`
 	} `xml:"bottomLine"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	Footer struct {
 		BackgroundColor struct {
 			Text string `xml:",chardata"`
@@ -58,7 +61,7 @@ type Letterhead struct {
 		HorizontalAlignment struct {
 			Text string `xml:",chardata"`
 		} `xml:"horizontalAlignment"`
-		Logo struct {
+		Logo *struct {
 			Text string `xml:",chardata"`
 		} `xml:"logo"`
 		VerticalAlignment struct {
@@ -84,9 +87,6 @@ type Letterhead struct {
 			Text string `xml:",chardata"`
 		} `xml:"height"`
 	} `xml:"topLine"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 func (c *Letterhead) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/lwc/lwc.go
+++ b/metadata/lwc/lwc.go
@@ -2,9 +2,15 @@ package lwc
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "LightningComponentBundle"
@@ -17,51 +23,53 @@ type LightningComponentBundle struct {
 	metadata.MetadataInfo
 	XMLName    xml.Name `xml:"LightningComponentBundle"`
 	Xmlns      string   `xml:"xmlns,attr"`
-	Fqn        string   `xml:"fqn,attr"`
+	Fqn        *string  `xml:"fqn,attr"`
 	ApiVersion struct {
 		Text string `xml:",chardata"`
 	} `xml:"apiVersion"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 	IsExposed struct {
 		Text string `xml:",chardata"`
 	} `xml:"isExposed"`
-	MasterLabel struct {
+	MasterLabel *struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
-	Targets struct {
+	RuntimeNamespace *struct {
+		Text string `xml:",chardata"`
+	} `xml:"runtimeNamespace"`
+	Targets *struct {
 		Target []struct {
 			Text string `xml:",chardata"`
 		} `xml:"target"`
 	} `xml:"targets"`
-	TargetConfigs struct {
+	TargetConfigs *struct {
 		TargetConfig []struct {
-			Targets  string `xml:"targets,attr"`
-			Xmlns    string `xml:"xmlns,attr"`
+			Xmlns    *string `xml:"xmlns,attr"`
+			Targets  string  `xml:"targets,attr"`
 			Property []struct {
-				Name        string `xml:"name,attr"`
-				Label       string `xml:"label,attr"`
-				Type        string `xml:"type,attr"`
-				Role        string `xml:"role,attr"`
-				Description string `xml:"description,attr"`
-				Datasource  string `xml:"datasource,attr"`
-				Default     string `xml:"default,attr"`
-				Required    string `xml:"required,attr"`
+				Name        string  `xml:"name,attr"`
+				Label       *string `xml:"label,attr"`
+				Type        string  `xml:"type,attr"`
+				Role        *string `xml:"role,attr"`
+				Description *string `xml:"description,attr"`
+				Datasource  *string `xml:"datasource,attr"`
+				Default     *string `xml:"default,attr"`
+				Required    *string `xml:"required,attr"`
 			} `xml:"property"`
-			SupportedFormFactors struct {
+			SupportedFormFactors *struct {
 				SupportedFormFactor []struct {
 					Type string `xml:"type,attr"`
 				} `xml:"supportedFormFactor"`
 			} `xml:"supportedFormFactors"`
-			ActionType struct {
+			ActionType *struct {
 				Text string `xml:",chardata"`
 			} `xml:"actionType"`
 		} `xml:"targetConfig"`
 	} `xml:"targetConfigs"`
-	RuntimeNamespace struct {
-		Text string `xml:",chardata"`
-	} `xml:"runtimeNamespace"`
+	BundleFiles map[string][]byte `xml:"-"`
+	SourcePath  string            `xml:"-"`
 }
 
 func (c *LightningComponentBundle) SetMetadata(m metadata.MetadataInfo) {
@@ -72,7 +80,128 @@ func (c *LightningComponentBundle) Type() metadata.MetadataType {
 	return NAME
 }
 
+// Tidy implements the general.Tidyable interface
+// It sorts targets and targetConfigs to ensure consistent output
+func (c *LightningComponentBundle) Tidy() {
+	// Sort targets if they exist
+	if c.Targets != nil && len(c.Targets.Target) > 0 {
+		sort.Slice(c.Targets.Target, func(i, j int) bool {
+			return c.Targets.Target[i].Text < c.Targets.Target[j].Text
+		})
+	}
+
+	// Sort targetConfigs if they exist
+	if c.TargetConfigs != nil && len(c.TargetConfigs.TargetConfig) > 0 {
+		sort.Slice(c.TargetConfigs.TargetConfig, func(i, j int) bool {
+			return c.TargetConfigs.TargetConfig[i].Targets < c.TargetConfigs.TargetConfig[j].Targets
+		})
+
+		// Sort properties within each targetConfig
+		for idx := range c.TargetConfigs.TargetConfig {
+			tc := &c.TargetConfigs.TargetConfig[idx]
+			if len(tc.Property) > 0 {
+				sort.Slice(tc.Property, func(i, j int) bool {
+					return tc.Property[i].Name < tc.Property[j].Name
+				})
+			}
+
+			// Sort supportedFormFactors if they exist
+			if tc.SupportedFormFactors != nil && len(tc.SupportedFormFactors.SupportedFormFactor) > 0 {
+				sort.Slice(tc.SupportedFormFactors.SupportedFormFactor, func(i, j int) bool {
+					return tc.SupportedFormFactors.SupportedFormFactor[i].Type < tc.SupportedFormFactors.SupportedFormFactor[j].Type
+				})
+			}
+		}
+	}
+}
+
+func (c *LightningComponentBundle) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the component name from metadata
+	componentName := c.MetadataInfo.Name()
+	if componentName == "" {
+		return nil, fmt.Errorf("component name is empty")
+	}
+
+	// Get the directory name for LWC components
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Load bundle files if we haven't already
+	if err := c.loadBundleFiles(); err != nil {
+		return nil, fmt.Errorf("failed to load bundle files: %w", err)
+	}
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal LWC metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	// Validate format
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same bundle structure for LWC
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	// LWC bundles should be in a directory with all component files
+	// Both source and metadata formats use the same bundle structure
+	componentDir := filepath.Join(dirName, string(componentName))
+
+	// Add the metadata file
+	metadataFileName := string(componentName) + ".js-meta.xml"
+	files[filepath.Join(componentDir, metadataFileName)] = xmlContent
+
+	// Add all bundle files (excluding __tests__ which are already filtered in Open)
+	for fileName, content := range c.BundleFiles {
+		// Skip any __tests__ files that might have been loaded
+		// (this shouldn't happen if Open() is working correctly, but being defensive)
+		if strings.Contains(fileName, "__tests__") {
+			continue
+		}
+		files[filepath.Join(componentDir, fileName)] = content
+	}
+
+	// If no other files were found (could happen during round-trip),
+	// this is okay - we at least have the metadata file
+
+	return files, nil
+}
+
 func Open(path string) (*LightningComponentBundle, error) {
-	p := &LightningComponentBundle{}
-	return p, metadata.ParseMetadataXml(p, path)
+	p := &LightningComponentBundle{
+		BundleFiles: make(map[string][]byte),
+	}
+
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find bundle files
+	p.SourcePath = path
+
+	// Note: We intentionally don't load bundle files here.
+	// The Files() method will handle loading them when needed.
+	// This keeps Open() focused on just parsing the metadata XML.
+
+	return p, nil
+}
+
+// loadBundleFiles loads all the bundle files from the source directory
+func (c *LightningComponentBundle) loadBundleFiles() error {
+	if c.SourcePath == "" || len(c.BundleFiles) > 0 {
+		// No source path or files already loaded
+		return nil
+	}
+
+	files, err := helpers.LoadBundleFiles(c.SourcePath, "__tests__", "-meta.xml")
+	if err != nil {
+		return err
+	}
+	if files != nil {
+		c.BundleFiles = files
+	}
+	return nil
 }

--- a/metadata/lwc/lwc_test.go
+++ b/metadata/lwc/lwc_test.go
@@ -1,0 +1,386 @@
+package lwc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLightningComponentBundleTidy(t *testing.T) {
+	tests := []struct {
+		name     string
+		lwc      *LightningComponentBundle
+		expected *LightningComponentBundle
+	}{
+		{
+			name: "Sort targets",
+			lwc: &LightningComponentBundle{
+				Targets: &struct {
+					Target []struct {
+						Text string `xml:",chardata"`
+					} `xml:"target"`
+				}{
+					Target: []struct {
+						Text string `xml:",chardata"`
+					}{
+						{Text: "lightning__RecordPage"},
+						{Text: "lightning__AppPage"},
+						{Text: "lightning__HomePage"},
+					},
+				},
+			},
+			expected: &LightningComponentBundle{
+				Targets: &struct {
+					Target []struct {
+						Text string `xml:",chardata"`
+					} `xml:"target"`
+				}{
+					Target: []struct {
+						Text string `xml:",chardata"`
+					}{
+						{Text: "lightning__AppPage"},
+						{Text: "lightning__HomePage"},
+						{Text: "lightning__RecordPage"},
+					},
+				},
+			},
+		},
+		{
+			name: "Sort targetConfigs and properties",
+			lwc: &LightningComponentBundle{
+				TargetConfigs: &struct {
+					TargetConfig []struct {
+						Xmlns    *string `xml:"xmlns,attr"`
+						Targets  string  `xml:"targets,attr"`
+						Property []struct {
+							Name        string  `xml:"name,attr"`
+							Label       *string `xml:"label,attr"`
+							Type        string  `xml:"type,attr"`
+							Role        *string `xml:"role,attr"`
+							Description *string `xml:"description,attr"`
+							Datasource  *string `xml:"datasource,attr"`
+							Default     *string `xml:"default,attr"`
+							Required    *string `xml:"required,attr"`
+						} `xml:"property"`
+						SupportedFormFactors *struct {
+							SupportedFormFactor []struct {
+								Type string `xml:"type,attr"`
+							} `xml:"supportedFormFactor"`
+						} `xml:"supportedFormFactors"`
+						ActionType *struct {
+							Text string `xml:",chardata"`
+						} `xml:"actionType"`
+					} `xml:"targetConfig"`
+				}{
+					TargetConfig: []struct {
+						Xmlns    *string `xml:"xmlns,attr"`
+						Targets  string  `xml:"targets,attr"`
+						Property []struct {
+							Name        string  `xml:"name,attr"`
+							Label       *string `xml:"label,attr"`
+							Type        string  `xml:"type,attr"`
+							Role        *string `xml:"role,attr"`
+							Description *string `xml:"description,attr"`
+							Datasource  *string `xml:"datasource,attr"`
+							Default     *string `xml:"default,attr"`
+							Required    *string `xml:"required,attr"`
+						} `xml:"property"`
+						SupportedFormFactors *struct {
+							SupportedFormFactor []struct {
+								Type string `xml:"type,attr"`
+							} `xml:"supportedFormFactor"`
+						} `xml:"supportedFormFactors"`
+						ActionType *struct {
+							Text string `xml:",chardata"`
+						} `xml:"actionType"`
+					}{
+						{
+							Targets: "lightning__RecordPage",
+							Property: []struct {
+								Name        string  `xml:"name,attr"`
+								Label       *string `xml:"label,attr"`
+								Type        string  `xml:"type,attr"`
+								Role        *string `xml:"role,attr"`
+								Description *string `xml:"description,attr"`
+								Datasource  *string `xml:"datasource,attr"`
+								Default     *string `xml:"default,attr"`
+								Required    *string `xml:"required,attr"`
+							}{
+								{Name: "recordId", Type: "String"},
+								{Name: "objectApiName", Type: "String"},
+							},
+						},
+						{
+							Targets: "lightning__AppPage",
+							Property: []struct {
+								Name        string  `xml:"name,attr"`
+								Label       *string `xml:"label,attr"`
+								Type        string  `xml:"type,attr"`
+								Role        *string `xml:"role,attr"`
+								Description *string `xml:"description,attr"`
+								Datasource  *string `xml:"datasource,attr"`
+								Default     *string `xml:"default,attr"`
+								Required    *string `xml:"required,attr"`
+							}{
+								{Name: "title", Type: "String"},
+							},
+						},
+					},
+				},
+			},
+			expected: &LightningComponentBundle{
+				TargetConfigs: &struct {
+					TargetConfig []struct {
+						Xmlns    *string `xml:"xmlns,attr"`
+						Targets  string  `xml:"targets,attr"`
+						Property []struct {
+							Name        string  `xml:"name,attr"`
+							Label       *string `xml:"label,attr"`
+							Type        string  `xml:"type,attr"`
+							Role        *string `xml:"role,attr"`
+							Description *string `xml:"description,attr"`
+							Datasource  *string `xml:"datasource,attr"`
+							Default     *string `xml:"default,attr"`
+							Required    *string `xml:"required,attr"`
+						} `xml:"property"`
+						SupportedFormFactors *struct {
+							SupportedFormFactor []struct {
+								Type string `xml:"type,attr"`
+							} `xml:"supportedFormFactor"`
+						} `xml:"supportedFormFactors"`
+						ActionType *struct {
+							Text string `xml:",chardata"`
+						} `xml:"actionType"`
+					} `xml:"targetConfig"`
+				}{
+					TargetConfig: []struct {
+						Xmlns    *string `xml:"xmlns,attr"`
+						Targets  string  `xml:"targets,attr"`
+						Property []struct {
+							Name        string  `xml:"name,attr"`
+							Label       *string `xml:"label,attr"`
+							Type        string  `xml:"type,attr"`
+							Role        *string `xml:"role,attr"`
+							Description *string `xml:"description,attr"`
+							Datasource  *string `xml:"datasource,attr"`
+							Default     *string `xml:"default,attr"`
+							Required    *string `xml:"required,attr"`
+						} `xml:"property"`
+						SupportedFormFactors *struct {
+							SupportedFormFactor []struct {
+								Type string `xml:"type,attr"`
+							} `xml:"supportedFormFactor"`
+						} `xml:"supportedFormFactors"`
+						ActionType *struct {
+							Text string `xml:",chardata"`
+						} `xml:"actionType"`
+					}{
+						{
+							Targets: "lightning__AppPage",
+							Property: []struct {
+								Name        string  `xml:"name,attr"`
+								Label       *string `xml:"label,attr"`
+								Type        string  `xml:"type,attr"`
+								Role        *string `xml:"role,attr"`
+								Description *string `xml:"description,attr"`
+								Datasource  *string `xml:"datasource,attr"`
+								Default     *string `xml:"default,attr"`
+								Required    *string `xml:"required,attr"`
+							}{
+								{Name: "title", Type: "String"},
+							},
+						},
+						{
+							Targets: "lightning__RecordPage",
+							Property: []struct {
+								Name        string  `xml:"name,attr"`
+								Label       *string `xml:"label,attr"`
+								Type        string  `xml:"type,attr"`
+								Role        *string `xml:"role,attr"`
+								Description *string `xml:"description,attr"`
+								Datasource  *string `xml:"datasource,attr"`
+								Default     *string `xml:"default,attr"`
+								Required    *string `xml:"required,attr"`
+							}{
+								{Name: "objectApiName", Type: "String"},
+								{Name: "recordId", Type: "String"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Handle nil fields gracefully",
+			lwc: &LightningComponentBundle{
+				Targets:       nil,
+				TargetConfigs: nil,
+			},
+			expected: &LightningComponentBundle{
+				Targets:       nil,
+				TargetConfigs: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.lwc.Tidy()
+			assert.Equal(t, tt.expected, tt.lwc)
+		})
+	}
+}
+
+func TestLightningComponentBundleOpen(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "myComponent")
+	require.NoError(t, os.MkdirAll(bundleDir, 0755))
+
+	// Create test metadata file
+	metaPath := filepath.Join(bundleDir, "myComponent.js-meta.xml")
+	metaContent := `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+</LightningComponentBundle>`
+
+	err := os.WriteFile(metaPath, []byte(metaContent), 0644)
+	require.NoError(t, err)
+
+	// Test Open function
+	lwc, err := Open(metaPath)
+	require.NoError(t, err)
+	assert.NotNil(t, lwc)
+	assert.Equal(t, metaPath, lwc.SourcePath)
+	assert.Equal(t, "58.0", lwc.ApiVersion.Text)
+	assert.Equal(t, "true", lwc.IsExposed.Text)
+	assert.Empty(t, lwc.BundleFiles) // Should not load files in Open
+}
+
+func TestLightningComponentBundleFiles(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "myComponent")
+	require.NoError(t, os.MkdirAll(bundleDir, 0755))
+
+	// Create __tests__ directory
+	testsDir := filepath.Join(bundleDir, "__tests__")
+	require.NoError(t, os.MkdirAll(testsDir, 0755))
+
+	tests := []struct {
+		name         string
+		setupFiles   map[string]string
+		format       metadata.Format
+		expectFiles  map[string]bool
+		expectBundle map[string]string // Expected bundle files after loading
+	}{
+		{
+			name: "Source format with bundle files",
+			setupFiles: map[string]string{
+				"myComponent.js":          "export default class MyComponent extends LightningElement {}",
+				"myComponent.html":        "<template><div>Hello</div></template>",
+				"myComponent.css":         ".container { color: red; }",
+				"myComponent.js-meta.xml": `<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></LightningComponentBundle>`,
+				"__tests__/test.js":       "// test file",
+			},
+			format: metadata.SourceFormat,
+			expectFiles: map[string]bool{
+				"lwc/myComponent/myComponent.js-meta.xml": true,
+				"lwc/myComponent/myComponent.js":          true,
+				"lwc/myComponent/myComponent.html":        true,
+				"lwc/myComponent/myComponent.css":         true,
+			},
+			expectBundle: map[string]string{
+				"myComponent.js":   "export default class MyComponent extends LightningElement {}",
+				"myComponent.html": "<template><div>Hello</div></template>",
+				"myComponent.css":  ".container { color: red; }",
+			},
+		},
+		{
+			name: "Metadata format with bundle files",
+			setupFiles: map[string]string{
+				"myComponent.js":          "export default class MyComponent extends LightningElement {}",
+				"myComponent.js-meta.xml": `<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></LightningComponentBundle>`,
+			},
+			format: metadata.MetadataFormat,
+			expectFiles: map[string]bool{
+				"lwc/myComponent/myComponent.js-meta.xml": true,
+				"lwc/myComponent/myComponent.js":          true,
+			},
+			expectBundle: map[string]string{
+				"myComponent.js": "export default class MyComponent extends LightningElement {}",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test files
+			for filename, content := range tt.setupFiles {
+				filePath := filepath.Join(bundleDir, filename)
+				// Create subdirectory if needed
+				dir := filepath.Dir(filePath)
+				if dir != bundleDir {
+					require.NoError(t, os.MkdirAll(dir, 0755))
+				}
+				err := os.WriteFile(filePath, []byte(content), 0644)
+				require.NoError(t, err)
+			}
+
+			// Create LightningComponentBundle instance using Open to properly set metadata
+			lwc, err := Open(filepath.Join(bundleDir, "myComponent.js-meta.xml"))
+			require.NoError(t, err)
+
+			// Test Files method
+			files, err := lwc.Files(tt.format)
+			require.NoError(t, err)
+
+			// Check expected files
+			for path, shouldExist := range tt.expectFiles {
+				if shouldExist {
+					assert.Contains(t, files, path, "Expected file %s to exist", path)
+				} else {
+					assert.NotContains(t, files, path, "Expected file %s to not exist", path)
+				}
+			}
+
+			// Check bundle files were loaded correctly (excluding __tests__)
+			assert.Equal(t, len(tt.expectBundle), len(lwc.BundleFiles))
+			for filename, content := range tt.expectBundle {
+				assert.Equal(t, content, string(lwc.BundleFiles[filename]))
+			}
+
+			// Cleanup test files
+			os.RemoveAll(bundleDir)
+			require.NoError(t, os.MkdirAll(bundleDir, 0755))
+		})
+	}
+}
+
+func TestLightningComponentBundleFilesUnsupportedFormat(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	bundleDir := filepath.Join(tmpDir, "myComponent")
+	require.NoError(t, os.MkdirAll(bundleDir, 0755))
+
+	metaPath := filepath.Join(bundleDir, "myComponent.js-meta.xml")
+	metaContent := `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+</LightningComponentBundle>`
+	err := os.WriteFile(metaPath, []byte(metaContent), 0644)
+	require.NoError(t, err)
+
+	lwc, err := Open(metaPath)
+	require.NoError(t, err)
+
+	// Test with an invalid format
+	_, err = lwc.Files(metadata.Format("invalid"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+}

--- a/metadata/matchingrules/matchingrules.go
+++ b/metadata/matchingrules/matchingrules.go
@@ -26,6 +26,9 @@ type MatchingRule struct {
 	FullName struct {
 		Text string `xml:",chardata"`
 	} `xml:"fullName"`
+	BooleanFilter *struct {
+		Text string `xml:",chardata"`
+	} `xml:"booleanFilter"`
 	Description struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
@@ -46,9 +49,6 @@ type MatchingRule struct {
 	RuleStatus struct {
 		Text string `xml:",chardata"`
 	} `xml:"ruleStatus"`
-	BooleanFilter struct {
-		Text string `xml:",chardata"`
-	} `xml:"booleanFilter"`
 }
 
 func (c *MatchingRules) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/namedCredentials/namedCredentials.go
+++ b/metadata/namedCredentials/namedCredentials.go
@@ -33,18 +33,18 @@ type NamedCredential struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
 	NamedCredentialParameters []struct {
+		ExternalCredential *struct {
+			Text string `xml:",chardata"`
+		} `xml:"externalCredential"`
 		ParameterName struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterName"`
 		ParameterType struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterType"`
-		ParameterValue struct {
+		ParameterValue *struct {
 			Text string `xml:",chardata"`
 		} `xml:"parameterValue"`
-		ExternalCredential struct {
-			Text string `xml:",chardata"`
-		} `xml:"externalCredential"`
 	} `xml:"namedCredentialParameters"`
 	NamedCredentialType struct {
 		Text string `xml:",chardata"`

--- a/metadata/objectTranslations/compose.go
+++ b/metadata/objectTranslations/compose.go
@@ -1,0 +1,81 @@
+package objectTranslations
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/ForceCLI/force-md/metadata"
+	objTransField "github.com/ForceCLI/force-md/metadata/objectTranslations/field"
+)
+
+// ChildComponentProvider provides access to child components for composition
+type ChildComponentProvider interface {
+	Items(metadataType string) []metadata.RegisterableMetadata
+}
+
+// ComposeFromChildren creates a composed CustomObjectTranslation by merging child components from a provider.
+// This is used when converting from source format (where components are separate) to metadata format.
+// The returned CustomObjectTranslation needs to have SetName called before using Files() method.
+func ComposeFromChildren(objectTranslationName string, provider ChildComponentProvider) *CustomObjectTranslation {
+	// Try to get the base object translation if it exists
+	var objTrans *CustomObjectTranslation
+	baseObjectTransExists := false
+
+	objectTranslationItems := provider.Items("CustomObjectTranslation")
+	for _, item := range objectTranslationItems {
+		if string(item.GetMetadataInfo().Name()) == objectTranslationName {
+			if customObjTrans, ok := item.(*CustomObjectTranslation); ok {
+				// Clone the object translation to avoid modifying the original
+				cloned := *customObjTrans
+				objTrans = &cloned
+				baseObjectTransExists = true
+				break
+			}
+		}
+	}
+
+	// If no base object translation exists, create a minimal one
+	if !baseObjectTransExists {
+		objTrans = &CustomObjectTranslation{
+			XMLName:         xml.Name{Local: "CustomObjectTranslation"},
+			Xmlns:           "http://soap.sforce.com/2006/04/metadata",
+			MetadataInfo:    metadata.MetadataInfo{},
+			translationName: objectTranslationName,
+		}
+	} else {
+		// Don't clear anything - we want to merge additional items from separate files
+		// with what's already in the base object translation
+		// Ensure proper namespace is set
+		objTrans.Xmlns = "http://soap.sforce.com/2006/04/metadata"
+		// Ensure the translation name is set in case MetadataInfo doesn't have it
+		if string(objTrans.MetadataInfo.Name()) == "" {
+			objTrans.translationName = objectTranslationName
+		}
+	}
+
+	// Helper function to find items with a specific prefix
+	findItemsByPrefix := func(items []metadata.RegisterableMetadata, prefix string) []metadata.RegisterableMetadata {
+		var result []metadata.RegisterableMetadata
+		for _, item := range items {
+			name := string(item.GetMetadataInfo().Name())
+			if strings.HasPrefix(name, prefix) {
+				result = append(result, item)
+			}
+		}
+		return result
+	}
+
+	prefix := objectTranslationName + "."
+
+	// Merge in field translations (only fields are decomposed, recordTypes and validationRules stay in base file)
+	for _, ftMeta := range findItemsByPrefix(provider.Items("CustomFieldTranslation"), prefix) {
+		if ft, ok := ftMeta.(*objTransField.CustomFieldTranslation); ok {
+			objTrans.Fields = append(objTrans.Fields, ft.Field)
+		}
+	}
+
+	// Tidy the composed object translation to ensure consistent ordering
+	objTrans.Tidy()
+
+	return objTrans
+}

--- a/metadata/objectTranslations/field/fieldTranslations.go
+++ b/metadata/objectTranslations/field/fieldTranslations.go
@@ -3,11 +3,16 @@ package field
 import (
 	"encoding/xml"
 
+	"path/filepath"
+	"regexp"
+
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
 )
 
 const FIELD_TRANSLATIONS_NAME = "CustomFieldTranslation"
+
+var fieldTransPathRegex = regexp.MustCompile(`.*/objectTranslations/([^/]+)/(?:fields/)?([^/]+)\.fieldTranslation-meta\.xml$`)
 
 func init() {
 	internal.TypeRegistry.Register(FIELD_TRANSLATIONS_NAME, func(path string) (metadata.RegisterableMetadata, error) { return Open(path) })
@@ -22,14 +27,15 @@ type Field struct {
 			Text string `xml:",chardata"`
 		} `xml:"value"`
 	} `xml:"caseValues"`
+	Label *struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
 	Name struct {
 		Text string `xml:",chardata"`
 	} `xml:"name"`
-	StartsWith struct {
+	StartsWith *struct {
 		Text string `xml:",chardata"`
 	} `xml:"startsWith"`
-	Label struct {
-	} `xml:"label"`
 	PicklistValues []struct {
 		MasterLabel struct {
 			Text string `xml:",chardata"`
@@ -52,6 +58,22 @@ func (c *CustomFieldTranslation) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *CustomFieldTranslation) Type() metadata.MetadataType {
 	return FIELD_TRANSLATIONS_NAME
+}
+
+func (c *CustomFieldTranslation) NameFromPath(path string) metadata.MetadataObjectName {
+	path = filepath.ToSlash(filepath.Clean(path))
+
+	matches := fieldTransPathRegex.FindStringSubmatch(path)
+
+	if len(matches) != 3 {
+		// Fallback to default implementation
+		return metadata.NameFromPath(path)
+	}
+
+	objectTransName := matches[1] // e.g., "Campaign-en_US"
+	fieldName := matches[2]       // e.g., "SomeField__c"
+
+	return metadata.MetadataObjectName(objectTransName + "." + fieldName)
 }
 
 func Open(path string) (*CustomFieldTranslation, error) {

--- a/metadata/objectTranslations/objectTranslations.go
+++ b/metadata/objectTranslations/objectTranslations.go
@@ -6,6 +6,8 @@ import (
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
 	"github.com/ForceCLI/force-md/metadata/objectTranslations/field"
+	"github.com/ForceCLI/force-md/metadata/objectTranslations/recordtype"
+	"github.com/ForceCLI/force-md/metadata/objectTranslations/validationrule"
 )
 
 const OBJECT_TRANSLATIONS_NAME = "CustomObjectTranslation"
@@ -15,29 +17,100 @@ func init() {
 }
 
 type FieldList []field.Field
+type RecordTypeList []recordtype.RecordType
+type ValidationRuleList []validationrule.ValidationRule
 
 type CustomObjectTranslation struct {
 	metadata.MetadataInfo
-	XMLName     xml.Name `xml:"CustomObjectTranslation"`
-	Xmlns       string   `xml:"xmlns,attr"`
-	RecordTypes struct {
-		Description struct {
+	XMLName    xml.Name `xml:"CustomObjectTranslation"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	CaseValues []struct {
+		Article *struct {
 			Text string `xml:",chardata"`
-		} `xml:"description"`
+		} `xml:"article"`
+		CaseType *struct {
+			Text string `xml:",chardata"`
+		} `xml:"caseType"`
+		Plural *struct {
+			Text string `xml:",chardata"`
+		} `xml:"plural"`
+		PossessivePlural *struct {
+			Text string `xml:",chardata"`
+		} `xml:"possessivePlural"`
+		Value *struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"caseValues"`
+	FieldSets []struct {
 		Label struct {
+			Text string `xml:",chardata"`
 		} `xml:"label"`
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
-	} `xml:"recordTypes"`
-	Fields          FieldList `xml:"fields"`
-	ValidationRules struct {
-		ErrorMessage struct {
-		} `xml:"errorMessage"`
+	} `xml:"fieldSets"`
+	Gender *struct {
+		Text string `xml:",chardata"`
+	} `xml:"gender"`
+	Layouts []struct {
+		Layout struct {
+			Text string `xml:",chardata"`
+		} `xml:"layout"`
+		Sections []struct {
+			Label struct {
+				Text string `xml:",chardata"`
+			} `xml:"label"`
+			Section struct {
+				Text string `xml:",chardata"`
+			} `xml:"section"`
+		} `xml:"sections"`
+	} `xml:"layouts"`
+	NameFieldLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"nameFieldLabel"`
+	QuickActions []struct {
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
-	} `xml:"validationRules"`
+	} `xml:"quickActions"`
+	SharingReasons []struct {
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+	} `xml:"sharingReasons"`
+	StartsWith *struct {
+		Text string `xml:",chardata"`
+	} `xml:"startsWith"`
+	WebLinks []struct {
+		Label struct {
+			Text string `xml:",chardata"`
+		} `xml:"label"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+	} `xml:"webLinks"`
+	WorkflowTasks []struct {
+		Description *struct {
+			Text string `xml:",chardata"`
+		} `xml:"description"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Subject *struct {
+			Text string `xml:",chardata"`
+		} `xml:"subject"`
+	} `xml:"workflowTasks"`
+	Fields          FieldList          `xml:"fields"`
+	RecordTypes     RecordTypeList     `xml:"recordTypes"`
+	ValidationRules ValidationRuleList `xml:"validationRules"`
+	// translationName is used when the object is created via composition
+	translationName string
 }
 
 func (c *CustomObjectTranslation) SetMetadata(m metadata.MetadataInfo) {
@@ -46,6 +119,77 @@ func (c *CustomObjectTranslation) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *CustomObjectTranslation) Type() metadata.MetadataType {
 	return OBJECT_TRANSLATIONS_NAME
+}
+
+func (c *CustomObjectTranslation) Files(format metadata.Format) (map[string][]byte, error) {
+	if format == metadata.SourceFormat {
+		// For source format, decompose the object translation into separate files
+		return c.decompose()
+	}
+
+	// For metadata format, use default behavior (single file)
+	files := make(map[string][]byte)
+	content, err := internal.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the stored translation name if MetadataInfo.Name() is empty
+	translationName := string(c.MetadataInfo.Name())
+	if translationName == "" && c.translationName != "" {
+		translationName = c.translationName
+	}
+	fileName := "objectTranslations/" + translationName + ".objectTranslation"
+	files[fileName] = content
+
+	return files, nil
+}
+
+func (c *CustomObjectTranslation) decompose() (map[string][]byte, error) {
+	files := make(map[string][]byte)
+	// Use the stored translation name if MetadataInfo.Name() is empty
+	translationName := string(c.MetadataInfo.Name())
+	if translationName == "" && c.translationName != "" {
+		translationName = c.translationName
+	}
+	baseDir := "objectTranslations/" + translationName
+
+	// Clone the translation and remove only field translations that will be written as separate files
+	// Keep recordTypes and validationRules in the base file per SFDX convention
+	minimalTranslation := *c
+	minimalTranslation.XMLName = xml.Name{Local: "CustomObjectTranslation"}
+	minimalTranslation.Xmlns = "http://soap.sforce.com/2006/04/metadata"
+
+	// Only clear out fields - recordTypes and validationRules remain in base file
+	minimalTranslation.Fields = nil
+
+	// Marshal the minimal translation
+	content, err := internal.Marshal(&minimalTranslation)
+	if err != nil {
+		return nil, err
+	}
+	files[baseDir+"/"+translationName+".objectTranslation-meta.xml"] = content
+
+	// Write field translations as separate files
+	for _, f := range c.Fields {
+		fieldTransMeta := &field.CustomFieldTranslation{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "CustomFieldTranslation"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			Field:        f,
+		}
+		fieldContent, err := internal.Marshal(fieldTransMeta)
+		if err != nil {
+			return nil, err
+		}
+		fieldName := f.Name.Text
+		if fieldName == "" {
+			continue
+		}
+		files[baseDir+"/"+fieldName+".fieldTranslation-meta.xml"] = fieldContent
+	}
+
+	return files, nil
 }
 
 func Open(path string) (*CustomObjectTranslation, error) {

--- a/metadata/objectTranslations/recordtype/recordtype.go
+++ b/metadata/objectTranslations/recordtype/recordtype.go
@@ -1,0 +1,81 @@
+package recordtype
+
+import (
+	"encoding/xml"
+	"path/filepath"
+	"strings"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/metadata"
+)
+
+const RECORD_TYPE_TRANSLATION_NAME = "RecordTypeTranslation"
+
+func init() {
+	internal.TypeRegistry.Register(RECORD_TYPE_TRANSLATION_NAME, func(path string) (metadata.RegisterableMetadata, error) { return Open(path) })
+}
+
+type RecordType struct {
+	Description struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+}
+
+type RecordTypeTranslation struct {
+	metadata.MetadataInfo
+	XMLName     xml.Name `xml:"RecordTypeTranslation"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	Label struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+}
+
+func (r *RecordTypeTranslation) SetMetadata(m metadata.MetadataInfo) {
+	r.MetadataInfo = m
+}
+
+func (r *RecordTypeTranslation) Type() metadata.MetadataType {
+	return RECORD_TYPE_TRANSLATION_NAME
+}
+
+func (r *RecordTypeTranslation) NameFromPath(path string) metadata.MetadataObjectName {
+	// Extract parent-child name from path
+	// e.g., /objectTranslations/Account-en_US/recordTypes/Business.recordTypeTranslation-meta.xml
+	// or /objectTranslations/Account-en_US/Business.recordTypeTranslation-meta.xml
+	// should return "Account-en_US.Business"
+	dir := filepath.Dir(path)
+	parentDir := filepath.Dir(dir)
+
+	// Check if the file is in a recordTypes subdirectory
+	if filepath.Base(dir) == "recordTypes" {
+		parentName := filepath.Base(parentDir)
+		baseName := filepath.Base(path)
+		childName := strings.TrimSuffix(baseName, ".recordTypeTranslation-meta.xml")
+		childName = strings.TrimSuffix(childName, ".recordTypeTranslation")
+		return metadata.MetadataObjectName(parentName + "." + childName)
+	} else {
+		// File is directly in the object translation directory
+		parentName := filepath.Base(dir)
+		baseName := filepath.Base(path)
+		childName := strings.TrimSuffix(baseName, ".recordTypeTranslation-meta.xml")
+		childName = strings.TrimSuffix(childName, ".recordTypeTranslation")
+		return metadata.MetadataObjectName(parentName + "." + childName)
+	}
+}
+
+func Open(path string) (*RecordTypeTranslation, error) {
+	rt := &RecordTypeTranslation{}
+	return rt, metadata.ParseMetadataXml(rt, path)
+}

--- a/metadata/objectTranslations/tidy.go
+++ b/metadata/objectTranslations/tidy.go
@@ -1,0 +1,23 @@
+package objectTranslations
+
+import (
+	"sort"
+)
+
+// Tidy sorts the fields, record types, and validation rules in the CustomObjectTranslation
+func (c *CustomObjectTranslation) Tidy() {
+	// Sort fields by name
+	sort.Slice(c.Fields, func(i, j int) bool {
+		return c.Fields[i].Name.Text < c.Fields[j].Name.Text
+	})
+
+	// Sort record types by name
+	sort.Slice(c.RecordTypes, func(i, j int) bool {
+		return c.RecordTypes[i].Name.Text < c.RecordTypes[j].Name.Text
+	})
+
+	// Sort validation rules by name
+	sort.Slice(c.ValidationRules, func(i, j int) bool {
+		return c.ValidationRules[i].Name.Text < c.ValidationRules[j].Name.Text
+	})
+}

--- a/metadata/objectTranslations/tidy_test.go
+++ b/metadata/objectTranslations/tidy_test.go
@@ -1,0 +1,57 @@
+package objectTranslations
+
+import (
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata/objectTranslations/field"
+	"github.com/ForceCLI/force-md/metadata/objectTranslations/recordtype"
+	"github.com/ForceCLI/force-md/metadata/objectTranslations/validationrule"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomObjectTranslationTidy(t *testing.T) {
+	trans := &CustomObjectTranslation{
+		Fields: FieldList{
+			field.Field{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "ZField__c"}},
+			field.Field{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "AField__c"}},
+			field.Field{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "MField__c"}},
+		},
+		RecordTypes: RecordTypeList{
+			recordtype.RecordType{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "ZType"}},
+			recordtype.RecordType{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "AType"}},
+		},
+		ValidationRules: ValidationRuleList{
+			validationrule.ValidationRule{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "ZRule"}},
+			validationrule.ValidationRule{Name: struct {
+				Text string `xml:",chardata"`
+			}{Text: "ARule"}},
+		},
+	}
+
+	trans.Tidy()
+
+	// Verify fields are sorted
+	assert.Equal(t, "AField__c", trans.Fields[0].Name.Text)
+	assert.Equal(t, "MField__c", trans.Fields[1].Name.Text)
+	assert.Equal(t, "ZField__c", trans.Fields[2].Name.Text)
+
+	// Verify record types are sorted
+	assert.Equal(t, "AType", trans.RecordTypes[0].Name.Text)
+	assert.Equal(t, "ZType", trans.RecordTypes[1].Name.Text)
+
+	// Verify validation rules are sorted
+	assert.Equal(t, "ARule", trans.ValidationRules[0].Name.Text)
+	assert.Equal(t, "ZRule", trans.ValidationRules[1].Name.Text)
+}

--- a/metadata/objectTranslations/validationrule/validationrule.go
+++ b/metadata/objectTranslations/validationrule/validationrule.go
@@ -1,0 +1,75 @@
+package validationrule
+
+import (
+	"encoding/xml"
+	"path/filepath"
+	"strings"
+
+	"github.com/ForceCLI/force-md/internal"
+	"github.com/ForceCLI/force-md/metadata"
+)
+
+const VALIDATION_RULE_TRANSLATION_NAME = "ValidationRuleTranslation"
+
+func init() {
+	internal.TypeRegistry.Register(VALIDATION_RULE_TRANSLATION_NAME, func(path string) (metadata.RegisterableMetadata, error) { return Open(path) })
+}
+
+type ValidationRule struct {
+	ErrorMessage struct {
+		Text string `xml:",chardata"`
+	} `xml:"errorMessage"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+}
+
+type ValidationRuleTranslation struct {
+	metadata.MetadataInfo
+	XMLName      xml.Name `xml:"ValidationRuleTranslation"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	ErrorMessage struct {
+		Text string `xml:",chardata"`
+	} `xml:"errorMessage"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+}
+
+func (v *ValidationRuleTranslation) SetMetadata(m metadata.MetadataInfo) {
+	v.MetadataInfo = m
+}
+
+func (v *ValidationRuleTranslation) Type() metadata.MetadataType {
+	return VALIDATION_RULE_TRANSLATION_NAME
+}
+
+func (v *ValidationRuleTranslation) NameFromPath(path string) metadata.MetadataObjectName {
+	// Extract parent-child name from path
+	// e.g., /objectTranslations/Account-en_US/validationRules/Amount_Must_Be_Positive.validationRuleTranslation-meta.xml
+	// or /objectTranslations/Account-en_US/Amount_Must_Be_Positive.validationRuleTranslation-meta.xml
+	// should return "Account-en_US.Amount_Must_Be_Positive"
+	dir := filepath.Dir(path)
+	parentDir := filepath.Dir(dir)
+
+	// Check if the file is in a validationRules subdirectory
+	if filepath.Base(dir) == "validationRules" {
+		parentName := filepath.Base(parentDir)
+		baseName := filepath.Base(path)
+		childName := strings.TrimSuffix(baseName, ".validationRuleTranslation-meta.xml")
+		childName = strings.TrimSuffix(childName, ".validationRuleTranslation")
+		return metadata.MetadataObjectName(parentName + "." + childName)
+	} else {
+		// File is directly in the object translation directory
+		parentName := filepath.Base(dir)
+		baseName := filepath.Base(path)
+		childName := strings.TrimSuffix(baseName, ".validationRuleTranslation-meta.xml")
+		childName = strings.TrimSuffix(childName, ".validationRuleTranslation")
+		return metadata.MetadataObjectName(parentName + "." + childName)
+	}
+}
+
+func Open(path string) (*ValidationRuleTranslation, error) {
+	vr := &ValidationRuleTranslation{}
+	return vr, metadata.ParseMetadataXml(vr, path)
+}

--- a/metadata/objects/compose.go
+++ b/metadata/objects/compose.go
@@ -1,0 +1,154 @@
+package objects
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/objects/businessprocess"
+	"github.com/ForceCLI/force-md/metadata/objects/compactlayout"
+	"github.com/ForceCLI/force-md/metadata/objects/field"
+	"github.com/ForceCLI/force-md/metadata/objects/fieldset"
+	"github.com/ForceCLI/force-md/metadata/objects/index"
+	"github.com/ForceCLI/force-md/metadata/objects/listview"
+	"github.com/ForceCLI/force-md/metadata/objects/recordtype"
+	"github.com/ForceCLI/force-md/metadata/objects/sharingreason"
+	"github.com/ForceCLI/force-md/metadata/objects/validationrule"
+	"github.com/ForceCLI/force-md/metadata/objects/weblink"
+)
+
+// ChildComponentProvider provides access to child components for composition
+type ChildComponentProvider interface {
+	Items(metadataType string) []metadata.RegisterableMetadata
+}
+
+// ComposeFromChildren creates a composed CustomObject by merging child components from a provider.
+// This is used when converting from source format (where components are separate) to metadata format.
+func ComposeFromChildren(objectName string, provider ChildComponentProvider) *CustomObject {
+	// Try to get the base object if it exists
+	var obj *CustomObject
+	baseObjectExists := false
+
+	objectItems := provider.Items("CustomObject")
+	for _, item := range objectItems {
+		if string(item.GetMetadataInfo().Name()) == objectName {
+			if customObj, ok := item.(*CustomObject); ok {
+				// Clone the object to avoid modifying the original
+				cloned := *customObj
+				obj = &cloned
+				baseObjectExists = true
+				break
+			}
+		}
+	}
+
+	// If no base object exists, create a minimal one
+	if !baseObjectExists {
+		obj = &CustomObject{
+			XMLName: xml.Name{Local: "CustomObject"},
+			Xmlns:   "http://soap.sforce.com/2006/04/metadata",
+		}
+	} else {
+		// Clear child component arrays since we'll rebuild them from the provider
+		obj.Fields = nil
+		obj.RecordTypes = nil
+		obj.ValidationRules = nil
+		obj.Indexes = nil
+		obj.FieldSets = nil
+		obj.WebLinks = nil
+		obj.CompactLayouts = nil
+		obj.SharingReasons = nil
+		obj.BusinessProcesses = nil
+		obj.ListViews = nil
+	}
+
+	// Helper function to find items with a specific prefix
+	findItemsByPrefix := func(items []metadata.RegisterableMetadata, prefix string) []metadata.RegisterableMetadata {
+		var result []metadata.RegisterableMetadata
+		for _, item := range items {
+			name := string(item.GetMetadataInfo().Name())
+			if strings.HasPrefix(name, prefix) {
+				result = append(result, item)
+			}
+		}
+		return result
+	}
+
+	prefix := objectName + "."
+
+	// Merge in business processes
+	for _, bpMeta := range findItemsByPrefix(provider.Items("BusinessProcess"), prefix) {
+		if bp, ok := bpMeta.(*businessprocess.BusinessProcessMetadata); ok {
+			obj.BusinessProcesses = append(obj.BusinessProcesses, bp.BusinessProcess)
+		}
+	}
+
+	// Merge in fields
+	for _, fieldMeta := range findItemsByPrefix(provider.Items("CustomField"), prefix) {
+		if f, ok := fieldMeta.(*field.CustomField); ok {
+			obj.Fields = append(obj.Fields, f.Field)
+		}
+	}
+
+	// Merge in record types
+	for _, rtMeta := range findItemsByPrefix(provider.Items("RecordType"), prefix) {
+		if rt, ok := rtMeta.(*recordtype.RecordTypeMetadata); ok {
+			obj.RecordTypes = append(obj.RecordTypes, rt.RecordType)
+		}
+	}
+
+	// Merge in validation rules
+	for _, vrMeta := range findItemsByPrefix(provider.Items("ValidationRule"), prefix) {
+		if vr, ok := vrMeta.(*validationrule.ValidationRule); ok {
+			obj.ValidationRules = append(obj.ValidationRules, vr.Rule)
+		}
+	}
+
+	// Merge in field sets
+	for _, fsMeta := range findItemsByPrefix(provider.Items("FieldSet"), prefix) {
+		if fs, ok := fsMeta.(*fieldset.FieldSetMetadata); ok {
+			obj.FieldSets = append(obj.FieldSets, fs.FieldSet)
+		}
+	}
+
+	// Merge in web links
+	for _, wlMeta := range findItemsByPrefix(provider.Items("WebLink"), prefix) {
+		if wl, ok := wlMeta.(*weblink.WebLinkMetadata); ok {
+			obj.WebLinks = append(obj.WebLinks, wl.WebLink)
+		}
+	}
+
+	// Merge in compact layouts
+	for _, clMeta := range findItemsByPrefix(provider.Items("CompactLayout"), prefix) {
+		if cl, ok := clMeta.(*compactlayout.CompactLayoutMetadata); ok {
+			obj.CompactLayouts = append(obj.CompactLayouts, cl.CompactLayout)
+		}
+	}
+
+	// Merge in sharing reasons
+	for _, srMeta := range findItemsByPrefix(provider.Items("SharingReason"), prefix) {
+		if sr, ok := srMeta.(*sharingreason.SharingReasonMetadata); ok {
+			obj.SharingReasons = append(obj.SharingReasons, sr.SharingReason)
+		}
+	}
+
+	// Merge in indexes
+	for _, idxMeta := range findItemsByPrefix(provider.Items("Index"), prefix) {
+		if idx, ok := idxMeta.(*index.Index); ok {
+			obj.Indexes = append(obj.Indexes, idx.BigObjectIndex)
+		}
+	}
+
+	// Merge in list views
+	for _, lvMeta := range findItemsByPrefix(provider.Items("ListView"), prefix) {
+		if lv, ok := lvMeta.(*listview.ListViewMetadata); ok {
+			obj.ListViews = append(obj.ListViews, lv.ListView)
+		}
+	}
+
+	// Tidy the composed object to ensure consistent ordering
+	obj.Tidy()
+
+	return obj
+}
+

--- a/metadata/objects/objects.go
+++ b/metadata/objects/objects.go
@@ -198,6 +198,211 @@ func (c *CustomObject) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *CustomObject) Files(format metadata.Format) (map[string][]byte, error) {
+	if format == metadata.SourceFormat {
+		// For source format, decompose the object into separate files
+		return c.decompose()
+	}
+
+	// For metadata format, use default behavior (single file)
+	files := make(map[string][]byte)
+	content, err := internal.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	objectName := c.MetadataInfo.Name()
+	fileName := "objects/" + string(objectName) + ".object"
+	files[fileName] = content
+
+	return files, nil
+}
+
+func (c *CustomObject) decompose() (map[string][]byte, error) {
+	files := make(map[string][]byte)
+	objectName := string(c.MetadataInfo.Name())
+	baseDir := "objects/" + objectName
+
+	// Clone the object and remove child components that will be written as separate files
+	minimalObj := *c
+	minimalObj.XMLName = xml.Name{Local: "CustomObject"}
+	minimalObj.Xmlns = "http://soap.sforce.com/2006/04/metadata"
+
+	// Clear out the child components that will be written separately
+	minimalObj.Fields = nil
+	minimalObj.RecordTypes = nil
+	minimalObj.ValidationRules = nil
+	minimalObj.Indexes = nil
+	minimalObj.FieldSets = nil
+	minimalObj.WebLinks = nil
+	minimalObj.CompactLayouts = nil
+	minimalObj.SharingReasons = nil
+	minimalObj.BusinessProcesses = nil
+	minimalObj.ListViews = nil
+
+	// Marshal the minimal object
+	content, err := internal.Marshal(&minimalObj)
+	if err != nil {
+		return nil, err
+	}
+	files[baseDir+"/"+objectName+".object-meta.xml"] = content
+
+	// Write fields as separate files
+	for _, f := range c.Fields {
+		fieldMeta := &field.CustomField{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "CustomField"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			Field:        f,
+		}
+		fieldContent, err := internal.Marshal(fieldMeta)
+		if err != nil {
+			return nil, err
+		}
+		if f.FullName == "" {
+			continue
+		}
+		files[baseDir+"/fields/"+f.FullName+".field-meta.xml"] = fieldContent
+	}
+
+	// Write record types as separate files
+	for _, rt := range c.RecordTypes {
+		rtMeta := &recordtype.RecordTypeMetadata{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "RecordType"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			RecordType:   rt,
+		}
+		rtContent, err := internal.Marshal(rtMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/recordTypes/"+rt.FullName+".recordType-meta.xml"] = rtContent
+	}
+
+	// Write validation rules as separate files
+	for _, vr := range c.ValidationRules {
+		vrMeta := &validationrule.ValidationRule{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "ValidationRule"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			Rule:         vr,
+		}
+		vrContent, err := internal.Marshal(vrMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/validationRules/"+vr.FullName+".validationRule-meta.xml"] = vrContent
+	}
+
+	// Write indexes as separate files
+	for _, idx := range c.Indexes {
+		idxMeta := &index.Index{
+			MetadataInfo:   metadata.MetadataInfo{},
+			XMLName:        xml.Name{Local: "Index"},
+			Xmlns:          "http://soap.sforce.com/2006/04/metadata",
+			BigObjectIndex: idx,
+		}
+		idxContent, err := internal.Marshal(idxMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/indexes/"+idx.Label+".index-meta.xml"] = idxContent
+	}
+
+	// Write field sets as separate files
+	for _, fs := range c.FieldSets {
+		fsMeta := &fieldset.FieldSetMetadata{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "FieldSet"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			FieldSet:     fs,
+		}
+		fsContent, err := internal.Marshal(fsMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/fieldSets/"+fs.FullName+".fieldSet-meta.xml"] = fsContent
+	}
+
+	// Write web links as separate files
+	for _, wl := range c.WebLinks {
+		wlMeta := &weblink.WebLinkMetadata{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "WebLink"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			WebLink:      wl,
+		}
+		wlContent, err := internal.Marshal(wlMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/webLinks/"+wl.FullName+".webLink-meta.xml"] = wlContent
+	}
+
+	// Write compact layouts as separate files
+	for _, cl := range c.CompactLayouts {
+		clMeta := &compactlayout.CompactLayoutMetadata{
+			MetadataInfo:  metadata.MetadataInfo{},
+			XMLName:       xml.Name{Local: "CompactLayout"},
+			Xmlns:         "http://soap.sforce.com/2006/04/metadata",
+			CompactLayout: cl,
+		}
+		clContent, err := internal.Marshal(clMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/compactLayouts/"+cl.FullName.Text+".compactLayout-meta.xml"] = clContent
+	}
+
+	// Write sharing reasons as separate files
+	for _, sr := range c.SharingReasons {
+		srMeta := &sharingreason.SharingReasonMetadata{
+			MetadataInfo:  metadata.MetadataInfo{},
+			XMLName:       xml.Name{Local: "SharingReason"},
+			Xmlns:         "http://soap.sforce.com/2006/04/metadata",
+			SharingReason: sr,
+		}
+		srContent, err := internal.Marshal(srMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/sharingReasons/"+sr.FullName+".sharingReason-meta.xml"] = srContent
+	}
+
+	// Write business processes as separate files
+	for _, bp := range c.BusinessProcesses {
+		bpMeta := &businessprocess.BusinessProcessMetadata{
+			MetadataInfo:    metadata.MetadataInfo{},
+			XMLName:         xml.Name{Local: "BusinessProcess"},
+			Xmlns:           "http://soap.sforce.com/2006/04/metadata",
+			BusinessProcess: bp,
+		}
+		bpContent, err := internal.Marshal(bpMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/businessProcesses/"+bp.FullName.Text+".businessProcess-meta.xml"] = bpContent
+	}
+
+	// Write list views as separate files
+	for _, lv := range c.ListViews {
+		lvMeta := &listview.ListViewMetadata{
+			MetadataInfo: metadata.MetadataInfo{},
+			XMLName:      xml.Name{Local: "ListView"},
+			Xmlns:        "http://soap.sforce.com/2006/04/metadata",
+			ListView:     lv,
+		}
+		lvContent, err := internal.Marshal(lvMeta)
+		if err != nil {
+			return nil, err
+		}
+		files[baseDir+"/listViews/"+lv.FullName.Text+".listView-meta.xml"] = lvContent
+	}
+
+	return files, nil
+}
+
 func Open(path string) (*CustomObject, error) {
 	p := &CustomObject{}
 	return p, metadata.ParseMetadataXml(p, path)

--- a/metadata/objects/tidy.go
+++ b/metadata/objects/tidy.go
@@ -18,6 +18,21 @@ func (p *CustomObject) Tidy() {
 	sort.Slice(p.ListViews, func(i, j int) bool {
 		return p.ListViews[i].FullName.Text < p.ListViews[j].FullName.Text
 	})
+	sort.Slice(p.CompactLayouts, func(i, j int) bool {
+		return p.CompactLayouts[i].FullName.Text < p.CompactLayouts[j].FullName.Text
+	})
+	sort.Slice(p.RecordTypes, func(i, j int) bool {
+		return p.RecordTypes[i].FullName < p.RecordTypes[j].FullName
+	})
+	sort.Slice(p.WebLinks, func(i, j int) bool {
+		return p.WebLinks[i].FullName < p.WebLinks[j].FullName
+	})
+	sort.Slice(p.SharingReasons, func(i, j int) bool {
+		return p.SharingReasons[i].FullName < p.SharingReasons[j].FullName
+	})
+	sort.Slice(p.BusinessProcesses, func(i, j int) bool {
+		return p.BusinessProcesses[i].FullName.Text < p.BusinessProcesses[j].FullName.Text
+	})
 }
 
 func (fields FieldList) Tidy() {

--- a/metadata/objects/tidy_test.go
+++ b/metadata/objects/tidy_test.go
@@ -1,0 +1,65 @@
+package objects
+
+import (
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata/objects/field"
+	"github.com/ForceCLI/force-md/metadata/objects/listview"
+	"github.com/ForceCLI/force-md/metadata/objects/recordtype"
+	"github.com/ForceCLI/force-md/metadata/objects/validationrule"
+	"github.com/ForceCLI/force-md/metadata/objects/weblink"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomObjectTidy(t *testing.T) {
+	obj := &CustomObject{
+		Fields: FieldList{
+			field.Field{FullName: "ZField__c"},
+			field.Field{FullName: "AField__c"},
+			field.Field{FullName: "MField__c"},
+		},
+		ListViews: []listview.ListView{
+			{FullName: struct {
+				Text string `xml:",chardata"`
+			}{Text: "ZView"}},
+			{FullName: struct {
+				Text string `xml:",chardata"`
+			}{Text: "AView"}},
+		},
+		RecordTypes: []recordtype.RecordType{
+			{FullName: "ZType"},
+			{FullName: "AType"},
+		},
+		ValidationRules: validationrule.ValidationRuleList{
+			{FullName: "ZRule"},
+			{FullName: "ARule"},
+		},
+		WebLinks: []weblink.WebLink{
+			{FullName: "ZLink"},
+			{FullName: "ALink"},
+		},
+	}
+
+	obj.Tidy()
+
+	// Verify fields are sorted
+	assert.Equal(t, "AField__c", obj.Fields[0].FullName)
+	assert.Equal(t, "MField__c", obj.Fields[1].FullName)
+	assert.Equal(t, "ZField__c", obj.Fields[2].FullName)
+
+	// Verify list views are sorted
+	assert.Equal(t, "AView", obj.ListViews[0].FullName.Text)
+	assert.Equal(t, "ZView", obj.ListViews[1].FullName.Text)
+
+	// Verify record types are sorted
+	assert.Equal(t, "AType", obj.RecordTypes[0].FullName)
+	assert.Equal(t, "ZType", obj.RecordTypes[1].FullName)
+
+	// Verify validation rules are sorted
+	assert.Equal(t, "ARule", obj.ValidationRules[0].FullName)
+	assert.Equal(t, "ZRule", obj.ValidationRules[1].FullName)
+
+	// Verify weblinks are sorted
+	assert.Equal(t, "ALink", obj.WebLinks[0].FullName)
+	assert.Equal(t, "ZLink", obj.WebLinks[1].FullName)
+}

--- a/metadata/objects/validationrule/tidy.go
+++ b/metadata/objects/validationrule/tidy.go
@@ -14,20 +14,24 @@ func (rules ValidationRuleList) Tidy() {
 		return rules[i].FullName < rules[j].FullName
 	})
 	for _, f := range rules {
+		if f.ErrorConditionFormula != nil {
+			formatted, err := formatter.Format(f.ErrorConditionFormula.String())
+			if err != nil {
+				log.Warn(fmt.Sprintf("error formatting %s: %s", f.FullName, err.Error()))
+			} else {
+				f.ErrorConditionFormula.Text = internal.FormulaEscaper.Replace(formatted)
+			}
+		}
+	}
+}
+
+func (f ValidationRule) Tidy() {
+	if f.ErrorConditionFormula != nil {
 		formatted, err := formatter.Format(f.ErrorConditionFormula.String())
 		if err != nil {
 			log.Warn(fmt.Sprintf("error formatting %s: %s", f.FullName, err.Error()))
 		} else {
 			f.ErrorConditionFormula.Text = internal.FormulaEscaper.Replace(formatted)
 		}
-	}
-}
-
-func (f ValidationRule) Tidy() {
-	formatted, err := formatter.Format(f.ErrorConditionFormula.String())
-	if err != nil {
-		log.Warn(fmt.Sprintf("error formatting %s: %s", f.FullName, err.Error()))
-	} else {
-		f.ErrorConditionFormula.Text = internal.FormulaEscaper.Replace(formatted)
 	}
 }

--- a/metadata/omniDataTransforms/omniDataTransform.go
+++ b/metadata/omniDataTransforms/omniDataTransform.go
@@ -3,6 +3,7 @@ package omniDataTransform
 import (
 	"encoding/xml"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
 )
@@ -26,15 +27,23 @@ type OmniDataTransform struct {
 	DeletedOnSuccess struct {
 		Text string `xml:",chardata"`
 	} `xml:"deletedOnSuccess"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	ErrorIgnored struct {
 		Text string `xml:",chardata"`
 	} `xml:"errorIgnored"`
+	ExpectedInputJson         *TextLiteral `xml:"expectedInputJson"`
+	ExpectedOutputJson        *TextLiteral `xml:"expectedOutputJson"`
 	FieldLevelSecurityEnabled struct {
 		Text string `xml:",chardata"`
 	} `xml:"fieldLevelSecurityEnabled"`
 	InputType struct {
 		Text string `xml:",chardata"`
 	} `xml:"inputType"`
+	IsManagedUsingStdDesigner *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isManagedUsingStdDesigner"`
 	Name struct {
 		Text string `xml:",chardata"`
 	} `xml:"name"`
@@ -42,30 +51,59 @@ type OmniDataTransform struct {
 		Text string `xml:",chardata"`
 	} `xml:"nullInputsIncludedInOutput"`
 	OmniDataTransformItem []struct {
+		DefaultValue *struct {
+			Text string `xml:",chardata"`
+		} `xml:"defaultValue"`
 		Disabled struct {
 			Text string `xml:",chardata"`
 		} `xml:"disabled"`
+		FilterDataType *struct {
+			Text string `xml:",chardata"`
+		} `xml:"filterDataType"`
 		FilterGroup struct {
 			Text string `xml:",chardata"`
 		} `xml:"filterGroup"`
+		FormulaConverted  *TextLiteral `xml:"formulaConverted"`
+		FormulaExpression *TextLiteral `xml:"formulaExpression"`
+		FilterOperator    *struct {
+			Text string `xml:",chardata"`
+		} `xml:"filterOperator"`
+		FilterValue *struct {
+			Text string `xml:",chardata"`
+		} `xml:"filterValue"`
+		FormulaResultPath *struct {
+			Text string `xml:",chardata"`
+		} `xml:"formulaResultPath"`
+		FormulaSequence *struct {
+			Text string `xml:",chardata"`
+		} `xml:"formulaSequence"`
 		GlobalKey struct {
 			Text string `xml:",chardata"`
 		} `xml:"globalKey"`
-		InputFieldName struct {
+		InputFieldName *struct {
 			Text string `xml:",chardata"`
 		} `xml:"inputFieldName"`
+		InputObjectName *struct {
+			Text string `xml:",chardata"`
+		} `xml:"inputObjectName"`
 		InputObjectQuerySequence struct {
 			Text string `xml:",chardata"`
 		} `xml:"inputObjectQuerySequence"`
 		LinkedObjectSequence struct {
 			Text string `xml:",chardata"`
 		} `xml:"linkedObjectSequence"`
+		MigrationValue *struct {
+			Text string `xml:",chardata"`
+		} `xml:"migrationValue"`
 		Name struct {
 			Text string `xml:",chardata"`
 		} `xml:"name"`
 		OutputCreationSequence struct {
 			Text string `xml:",chardata"`
 		} `xml:"outputCreationSequence"`
+		OutputFieldFormat *struct {
+			Text string `xml:",chardata"`
+		} `xml:"outputFieldFormat"`
 		OutputFieldName struct {
 			Text string `xml:",chardata"`
 		} `xml:"outputFieldName"`
@@ -75,58 +113,26 @@ type OmniDataTransform struct {
 		RequiredForUpsert struct {
 			Text string `xml:",chardata"`
 		} `xml:"requiredForUpsert"`
+		TransformValuesMappings *struct {
+			Text string `xml:",chardata"`
+		} `xml:"transformValuesMappings"`
 		UpsertKey struct {
 			Text string `xml:",chardata"`
 		} `xml:"upsertKey"`
-		FormulaConverted struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaConverted"`
-		FormulaExpression struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaExpression"`
-		FormulaResultPath struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaResultPath"`
-		FormulaSequence struct {
-			Text string `xml:",chardata"`
-		} `xml:"formulaSequence"`
-		FilterOperator struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterOperator"`
-		MigrationValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"migrationValue"`
-		DefaultValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"defaultValue"`
-		FilterValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterValue"`
-		InputObjectName struct {
-			Text string `xml:",chardata"`
-		} `xml:"inputObjectName"`
-		OutputFieldFormat struct {
-			Text string `xml:",chardata"`
-		} `xml:"outputFieldFormat"`
-		TransformValuesMappings struct {
-			Text string `xml:",chardata"`
-		} `xml:"transformValuesMappings"`
-		FilterDataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"filterDataType"`
 	} `xml:"omniDataTransformItem"`
 	OutputType struct {
 		Text string `xml:",chardata"`
 	} `xml:"outputType"`
-	PreviewJsonData struct {
-		Text string `xml:",chardata"`
-	} `xml:"previewJsonData"`
+	PreviewJsonData  *TextLiteral `xml:"previewJsonData"`
 	ProcessSuperBulk struct {
 		Text string `xml:",chardata"`
 	} `xml:"processSuperBulk"`
 	ResponseCacheTtlMinutes struct {
 		Text string `xml:",chardata"`
 	} `xml:"responseCacheTtlMinutes"`
+	ResponseCacheType *struct {
+		Text string `xml:",chardata"`
+	} `xml:"responseCacheType"`
 	RollbackOnError struct {
 		Text string `xml:",chardata"`
 	} `xml:"rollbackOnError"`
@@ -139,6 +145,9 @@ type OmniDataTransform struct {
 	SynchronousProcessThreshold struct {
 		Text string `xml:",chardata"`
 	} `xml:"synchronousProcessThreshold"`
+	TargetOutputFileName *struct {
+		Text string `xml:",chardata"`
+	} `xml:"targetOutputFileName"`
 	OmniDataTransformType struct {
 		Text string `xml:",chardata"`
 	} `xml:"type"`
@@ -151,21 +160,6 @@ type OmniDataTransform struct {
 	XmlDeclarationRemoved struct {
 		Text string `xml:",chardata"`
 	} `xml:"xmlDeclarationRemoved"`
-	ExpectedOutputJson struct {
-		Text string `xml:",chardata"`
-	} `xml:"expectedOutputJson"`
-	ResponseCacheType struct {
-		Text string `xml:",chardata"`
-	} `xml:"responseCacheType"`
-	ExpectedInputJson struct {
-		Text string `xml:",chardata"`
-	} `xml:"expectedInputJson"`
-	TargetOutputFileName struct {
-		Text string `xml:",chardata"`
-	} `xml:"targetOutputFileName"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 func (c *OmniDataTransform) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/omniIntegrationProcedures/omniIntegrationProcedure.go
+++ b/metadata/omniIntegrationProcedures/omniIntegrationProcedure.go
@@ -3,6 +3,7 @@ package omniIntegrationProcedure
 import (
 	"encoding/xml"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
 )
@@ -15,12 +16,10 @@ func init() {
 
 type OmniIntegrationProcedure struct {
 	metadata.MetadataInfo
-	XMLName          xml.Name `xml:"OmniIntegrationProcedure"`
-	Xmlns            string   `xml:"xmlns,attr"`
-	CustomJavaScript struct {
-		Text string `xml:",chardata"`
-	} `xml:"customJavaScript"`
-	Description struct {
+	XMLName          xml.Name     `xml:"OmniIntegrationProcedure"`
+	Xmlns            string       `xml:"xmlns,attr"`
+	CustomJavaScript *TextLiteral `xml:"customJavaScript"`
+	Description      *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 	ElementTypeComponentMapping struct {
@@ -29,9 +28,15 @@ type OmniIntegrationProcedure struct {
 	IsActive struct {
 		Text string `xml:",chardata"`
 	} `xml:"isActive"`
+	IsIntegProcdSignatureAvl *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isIntegProcdSignatureAvl"`
 	IsIntegrationProcedure struct {
 		Text string `xml:",chardata"`
 	} `xml:"isIntegrationProcedure"`
+	IsManagedUsingStdDesigner *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isManagedUsingStdDesigner"`
 	IsMetadataCacheDisabled struct {
 		Text string `xml:",chardata"`
 	} `xml:"isMetadataCacheDisabled"`
@@ -51,6 +56,31 @@ type OmniIntegrationProcedure struct {
 		Text string `xml:",chardata"`
 	} `xml:"name"`
 	OmniProcessElements []struct {
+		ChildElements []struct {
+			Description *TextLiteral `xml:"description"`
+			IsActive    struct {
+				Text string `xml:",chardata"`
+			} `xml:"isActive"`
+			IsOmniScriptEmbeddable struct {
+				Text string `xml:",chardata"`
+			} `xml:"isOmniScriptEmbeddable"`
+			Level struct {
+				Text string `xml:",chardata"`
+			} `xml:"level"`
+			Name struct {
+				Text string `xml:",chardata"`
+			} `xml:"name"`
+			OmniProcessVersionNumber struct {
+				Text string `xml:",chardata"`
+			} `xml:"omniProcessVersionNumber"`
+			PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+			SequenceNumber    struct {
+				Text string `xml:",chardata"`
+			} `xml:"sequenceNumber"`
+			Type struct {
+				Text string `xml:",chardata"`
+			} `xml:"type"`
+		} `xml:"childElements"`
 		IsActive struct {
 			Text string `xml:",chardata"`
 		} `xml:"isActive"`
@@ -66,44 +96,13 @@ type OmniIntegrationProcedure struct {
 		OmniProcessVersionNumber struct {
 			Text string `xml:",chardata"`
 		} `xml:"omniProcessVersionNumber"`
-		PropertySetConfig struct {
-			Text string `xml:",chardata"`
-		} `xml:"propertySetConfig"`
-		SequenceNumber struct {
+		PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+		SequenceNumber    struct {
 			Text string `xml:",chardata"`
 		} `xml:"sequenceNumber"`
 		Type struct {
 			Text string `xml:",chardata"`
 		} `xml:"type"`
-		ChildElements []struct {
-			IsActive struct {
-				Text string `xml:",chardata"`
-			} `xml:"isActive"`
-			IsOmniScriptEmbeddable struct {
-				Text string `xml:",chardata"`
-			} `xml:"isOmniScriptEmbeddable"`
-			Level struct {
-				Text string `xml:",chardata"`
-			} `xml:"level"`
-			Name struct {
-				Text string `xml:",chardata"`
-			} `xml:"name"`
-			OmniProcessVersionNumber struct {
-				Text string `xml:",chardata"`
-			} `xml:"omniProcessVersionNumber"`
-			PropertySetConfig struct {
-				Text string `xml:",chardata"`
-			} `xml:"propertySetConfig"`
-			SequenceNumber struct {
-				Text string `xml:",chardata"`
-			} `xml:"sequenceNumber"`
-			Type struct {
-				Text string `xml:",chardata"`
-			} `xml:"type"`
-			Description struct {
-				Text string `xml:",chardata"`
-			} `xml:"description"`
-		} `xml:"childElements"`
 	} `xml:"omniProcessElements"`
 	OmniProcessKey struct {
 		Text string `xml:",chardata"`
@@ -111,10 +110,8 @@ type OmniIntegrationProcedure struct {
 	OmniProcessType struct {
 		Text string `xml:",chardata"`
 	} `xml:"omniProcessType"`
-	PropertySetConfig struct {
-		Text string `xml:",chardata"`
-	} `xml:"propertySetConfig"`
-	SubType struct {
+	PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+	SubType           struct {
 		Text string `xml:",chardata"`
 	} `xml:"subType"`
 	IntegrationProcedureType struct {

--- a/metadata/omniScripts/omniScripts.go
+++ b/metadata/omniScripts/omniScripts.go
@@ -3,6 +3,7 @@ package omniscript
 import (
 	"encoding/xml"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
 )
@@ -26,6 +27,9 @@ type OmniScript struct {
 	IsIntegrationProcedure struct {
 		Text string `xml:",chardata"`
 	} `xml:"isIntegrationProcedure"`
+	IsManagedUsingStdDesigner *struct {
+		Text string `xml:",chardata"`
+	} `xml:"isManagedUsingStdDesigner"`
 	IsMetadataCacheDisabled struct {
 		Text string `xml:",chardata"`
 	} `xml:"isMetadataCacheDisabled"`
@@ -45,56 +49,8 @@ type OmniScript struct {
 		Text string `xml:",chardata"`
 	} `xml:"name"`
 	OmniProcessElements []struct {
-		IsActive struct {
-			Text string `xml:",chardata"`
-		} `xml:"isActive"`
-		IsOmniScriptEmbeddable struct {
-			Text string `xml:",chardata"`
-		} `xml:"isOmniScriptEmbeddable"`
-		Level struct {
-			Text string `xml:",chardata"`
-		} `xml:"level"`
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		OmniProcessVersionNumber struct {
-			Text string `xml:",chardata"`
-		} `xml:"omniProcessVersionNumber"`
-		PropertySetConfig struct {
-			Text string `xml:",chardata"`
-		} `xml:"propertySetConfig"`
-		SequenceNumber struct {
-			Text string `xml:",chardata"`
-		} `xml:"sequenceNumber"`
-		Type struct {
-			Text string `xml:",chardata"`
-		} `xml:"type"`
 		ChildElements []struct {
 			ChildElements []struct {
-				IsActive struct {
-					Text string `xml:",chardata"`
-				} `xml:"isActive"`
-				IsOmniScriptEmbeddable struct {
-					Text string `xml:",chardata"`
-				} `xml:"isOmniScriptEmbeddable"`
-				Level struct {
-					Text string `xml:",chardata"`
-				} `xml:"level"`
-				Name struct {
-					Text string `xml:",chardata"`
-				} `xml:"name"`
-				OmniProcessVersionNumber struct {
-					Text string `xml:",chardata"`
-				} `xml:"omniProcessVersionNumber"`
-				PropertySetConfig struct {
-					Text string `xml:",chardata"`
-				} `xml:"propertySetConfig"`
-				SequenceNumber struct {
-					Text string `xml:",chardata"`
-				} `xml:"sequenceNumber"`
-				Type struct {
-					Text string `xml:",chardata"`
-				} `xml:"type"`
 				ChildElements []struct {
 					IsActive struct {
 						Text string `xml:",chardata"`
@@ -111,16 +67,36 @@ type OmniScript struct {
 					OmniProcessVersionNumber struct {
 						Text string `xml:",chardata"`
 					} `xml:"omniProcessVersionNumber"`
-					PropertySetConfig struct {
-						Text string `xml:",chardata"`
-					} `xml:"propertySetConfig"`
-					SequenceNumber struct {
+					PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+					SequenceNumber    struct {
 						Text string `xml:",chardata"`
 					} `xml:"sequenceNumber"`
 					Type struct {
 						Text string `xml:",chardata"`
 					} `xml:"type"`
 				} `xml:"childElements"`
+				IsActive struct {
+					Text string `xml:",chardata"`
+				} `xml:"isActive"`
+				IsOmniScriptEmbeddable struct {
+					Text string `xml:",chardata"`
+				} `xml:"isOmniScriptEmbeddable"`
+				Level struct {
+					Text string `xml:",chardata"`
+				} `xml:"level"`
+				Name struct {
+					Text string `xml:",chardata"`
+				} `xml:"name"`
+				OmniProcessVersionNumber struct {
+					Text string `xml:",chardata"`
+				} `xml:"omniProcessVersionNumber"`
+				PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+				SequenceNumber    struct {
+					Text string `xml:",chardata"`
+				} `xml:"sequenceNumber"`
+				Type struct {
+					Text string `xml:",chardata"`
+				} `xml:"type"`
 			} `xml:"childElements"`
 			IsActive struct {
 				Text string `xml:",chardata"`
@@ -137,27 +113,43 @@ type OmniScript struct {
 			OmniProcessVersionNumber struct {
 				Text string `xml:",chardata"`
 			} `xml:"omniProcessVersionNumber"`
-			PropertySetConfig struct {
-				Text string `xml:",chardata"`
-			} `xml:"propertySetConfig"`
-			SequenceNumber struct {
+			PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+			SequenceNumber    struct {
 				Text string `xml:",chardata"`
 			} `xml:"sequenceNumber"`
 			Type struct {
 				Text string `xml:",chardata"`
 			} `xml:"type"`
 		} `xml:"childElements"`
-		Description struct {
+		Description *TextLiteral `xml:"description"`
+		IsActive    struct {
 			Text string `xml:",chardata"`
-		} `xml:"description"`
+		} `xml:"isActive"`
+		IsOmniScriptEmbeddable struct {
+			Text string `xml:",chardata"`
+		} `xml:"isOmniScriptEmbeddable"`
+		Level struct {
+			Text string `xml:",chardata"`
+		} `xml:"level"`
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		OmniProcessVersionNumber struct {
+			Text string `xml:",chardata"`
+		} `xml:"omniProcessVersionNumber"`
+		PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+		SequenceNumber    struct {
+			Text string `xml:",chardata"`
+		} `xml:"sequenceNumber"`
+		Type struct {
+			Text string `xml:",chardata"`
+		} `xml:"type"`
 	} `xml:"omniProcessElements"`
 	OmniProcessType struct {
 		Text string `xml:",chardata"`
 	} `xml:"omniProcessType"`
-	PropertySetConfig struct {
-		Text string `xml:",chardata"`
-	} `xml:"propertySetConfig"`
-	SubType struct {
+	PropertySetConfig *TextLiteral `xml:"propertySetConfig"`
+	SubType           struct {
 		Text string `xml:",chardata"`
 	} `xml:"subType"`
 	OmniScriptType struct {

--- a/metadata/omniUiCard/omniUiCard.go
+++ b/metadata/omniUiCard/omniUiCard.go
@@ -38,12 +38,12 @@ type OmniUiCard struct {
 	SampleDataSourceResponse struct {
 		Text string `xml:",chardata"`
 	} `xml:"sampleDataSourceResponse"`
+	StylingConfiguration *struct {
+		Text string `xml:",chardata"`
+	} `xml:"stylingConfiguration"`
 	VersionNumber struct {
 		Text string `xml:",chardata"`
 	} `xml:"versionNumber"`
-	StylingConfiguration struct {
-		Text string `xml:",chardata"`
-	} `xml:"stylingConfiguration"`
 }
 
 func (c *OmniUiCard) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/pages/page.go
+++ b/metadata/pages/page.go
@@ -2,9 +2,12 @@ package apexPage
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ApexPage"
@@ -20,18 +23,22 @@ type ApexPage struct {
 	ApiVersion struct {
 		Text string `xml:",chardata"`
 	} `xml:"apiVersion"`
+	AvailableInTouch *struct {
+		Text string `xml:",chardata"`
+	} `xml:"availableInTouch"`
+	ConfirmationTokenRequired *struct {
+		Text string `xml:",chardata"`
+	} `xml:"confirmationTokenRequired"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	AvailableInTouch struct {
-		Text string `xml:",chardata"`
-	} `xml:"availableInTouch"`
-	ConfirmationTokenRequired struct {
-		Text string `xml:",chardata"`
-	} `xml:"confirmationTokenRequired"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
+
+	// Non-XML fields
+	PageCode   []byte `xml:"-"` // The actual page code
+	SourcePath string `xml:"-"`
 }
 
 func (c *ApexPage) SetMetadata(m metadata.MetadataInfo) {
@@ -42,7 +49,44 @@ func (c *ApexPage) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *ApexPage) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the page name from metadata
+	pageName := c.MetadataInfo.Name()
+	if pageName == "" {
+		return nil, fmt.Errorf("page name is empty")
+	}
+
+	// Get the directory name for pages
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Load page code if we haven't already
+	if c.PageCode == nil {
+		c.PageCode = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".page")
+	}
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal page metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for ApexPage
+		return helpers.GenerateMetadataFilePaths(dirName, string(pageName), ".page-meta.xml", ".page", xmlContent, c.PageCode), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func Open(path string) (*ApexPage, error) {
 	p := &ApexPage{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated code files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/permissionsetgroup/permissionsetgroup.go
+++ b/metadata/permissionsetgroup/permissionsetgroup.go
@@ -26,7 +26,7 @@ type PermissionSetGroup struct {
 	Description struct {
 		Text string `xml:",innerxml"`
 	} `xml:"description"`
-	HasActivationRequired struct {
+	HasActivationRequired *struct {
 		Text string `xml:",chardata"`
 	} `xml:"hasActivationRequired"`
 	Label struct {

--- a/metadata/pkg/package.go
+++ b/metadata/pkg/package.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
 	"sort"
 
 	. "github.com/ForceCLI/force-md/general"
@@ -70,4 +72,32 @@ func (members *MetadataItems) Tidy() {
 		return members.Members[i] < members.Members[j]
 	})
 	RemoveDuplicates(&members.Members)
+}
+
+// Files implements the FilesGenerator interface
+func (p *Package) Files(format metadata.Format) (map[string][]byte, error) {
+	// Marshal the package to XML
+	xmlContent, err := internal.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal package: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	// Get the original path to determine the package file name
+	originalPath := string(p.MetadataInfo.Path())
+	fileName := ""
+	if originalPath != "" {
+		fileName = filepath.Base(originalPath)
+	}
+
+	// If no path info or generic name, default to package.xml
+	if fileName == "" || fileName == "Package" {
+		fileName = "package.xml"
+	}
+
+	// Package files go in the root directory for both formats
+	files[fileName] = xmlContent
+
+	return files, nil
 }

--- a/metadata/platformEventSubscriberConfigs/platformEventSubscriberConfigs.go
+++ b/metadata/platformEventSubscriberConfigs/platformEventSubscriberConfigs.go
@@ -24,6 +24,12 @@ type PlatformEventSubscriberConfig struct {
 	MasterLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
+	NumPartitions *struct {
+		Text string `xml:",chardata"`
+	} `xml:"numPartitions"`
+	PartitionKey *struct {
+		Text string `xml:",chardata"`
+	} `xml:"partitionKey"`
 	PlatformEventConsumer struct {
 		Text string `xml:",chardata"`
 	} `xml:"platformEventConsumer"`

--- a/metadata/queues/queue.go
+++ b/metadata/queues/queue.go
@@ -37,8 +37,11 @@ type SobjectType struct {
 
 type Queue struct {
 	metadata.MetadataInfo
-	XMLName                xml.Name `xml:"Queue"`
-	Xmlns                  string   `xml:"xmlns,attr"`
+	XMLName     xml.Name `xml:"Queue"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	DoesSendEmailToMembers struct {
 		Text string `xml:",chardata"`
 	} `xml:"doesSendEmailToMembers"`

--- a/metadata/quickActions/quickAction.go
+++ b/metadata/quickActions/quickAction.go
@@ -15,15 +15,50 @@ func init() {
 
 type QuickAction struct {
 	metadata.MetadataInfo
-	XMLName xml.Name `xml:"QuickAction"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	Label   struct {
+	XMLName       xml.Name `xml:"QuickAction"`
+	Xmlns         string   `xml:"xmlns,attr"`
+	ActionSubtype *struct {
+		Text string `xml:",chardata"`
+	} `xml:"actionSubtype"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
+	FieldOverrides []struct {
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		Formula *struct {
+			Text string `xml:",chardata"`
+		} `xml:"formula"`
+		LiteralValue *struct {
+			Text string `xml:",chardata"`
+		} `xml:"literalValue"`
+	} `xml:"fieldOverrides"`
+	FlowDefinition *struct {
+		Text string `xml:",chardata"`
+	} `xml:"flowDefinition"`
+	Height *struct {
+		Text string `xml:",chardata"`
+	} `xml:"height"`
+	Icon *struct {
+		Text string `xml:",chardata"`
+	} `xml:"icon"`
+	Label *struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
+	LightningComponent *struct {
+		Text string `xml:",chardata"`
+	} `xml:"lightningComponent"`
+	LightningWebComponent *struct {
+		Text string `xml:",chardata"`
+	} `xml:"lightningWebComponent"`
 	OptionsCreateFeedItem struct {
 		Text string `xml:",chardata"`
 	} `xml:"optionsCreateFeedItem"`
-	QuickActionLayout struct {
+	Page *struct {
+		Text string `xml:",chardata"`
+	} `xml:"page"`
+	QuickActionLayout *struct {
 		LayoutSectionStyle struct {
 			Text string `xml:",chardata"`
 		} `xml:"layoutSectionStyle"`
@@ -32,7 +67,7 @@ type QuickAction struct {
 				EmptySpace struct {
 					Text string `xml:",chardata"`
 				} `xml:"emptySpace"`
-				Field struct {
+				Field *struct {
 					Text string `xml:",chardata"`
 				} `xml:"field"`
 				UiBehavior struct {
@@ -41,62 +76,27 @@ type QuickAction struct {
 			} `xml:"quickActionLayoutItems"`
 		} `xml:"quickActionLayoutColumns"`
 	} `xml:"quickActionLayout"`
-	TargetObject struct {
+	StandardLabel *struct {
+		Text string `xml:",chardata"`
+	} `xml:"standardLabel"`
+	SuccessMessage *struct {
+		Text string `xml:",chardata"`
+	} `xml:"successMessage"`
+	TargetObject *struct {
 		Text string `xml:",chardata"`
 	} `xml:"targetObject"`
-	TargetParentField struct {
+	TargetParentField *struct {
 		Text string `xml:",chardata"`
 	} `xml:"targetParentField"`
-	TargetRecordType struct {
+	TargetRecordType *struct {
 		Text string `xml:",chardata"`
 	} `xml:"targetRecordType"`
 	QuickActionType struct {
 		Text string `xml:",chardata"`
 	} `xml:"type"`
-	FieldOverrides []struct {
-		Field struct {
-			Text string `xml:",chardata"`
-		} `xml:"field"`
-		Formula struct {
-			Text string `xml:",chardata"`
-		} `xml:"formula"`
-		LiteralValue struct {
-			Text string `xml:",chardata"`
-		} `xml:"literalValue"`
-	} `xml:"fieldOverrides"`
-	StandardLabel struct {
-		Text string `xml:",chardata"`
-	} `xml:"standardLabel"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	SuccessMessage struct {
-		Text string `xml:",chardata"`
-	} `xml:"successMessage"`
-	FlowDefinition struct {
-		Text string `xml:",chardata"`
-	} `xml:"flowDefinition"`
-	Height struct {
-		Text string `xml:",chardata"`
-	} `xml:"height"`
-	Page struct {
-		Text string `xml:",chardata"`
-	} `xml:"page"`
-	Width struct {
+	Width *struct {
 		Text string `xml:",chardata"`
 	} `xml:"width"`
-	ActionSubtype struct {
-		Text string `xml:",chardata"`
-	} `xml:"actionSubtype"`
-	LightningWebComponent struct {
-		Text string `xml:",chardata"`
-	} `xml:"lightningWebComponent"`
-	LightningComponent struct {
-		Text string `xml:",chardata"`
-	} `xml:"lightningComponent"`
-	Icon struct {
-		Text string `xml:",chardata"`
-	} `xml:"icon"`
 }
 
 func (c *QuickAction) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/remoteSiteSettings/remoteSiteSetting.go
+++ b/metadata/remoteSiteSettings/remoteSiteSetting.go
@@ -15,8 +15,11 @@ func init() {
 
 type RemoteSiteSetting struct {
 	metadata.MetadataInfo
-	XMLName                 xml.Name `xml:"RemoteSiteSetting"`
-	Xmlns                   string   `xml:"xmlns,attr"`
+	XMLName     xml.Name `xml:"RemoteSiteSetting"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Description *struct {
+		Text string `xml:",chardata"`
+	} `xml:"description"`
 	DisableProtocolSecurity struct {
 		Text string `xml:",chardata"`
 	} `xml:"disableProtocolSecurity"`
@@ -26,9 +29,6 @@ type RemoteSiteSetting struct {
 	URL struct {
 		Text string `xml:",chardata"`
 	} `xml:"url"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
 }
 
 func (c *RemoteSiteSetting) SetMetadata(m metadata.MetadataInfo) {

--- a/metadata/reportFolder/reportFolder.go
+++ b/metadata/reportFolder/reportFolder.go
@@ -2,9 +2,13 @@ package reportFolder
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ReportFolder"
@@ -33,6 +37,59 @@ func (c *ReportFolder) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *ReportFolder) Type() metadata.MetadataType {
 	return NAME
+}
+
+func (c *ReportFolder) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the original path from metadata info
+	originalPath := string(c.MetadataInfo.Path())
+
+	// Get the directory name for report folders
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Extract the folder structure from the original path
+	// e.g., reports/CRM_Admin_Exception_Reports/SystemAdminExceptionDashboard/BD_Discharge_Reports_Master.reportFolder-meta.xml
+	// Should preserve: CRM_Admin_Exception_Reports/SystemAdminExceptionDashboard/BD_Discharge_Reports_Master
+
+	var relativePath string
+	if strings.Contains(originalPath, "reports/") {
+		// Extract everything after "reports/"
+		parts := strings.Split(originalPath, "reports/")
+		if len(parts) > 1 {
+			relativePath = parts[1]
+		}
+	}
+
+	if relativePath == "" {
+		return nil, fmt.Errorf("could not extract report folder path from %s", originalPath)
+	}
+
+	// Remove the file extension and -meta.xml suffix to get the clean relative path
+	relativePath = strings.TrimSuffix(relativePath, "-meta.xml")
+	relativePath = strings.TrimSuffix(relativePath, ".reportFolder")
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal report folder metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	var fileName string
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: preserve folder structure and add -meta.xml suffix
+		fileName = relativePath + "-meta.xml"
+	case metadata.MetadataFormat:
+		// Metadata format: preserve folder structure, add -meta.xml suffix
+		fileName = relativePath + "-meta.xml"
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	files[filepath.Join(dirName, fileName)] = xmlContent
+
+	return files, nil
 }
 
 func Open(path string) (*ReportFolder, error) {

--- a/metadata/reportType/reportType.go
+++ b/metadata/reportType/reportType.go
@@ -43,10 +43,8 @@ type ReportType struct {
 	Deployed struct {
 		Text string `xml:",chardata"`
 	} `xml:"deployed"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Join *struct {
+	Description *TextLiteral `xml:"description"`
+	Join        *struct {
 		Join *struct {
 			Join *struct {
 				OuterJoin struct {

--- a/metadata/reports/report.go
+++ b/metadata/reports/report.go
@@ -2,9 +2,14 @@ package report
 
 import (
 	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"strings"
 
+	. "github.com/ForceCLI/force-md/general"
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "Report"
@@ -15,108 +20,69 @@ func init() {
 
 type Report struct {
 	metadata.MetadataInfo
-	XMLName xml.Name `xml:"Report"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	Columns []struct {
-		Field struct {
+	XMLName    xml.Name `xml:"Report"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	Aggregates []struct {
+		AcrossGroupingContext *struct {
 			Text string `xml:",chardata"`
-		} `xml:"field"`
-		AggregateTypes struct {
+		} `xml:"acrossGroupingContext"`
+		CalculatedFormula *TextLiteral `xml:"calculatedFormula"`
+		Datatype          struct {
 			Text string `xml:",chardata"`
-		} `xml:"aggregateTypes"`
-	} `xml:"columns"`
-	Description struct {
-		Text string `xml:",chardata"`
-	} `xml:"description"`
-	Filter struct {
-		CriteriaItems []struct {
-			Column struct {
-				Text string `xml:",chardata"`
-			} `xml:"column"`
-			ColumnToColumn struct {
-				Text string `xml:",chardata"`
-			} `xml:"columnToColumn"`
-			IsUnlocked struct {
-				Text string `xml:",chardata"`
-			} `xml:"isUnlocked"`
-			Operator struct {
-				Text string `xml:",chardata"`
-			} `xml:"operator"`
+		} `xml:"datatype"`
+		DeveloperName struct {
+			Text string `xml:",chardata"`
+		} `xml:"developerName"`
+		DownGroupingContext *struct {
+			Text string `xml:",chardata"`
+		} `xml:"downGroupingContext"`
+		IsActive struct {
+			Text string `xml:",chardata"`
+		} `xml:"isActive"`
+		IsCrossBlock struct {
+			Text string `xml:",chardata"`
+		} `xml:"isCrossBlock"`
+		MasterLabel struct {
+			Text string `xml:",chardata"`
+		} `xml:"masterLabel"`
+		Scale struct {
+			Text string `xml:",chardata"`
+		} `xml:"scale"`
+	} `xml:"aggregates"`
+	Buckets []struct {
+		BucketType struct {
+			Text string `xml:",chardata"`
+		} `xml:"bucketType"`
+		DeveloperName struct {
+			Text string `xml:",chardata"`
+		} `xml:"developerName"`
+		MasterLabel struct {
+			Text string `xml:",chardata"`
+		} `xml:"masterLabel"`
+		NullTreatment struct {
+			Text string `xml:",chardata"`
+		} `xml:"nullTreatment"`
+		OtherBucketLabel *struct {
+			Text string `xml:",chardata"`
+		} `xml:"otherBucketLabel"`
+		SourceColumnName struct {
+			Text string `xml:",chardata"`
+		} `xml:"sourceColumnName"`
+		UseOther struct {
+			Text string `xml:",chardata"`
+		} `xml:"useOther"`
+		Values []struct {
+			SourceValues []struct {
+				SourceValue struct {
+					Text string `xml:",chardata"`
+				} `xml:"sourceValue"`
+			} `xml:"sourceValues"`
 			Value struct {
 				Text string `xml:",chardata"`
 			} `xml:"value"`
-		} `xml:"criteriaItems"`
-		BooleanFilter struct {
-			Text string `xml:",chardata"`
-		} `xml:"booleanFilter"`
-	} `xml:"filter"`
-	Format struct {
-		Text string `xml:",chardata"`
-	} `xml:"format"`
-	GroupingsDown []struct {
-		DateGranularity struct {
-			Text string `xml:",chardata"`
-		} `xml:"dateGranularity"`
-		Field struct {
-			Text string `xml:",chardata"`
-		} `xml:"field"`
-		SortOrder struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortOrder"`
-		AggregateType struct {
-			Text string `xml:",chardata"`
-		} `xml:"aggregateType"`
-		SortByName struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortByName"`
-		SortType struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortType"`
-	} `xml:"groupingsDown"`
-	Name struct {
-		Text string `xml:",chardata"`
-	} `xml:"name"`
-	Params []struct {
-		Name struct {
-			Text string `xml:",chardata"`
-		} `xml:"name"`
-		Value struct {
-			Text string `xml:",chardata"`
-		} `xml:"value"`
-	} `xml:"params"`
-	ReportType struct {
-		Text string `xml:",chardata"`
-	} `xml:"reportType"`
-	Scope struct {
-		Text string `xml:",chardata"`
-	} `xml:"scope"`
-	ShowDetails struct {
-		Text string `xml:",chardata"`
-	} `xml:"showDetails"`
-	ShowGrandTotal struct {
-		Text string `xml:",chardata"`
-	} `xml:"showGrandTotal"`
-	ShowSubTotals struct {
-		Text string `xml:",chardata"`
-	} `xml:"showSubTotals"`
-	TimeFrameFilter struct {
-		DateColumn struct {
-			Text string `xml:",chardata"`
-		} `xml:"dateColumn"`
-		Interval struct {
-			Text string `xml:",chardata"`
-		} `xml:"interval"`
-		StartDate struct {
-			Text string `xml:",chardata"`
-		} `xml:"startDate"`
-	} `xml:"timeFrameFilter"`
-	SortColumn struct {
-		Text string `xml:",chardata"`
-	} `xml:"sortColumn"`
-	SortOrder struct {
-		Text string `xml:",chardata"`
-	} `xml:"sortOrder"`
-	Chart struct {
+		} `xml:"values"`
+	} `xml:"buckets"`
+	Chart *struct {
 		BackgroundColor1 struct {
 			Text string `xml:",chardata"`
 		} `xml:"backgroundColor1"`
@@ -127,15 +93,15 @@ type Report struct {
 			Text string `xml:",chardata"`
 		} `xml:"backgroundFadeDir"`
 		ChartSummaries struct {
+			Aggregate *struct {
+				Text string `xml:",chardata"`
+			} `xml:"aggregate"`
 			AxisBinding struct {
 				Text string `xml:",chardata"`
 			} `xml:"axisBinding"`
 			Column struct {
 				Text string `xml:",chardata"`
 			} `xml:"column"`
-			Aggregate struct {
-				Text string `xml:",chardata"`
-			} `xml:"aggregate"`
 		} `xml:"chartSummaries"`
 		ChartType struct {
 			Text string `xml:",chardata"`
@@ -149,9 +115,15 @@ type Report struct {
 		GroupingColumn struct {
 			Text string `xml:",chardata"`
 		} `xml:"groupingColumn"`
+		LegendPosition *struct {
+			Text string `xml:",chardata"`
+		} `xml:"legendPosition"`
 		Location struct {
 			Text string `xml:",chardata"`
 		} `xml:"location"`
+		SecondaryGroupingColumn *struct {
+			Text string `xml:",chardata"`
+		} `xml:"secondaryGroupingColumn"`
 		ShowAxisLabels struct {
 			Text string `xml:",chardata"`
 		} `xml:"showAxisLabels"`
@@ -176,84 +148,45 @@ type Report struct {
 		TextSize struct {
 			Text string `xml:",chardata"`
 		} `xml:"textSize"`
+		Title *struct {
+			Text string `xml:",chardata"`
+		} `xml:"title"`
 		TitleColor struct {
 			Text string `xml:",chardata"`
 		} `xml:"titleColor"`
 		TitleSize struct {
 			Text string `xml:",chardata"`
 		} `xml:"titleSize"`
-		Title struct {
-			Text string `xml:",chardata"`
-		} `xml:"title"`
-		LegendPosition struct {
-			Text string `xml:",chardata"`
-		} `xml:"legendPosition"`
-		SecondaryGroupingColumn struct {
-			Text string `xml:",chardata"`
-		} `xml:"secondaryGroupingColumn"`
 	} `xml:"chart"`
-	GroupingsAcross []struct {
-		DateGranularity struct {
+	ColorRanges []struct {
+		ColumnName struct {
 			Text string `xml:",chardata"`
-		} `xml:"dateGranularity"`
+		} `xml:"columnName"`
+		HighBreakpoint *struct {
+			Text string `xml:",chardata"`
+		} `xml:"highBreakpoint"`
+		HighColor struct {
+			Text string `xml:",chardata"`
+		} `xml:"highColor"`
+		LowBreakpoint struct {
+			Text string `xml:",chardata"`
+		} `xml:"lowBreakpoint"`
+		LowColor struct {
+			Text string `xml:",chardata"`
+		} `xml:"lowColor"`
+		MidColor struct {
+			Text string `xml:",chardata"`
+		} `xml:"midColor"`
+	} `xml:"colorRanges"`
+	Columns []struct {
+		AggregateTypes *struct {
+			Text string `xml:",chardata"`
+		} `xml:"aggregateTypes"`
 		Field struct {
 			Text string `xml:",chardata"`
 		} `xml:"field"`
-		SortOrder struct {
-			Text string `xml:",chardata"`
-		} `xml:"sortOrder"`
-	} `xml:"groupingsAcross"`
-	Buckets struct {
-		BucketType struct {
-			Text string `xml:",chardata"`
-		} `xml:"bucketType"`
-		DeveloperName struct {
-			Text string `xml:",chardata"`
-		} `xml:"developerName"`
-		MasterLabel struct {
-			Text string `xml:",chardata"`
-		} `xml:"masterLabel"`
-		NullTreatment struct {
-			Text string `xml:",chardata"`
-		} `xml:"nullTreatment"`
-		SourceColumnName struct {
-			Text string `xml:",chardata"`
-		} `xml:"sourceColumnName"`
-		UseOther struct {
-			Text string `xml:",chardata"`
-		} `xml:"useOther"`
-		Values []struct {
-			SourceValues []struct {
-				SourceValue struct {
-					Text string `xml:",chardata"`
-				} `xml:"sourceValue"`
-			} `xml:"sourceValues"`
-			Value struct {
-				Text string `xml:",chardata"`
-			} `xml:"value"`
-		} `xml:"values"`
-		OtherBucketLabel struct {
-			Text string `xml:",chardata"`
-		} `xml:"otherBucketLabel"`
-	} `xml:"buckets"`
-	CustomDetailFormulas struct {
-		CalculatedFormula struct {
-			Text string `xml:",chardata"`
-		} `xml:"calculatedFormula"`
-		DataType struct {
-			Text string `xml:",chardata"`
-		} `xml:"dataType"`
-		DeveloperName struct {
-			Text string `xml:",chardata"`
-		} `xml:"developerName"`
-		Label struct {
-			Text string `xml:",chardata"`
-		} `xml:"label"`
-		Scale struct {
-			Text string `xml:",chardata"`
-		} `xml:"scale"`
-	} `xml:"customDetailFormulas"`
-	CrossFilters struct {
+	} `xml:"columns"`
+	CrossFilters []struct {
 		Operation struct {
 			Text string `xml:",chardata"`
 		} `xml:"operation"`
@@ -267,71 +200,142 @@ type Report struct {
 			Text string `xml:",chardata"`
 		} `xml:"relatedTableJoinColumn"`
 	} `xml:"crossFilters"`
-	Aggregates []struct {
+	CustomDetailFormulas []struct {
 		CalculatedFormula struct {
 			Text string `xml:",chardata"`
 		} `xml:"calculatedFormula"`
-		Datatype struct {
+		DataType struct {
 			Text string `xml:",chardata"`
-		} `xml:"datatype"`
+		} `xml:"dataType"`
+		Description *struct {
+			Text string `xml:",chardata"`
+		} `xml:"description"`
 		DeveloperName struct {
 			Text string `xml:",chardata"`
 		} `xml:"developerName"`
-		IsActive struct {
+		Label struct {
 			Text string `xml:",chardata"`
-		} `xml:"isActive"`
-		IsCrossBlock struct {
-			Text string `xml:",chardata"`
-		} `xml:"isCrossBlock"`
-		MasterLabel struct {
-			Text string `xml:",chardata"`
-		} `xml:"masterLabel"`
+		} `xml:"label"`
 		Scale struct {
 			Text string `xml:",chardata"`
 		} `xml:"scale"`
-		AcrossGroupingContext struct {
+	} `xml:"customDetailFormulas"`
+	Description *TextLiteral `xml:"description"`
+	Filter      *struct {
+		BooleanFilter *struct {
 			Text string `xml:",chardata"`
-		} `xml:"acrossGroupingContext"`
-		DownGroupingContext struct {
-			Text string `xml:",chardata"`
-		} `xml:"downGroupingContext"`
-	} `xml:"aggregates"`
-	ColorRanges struct {
-		ColumnName struct {
-			Text string `xml:",chardata"`
-		} `xml:"columnName"`
-		HighColor struct {
-			Text string `xml:",chardata"`
-		} `xml:"highColor"`
-		LowBreakpoint struct {
-			Text string `xml:",chardata"`
-		} `xml:"lowBreakpoint"`
-		LowColor struct {
-			Text string `xml:",chardata"`
-		} `xml:"lowColor"`
-		MidColor struct {
-			Text string `xml:",chardata"`
-		} `xml:"midColor"`
-		HighBreakpoint struct {
-			Text string `xml:",chardata"`
-		} `xml:"highBreakpoint"`
-	} `xml:"colorRanges"`
-	FormattingRules struct {
+		} `xml:"booleanFilter"`
+		CriteriaItems []struct {
+			Column struct {
+				Text string `xml:",chardata"`
+			} `xml:"column"`
+			ColumnToColumn struct {
+				Text string `xml:",chardata"`
+			} `xml:"columnToColumn"`
+			IsUnlocked struct {
+				Text string `xml:",chardata"`
+			} `xml:"isUnlocked"`
+			Operator struct {
+				Text string `xml:",chardata"`
+			} `xml:"operator"`
+			Value struct {
+				Text string `xml:",chardata"`
+			} `xml:"value"`
+		} `xml:"criteriaItems"`
+	} `xml:"filter"`
+	Format struct {
+		Text string `xml:",chardata"`
+	} `xml:"format"`
+	FormattingRules []struct {
 		ColumnName struct {
 			Text string `xml:",chardata"`
 		} `xml:"columnName"`
 		Values []struct {
-			RangeUpperBound struct {
-				Text string `xml:",chardata"`
-			} `xml:"rangeUpperBound"`
-			BackgroundColor struct {
+			BackgroundColor *struct {
 				Text string `xml:",chardata"`
 			} `xml:"backgroundColor"`
+			RangeUpperBound *struct {
+				Text string `xml:",chardata"`
+			} `xml:"rangeUpperBound"`
 		} `xml:"values"`
 	} `xml:"formattingRules"`
-	RoleHierarchyFilter struct {
+	GroupingsAcross []struct {
+		DateGranularity *struct {
+			Text string `xml:",chardata"`
+		} `xml:"dateGranularity"`
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		SortOrder struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortOrder"`
+	} `xml:"groupingsAcross"`
+	GroupingsDown []struct {
+		AggregateType *struct {
+			Text string `xml:",chardata"`
+		} `xml:"aggregateType"`
+		DateGranularity *struct {
+			Text string `xml:",chardata"`
+		} `xml:"dateGranularity"`
+		Field struct {
+			Text string `xml:",chardata"`
+		} `xml:"field"`
+		SortByName *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortByName"`
+		SortOrder struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortOrder"`
+		SortType *struct {
+			Text string `xml:",chardata"`
+		} `xml:"sortType"`
+	} `xml:"groupingsDown"`
+	Name struct {
+		Text string `xml:",chardata"`
+	} `xml:"name"`
+	Params []struct {
+		Name struct {
+			Text string `xml:",chardata"`
+		} `xml:"name"`
+		Value struct {
+			Text string `xml:",chardata"`
+		} `xml:"value"`
+	} `xml:"params"`
+	ReportType struct {
+		Text string `xml:",chardata"`
+	} `xml:"reportType"`
+	RoleHierarchyFilter []struct {
 		Text string `xml:",chardata"`
 	} `xml:"roleHierarchyFilter"`
+	Scope *struct {
+		Text string `xml:",chardata"`
+	} `xml:"scope"`
+	ShowDetails struct {
+		Text string `xml:",chardata"`
+	} `xml:"showDetails"`
+	ShowGrandTotal struct {
+		Text string `xml:",chardata"`
+	} `xml:"showGrandTotal"`
+	ShowSubTotals struct {
+		Text string `xml:",chardata"`
+	} `xml:"showSubTotals"`
+	SortColumn *struct {
+		Text string `xml:",chardata"`
+	} `xml:"sortColumn"`
+	SortOrder *struct {
+		Text string `xml:",chardata"`
+	} `xml:"sortOrder"`
+	TimeFrameFilter struct {
+		DateColumn struct {
+			Text string `xml:",chardata"`
+		} `xml:"dateColumn"`
+		Interval struct {
+			Text string `xml:",chardata"`
+		} `xml:"interval"`
+		StartDate *struct {
+			Text string `xml:",chardata"`
+		} `xml:"startDate"`
+	} `xml:"timeFrameFilter"`
 }
 
 func (c *Report) SetMetadata(m metadata.MetadataInfo) {
@@ -340,6 +344,60 @@ func (c *Report) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *Report) Type() metadata.MetadataType {
 	return NAME
+}
+
+func (c *Report) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the original path from metadata info
+	originalPath := string(c.MetadataInfo.Path())
+
+	// Extract the folder structure from the original path
+	// e.g., reports/CRM_Admin_Exception_Reports/SystemAdminExceptionDashboard/Accounts_For_Merging_DSj.report-meta.xml
+	// Should preserve: CRM_Admin_Exception_Reports/SystemAdminExceptionDashboard/Accounts_For_Merging_DSj
+
+	// Get the directory name for reports
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Get relative path within the reports directory
+	var relativePath string
+	if strings.Contains(originalPath, "reports/") {
+		// Extract everything after "reports/"
+		parts := strings.Split(originalPath, "reports/")
+		if len(parts) > 1 {
+			relativePath = parts[1]
+		}
+	}
+
+	if relativePath == "" {
+		return nil, fmt.Errorf("could not extract report path from %s", originalPath)
+	}
+
+	// Remove the file extension and -meta.xml suffix to get the clean relative path
+	relativePath = strings.TrimSuffix(relativePath, "-meta.xml")
+	relativePath = strings.TrimSuffix(relativePath, ".report")
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal report metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	var fileName string
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: preserve folder structure and add -meta.xml suffix
+		fileName = relativePath + ".report-meta.xml"
+	case metadata.MetadataFormat:
+		// Metadata format: preserve folder structure, no -meta.xml suffix
+		fileName = relativePath + ".report"
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	files[filepath.Join(dirName, fileName)] = xmlContent
+
+	return files, nil
 }
 
 func Open(path string) (*Report, error) {

--- a/metadata/role/role.go
+++ b/metadata/role/role.go
@@ -23,7 +23,7 @@ type Role struct {
 	ContactAccessLevel struct {
 		Text string `xml:",chardata"`
 	} `xml:"contactAccessLevel"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 	MayForecastManagerShare struct {
@@ -35,7 +35,7 @@ type Role struct {
 	OpportunityAccessLevel struct {
 		Text string `xml:",chardata"`
 	} `xml:"opportunityAccessLevel"`
-	ParentRole struct {
+	ParentRole *struct {
 		Text string `xml:",chardata"`
 	} `xml:"parentRole"`
 }

--- a/metadata/standardvalueset/standardvalueset.go
+++ b/metadata/standardvalueset/standardvalueset.go
@@ -24,37 +24,37 @@ type StandardValue struct {
 	Label struct {
 		Text string `xml:",chardata"`
 	} `xml:"label"`
-	CssExposed struct {
+	CssExposed *struct {
 		Text string `xml:",chardata"`
 	} `xml:"cssExposed"`
-	Closed struct {
+	Closed *struct {
 		Text string `xml:",chardata"`
 	} `xml:"closed"`
-	GroupingString struct {
+	GroupingString *struct {
 		Text string `xml:",chardata"`
 	} `xml:"groupingString"`
-	Converted struct {
+	Converted *struct {
 		Text string `xml:",chardata"`
 	} `xml:"converted"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
-	ForecastCategory struct {
+	ForecastCategory *struct {
 		Text string `xml:",chardata"`
 	} `xml:"forecastCategory"`
-	Probability struct {
+	Probability *struct {
 		Text string `xml:",chardata"`
 	} `xml:"probability"`
-	Won struct {
+	Won *struct {
 		Text string `xml:",chardata"`
 	} `xml:"won"`
-	ReverseRole struct {
+	ReverseRole *struct {
 		Text string `xml:",chardata"`
 	} `xml:"reverseRole"`
-	AllowEmail struct {
+	AllowEmail *struct {
 		Text string `xml:",chardata"`
 	} `xml:"allowEmail"`
-	HighPriority struct {
+	HighPriority *struct {
 		Text string `xml:",chardata"`
 	} `xml:"highPriority"`
 }
@@ -67,7 +67,7 @@ type StandardValueSet struct {
 		Text string `xml:",chardata"`
 	} `xml:"sorted"`
 	StandardValue      []StandardValue `xml:"standardValue"`
-	GroupingStringEnum struct {
+	GroupingStringEnum *struct {
 		Text string `xml:",chardata"`
 	} `xml:"groupingStringEnum"`
 }

--- a/metadata/staticresources/staticresource.go
+++ b/metadata/staticresources/staticresource.go
@@ -1,10 +1,19 @@
 package staticresource
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "StaticResource"
@@ -16,14 +25,14 @@ func init() {
 type StaticResource struct {
 	metadata.MetadataInfo
 	XMLName      xml.Name `xml:"StaticResource"`
-	Xmlns        string   `xml:"xmlns,attr"`
+	Xmlns        *string  `xml:"xmlns,attr"`
 	CacheControl struct {
 		Text string `xml:",chardata"`
 	} `xml:"cacheControl"`
 	ContentType struct {
 		Text string `xml:",chardata"`
 	} `xml:"contentType"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 }
@@ -34,6 +43,164 @@ func (c *StaticResource) SetMetadata(m metadata.MetadataInfo) {
 
 func (c *StaticResource) Type() metadata.MetadataType {
 	return NAME
+}
+
+// zipDirectory creates a zip archive from a directory
+func zipDirectory(dirPath string) ([]byte, error) {
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+	defer zipWriter.Close()
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get the relative path from the base directory
+		relPath, err := filepath.Rel(dirPath, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip the root directory itself
+		if relPath == "." {
+			return nil
+		}
+
+		// Create header
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relPath)
+
+		// Write header
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		// If it's a directory, we're done
+		if info.IsDir() {
+			return nil
+		}
+
+		// If it's a file, write its contents
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(writer, file)
+		return err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Close the zip writer to flush any remaining data
+	if err := zipWriter.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c *StaticResource) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the resource name from metadata
+	resourceName := c.MetadataInfo.Name()
+	if resourceName == "" {
+		return nil, fmt.Errorf("resource name is empty")
+	}
+
+	// Get the directory name for static resources
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Marshal the metadata to XML using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal static resource metadata: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	// Get the original path from metadata info to find the resource file
+	originalPath := string(c.MetadataInfo.Path())
+	metadataDir := filepath.Dir(originalPath)
+
+	// Try to find and read the resource content
+	var resourceContent []byte
+
+	// First check if there's a directory with the resource name (unzipped static resource in SFDX)
+	resourceDirPath := filepath.Join(metadataDir, string(resourceName))
+	if info, err := os.Stat(resourceDirPath); err == nil && info.IsDir() {
+		// It's a directory - we need to zip it for metadata format
+		if format == metadata.MetadataFormat {
+			zipContent, err := zipDirectory(resourceDirPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to zip directory %s: %w", resourceDirPath, err)
+			}
+			resourceContent = zipContent
+		}
+		// For source format, we would need to handle directory copying differently
+		// but that's not typically how static resources work in source format
+	} else {
+		// Try to find .resource file
+		resourcePath := filepath.Join(metadataDir, string(resourceName)+".resource")
+		if content, err := ioutil.ReadFile(resourcePath); err == nil {
+			resourceContent = content
+		} else {
+			// If .resource doesn't exist, look for the actual file with its real extension
+			// Static resources in SFDX format can have their actual extensions (.css, .js, .zip, etc.)
+			dirFiles, dirErr := ioutil.ReadDir(metadataDir)
+			if dirErr == nil {
+				for _, file := range dirFiles {
+					if file.IsDir() {
+						continue
+					}
+					fileName := file.Name()
+					// Look for files that start with the resource name but aren't metadata files
+					if strings.HasPrefix(fileName, string(resourceName)) &&
+						!strings.HasSuffix(fileName, "-meta.xml") &&
+						!strings.HasSuffix(fileName, ".resource-meta.xml") {
+						// Found a potential resource file
+						fullPath := filepath.Join(metadataDir, fileName)
+						if content, err := ioutil.ReadFile(fullPath); err == nil {
+							resourceContent = content
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	switch format {
+	case metadata.SourceFormat:
+		// Source format: .resource-meta.xml for metadata
+		files[filepath.Join(dirName, string(resourceName)+".resource-meta.xml")] = xmlContent
+
+		// Add the resource content if we found it
+		if resourceContent != nil {
+			files[filepath.Join(dirName, string(resourceName)+".resource")] = resourceContent
+		}
+
+	case metadata.MetadataFormat:
+		// Metadata format: .resource-meta.xml for metadata (same as source format)
+		files[filepath.Join(dirName, string(resourceName)+".resource-meta.xml")] = xmlContent
+
+		// Add the resource content if we found it
+		if resourceContent != nil {
+			files[filepath.Join(dirName, string(resourceName)+".resource")] = resourceContent
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+
+	return files, nil
 }
 
 func Open(path string) (*StaticResource, error) {

--- a/metadata/staticresources/staticresource_test.go
+++ b/metadata/staticresources/staticresource_test.go
@@ -1,0 +1,201 @@
+package staticresource
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ForceCLI/force-md/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticResourceFiles(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceName  string
+		contentFile   string
+		contentData   string
+		expectedFiles int
+		format        metadata.Format
+	}{
+		{
+			name:          "CSS file with .resource extension",
+			resourceName:  "TestStyle",
+			contentFile:   "TestStyle.resource",
+			contentData:   ".test { color: red; }",
+			expectedFiles: 2,
+			format:        metadata.MetadataFormat,
+		},
+		{
+			name:          "CSS file with actual .css extension",
+			resourceName:  "TestStyle",
+			contentFile:   "TestStyle.css",
+			contentData:   ".test { color: blue; }",
+			expectedFiles: 2,
+			format:        metadata.SourceFormat,
+		},
+		{
+			name:          "JavaScript file with .js extension",
+			resourceName:  "TestScript",
+			contentFile:   "TestScript.js",
+			contentData:   "console.log('test');",
+			expectedFiles: 2,
+			format:        metadata.SourceFormat,
+		},
+		{
+			name:          "ZIP file with .zip extension",
+			resourceName:  "TestArchive",
+			contentFile:   "TestArchive.zip",
+			contentData:   "PK\x03\x04", // ZIP file header
+			expectedFiles: 2,
+			format:        metadata.MetadataFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir, err := ioutil.TempDir("", "staticresource-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			// Create metadata file
+			metadataPath := filepath.Join(tmpDir, tt.resourceName+".resource-meta.xml")
+			metadataContent := `<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Public</cacheControl>
+    <contentType>text/css</contentType>
+</StaticResource>`
+			err = ioutil.WriteFile(metadataPath, []byte(metadataContent), 0644)
+			require.NoError(t, err)
+
+			// Create content file
+			contentPath := filepath.Join(tmpDir, tt.contentFile)
+			err = ioutil.WriteFile(contentPath, []byte(tt.contentData), 0644)
+			require.NoError(t, err)
+
+			// Open and parse the static resource
+			sr, err := Open(metadataPath)
+			require.NoError(t, err)
+
+			// Get files
+			files, err := sr.Files(tt.format)
+			require.NoError(t, err)
+
+			// Verify we got the expected number of files
+			assert.Equal(t, tt.expectedFiles, len(files))
+
+			// Verify metadata file exists
+			foundMetadata := false
+			foundContent := false
+			for path, content := range files {
+				if filepath.Ext(path) == ".xml" {
+					foundMetadata = true
+					assert.Contains(t, string(content), "StaticResource")
+				} else if filepath.Ext(path) == ".resource" {
+					foundContent = true
+					assert.Equal(t, tt.contentData, string(content))
+				}
+			}
+
+			assert.True(t, foundMetadata, "Should have metadata file")
+			assert.True(t, foundContent, "Should have content file")
+		})
+	}
+}
+
+func TestStaticResourceNoContent(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := ioutil.TempDir("", "staticresource-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create only metadata file, no content
+	metadataPath := filepath.Join(tmpDir, "NoContent.resource-meta.xml")
+	metadataContent := `<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/octet-stream</contentType>
+</StaticResource>`
+	err = ioutil.WriteFile(metadataPath, []byte(metadataContent), 0644)
+	require.NoError(t, err)
+
+	// Open and parse the static resource
+	sr, err := Open(metadataPath)
+	require.NoError(t, err)
+
+	// Get files for metadata format
+	files, err := sr.Files(metadata.MetadataFormat)
+	require.NoError(t, err)
+
+	// Should only have metadata file when no content exists
+	assert.Equal(t, 1, len(files))
+
+	// Verify it's the metadata file
+	for path, content := range files {
+		assert.True(t, filepath.Ext(path) == ".xml")
+		assert.Contains(t, string(content), "StaticResource")
+	}
+}
+
+func TestStaticResourceDirectory(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := ioutil.TempDir("", "staticresource-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create metadata file
+	metadataPath := filepath.Join(tmpDir, "FontAwesome.resource-meta.xml")
+	metadataContent := `<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Public</cacheControl>
+    <contentType>application/zip</contentType>
+</StaticResource>`
+	err = ioutil.WriteFile(metadataPath, []byte(metadataContent), 0644)
+	require.NoError(t, err)
+
+	// Create a directory structure that represents an unzipped static resource
+	resourceDir := filepath.Join(tmpDir, "FontAwesome")
+	require.NoError(t, os.MkdirAll(filepath.Join(resourceDir, "css"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(resourceDir, "fonts"), 0755))
+
+	// Add some files to the directory
+	cssContent := "body { font-family: FontAwesome; }"
+	err = ioutil.WriteFile(filepath.Join(resourceDir, "css", "font-awesome.css"), []byte(cssContent), 0644)
+	require.NoError(t, err)
+
+	fontContent := "binary font data"
+	err = ioutil.WriteFile(filepath.Join(resourceDir, "fonts", "fontawesome.woff"), []byte(fontContent), 0644)
+	require.NoError(t, err)
+
+	// Open and parse the static resource
+	sr, err := Open(metadataPath)
+	require.NoError(t, err)
+
+	// Get files for metadata format (should zip the directory)
+	files, err := sr.Files(metadata.MetadataFormat)
+	require.NoError(t, err)
+
+	// Should have metadata and zipped content
+	assert.Equal(t, 2, len(files))
+
+	// Verify we have both files
+	foundMetadata := false
+	foundZip := false
+	for path, content := range files {
+		if filepath.Ext(path) == ".xml" {
+			foundMetadata = true
+			assert.Contains(t, string(content), "StaticResource")
+		} else if filepath.Ext(path) == ".resource" {
+			foundZip = true
+			// Verify it's a valid zip file by checking for ZIP header
+			assert.True(t, len(content) > 4)
+			assert.Equal(t, []byte("PK"), content[0:2], "Should be a valid ZIP file")
+		}
+	}
+
+	assert.True(t, foundMetadata, "Should have metadata file")
+	assert.True(t, foundZip, "Should have zipped resource file")
+}

--- a/metadata/tabs/tab.go
+++ b/metadata/tabs/tab.go
@@ -17,40 +17,40 @@ type CustomTab struct {
 	metadata.MetadataInfo
 	XMLName      xml.Name `xml:"CustomTab"`
 	Xmlns        string   `xml:"xmlns,attr"`
-	CustomObject struct {
+	CustomObject *struct {
 		Text string `xml:",chardata"`
 	} `xml:"customObject"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
+	FlexiPage *struct {
+		Text string `xml:",chardata"`
+	} `xml:"flexiPage"`
+	FrameHeight *struct {
+		Text string `xml:",chardata"`
+	} `xml:"frameHeight"`
+	HasSidebar *struct {
+		Text string `xml:",chardata"`
+	} `xml:"hasSidebar"`
+	Icon *struct {
+		Text string `xml:",chardata"`
+	} `xml:"icon"`
+	Label *struct {
+		Text string `xml:",chardata"`
+	} `xml:"label"`
+	LwcComponent *struct {
+		Text string `xml:",chardata"`
+	} `xml:"lwcComponent"`
 	Motif struct {
 		Text string `xml:",chardata"`
 	} `xml:"motif"`
-	Label struct {
-		Text string `xml:",chardata"`
-	} `xml:"label"`
-	Page struct {
+	Page *struct {
 		Text string `xml:",chardata"`
 	} `xml:"page"`
-	FlexiPage struct {
-		Text string `xml:",chardata"`
-	} `xml:"flexiPage"`
-	Icon struct {
-		Text string `xml:",chardata"`
-	} `xml:"icon"`
-	LwcComponent struct {
-		Text string `xml:",chardata"`
-	} `xml:"lwcComponent"`
-	FrameHeight struct {
-		Text string `xml:",chardata"`
-	} `xml:"frameHeight"`
-	HasSidebar struct {
-		Text string `xml:",chardata"`
-	} `xml:"hasSidebar"`
-	URL struct {
+	URL *struct {
 		Text string `xml:",chardata"`
 	} `xml:"url"`
-	UrlEncodingKey struct {
+	UrlEncodingKey *struct {
 		Text string `xml:",chardata"`
 	} `xml:"urlEncodingKey"`
 }

--- a/metadata/triggers/trigger.go
+++ b/metadata/triggers/trigger.go
@@ -2,9 +2,12 @@ package trigger
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const NAME = "ApexTrigger"
@@ -20,10 +23,7 @@ type ApexTrigger struct {
 	ApiVersion struct {
 		Text string `xml:",chardata"`
 	} `xml:"apiVersion"`
-	Status struct {
-		Text string `xml:",chardata"`
-	} `xml:"status"`
-	PackageVersions struct {
+	PackageVersions []struct {
 		MajorNumber struct {
 			Text string `xml:",chardata"`
 		} `xml:"majorNumber"`
@@ -34,6 +34,13 @@ type ApexTrigger struct {
 			Text string `xml:",chardata"`
 		} `xml:"namespace"`
 	} `xml:"packageVersions"`
+	Status struct {
+		Text string `xml:",chardata"`
+	} `xml:"status"`
+
+	// Non-XML field to store the actual trigger code
+	SourceCode []byte `xml:"-"`
+	SourcePath string `xml:"-"`
 }
 
 func (c *ApexTrigger) SetMetadata(m metadata.MetadataInfo) {
@@ -44,7 +51,44 @@ func (c *ApexTrigger) Type() metadata.MetadataType {
 	return NAME
 }
 
+func (c *ApexTrigger) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the trigger name from metadata
+	triggerName := c.MetadataInfo.Name()
+	if triggerName == "" {
+		return nil, fmt.Errorf("trigger name is empty")
+	}
+
+	// Get the directory name for triggers
+	dirName := registry.GetCanonicalDirectoryName(NAME)
+
+	// Load source code if we haven't already
+	if c.SourceCode == nil {
+		c.SourceCode = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".trigger")
+	}
+
+	// Marshal the XML metadata using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal trigger metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for ApexTrigger
+		return helpers.GenerateMetadataFilePaths(dirName, string(triggerName), ".trigger-meta.xml", ".trigger", xmlContent, c.SourceCode), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func Open(path string) (*ApexTrigger, error) {
 	p := &ApexTrigger{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated code files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/wave/dataflow.go
+++ b/metadata/wave/dataflow.go
@@ -2,9 +2,12 @@ package wave
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const DATA_FLOW_NAME = "WaveDataflow"
@@ -15,24 +18,28 @@ func init() {
 
 type WaveDataflow struct {
 	metadata.MetadataInfo
-	XMLName xml.Name `xml:"WaveDataflow"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	Xsi     string   `xml:"xsi,attr"`
+	XMLName     xml.Name `xml:"WaveDataflow"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Xsi         string   `xml:"xsi,attr"`
+	Application *struct {
+		Text string `xml:",chardata"`
+	} `xml:"application"`
 	Content struct {
 		Nil string `xml:"nil,attr"`
 	} `xml:"content"`
 	DataflowType struct {
 		Text string `xml:",chardata"`
 	} `xml:"dataflowType"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
 	MasterLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
-	Application struct {
-		Text string `xml:",chardata"`
-	} `xml:"application"`
+
+	// Non-XML fields to store the actual dataflow content
+	SourceContent []byte `xml:"-"`
+	SourcePath    string `xml:"-"`
 }
 
 func (c *WaveDataflow) SetMetadata(m metadata.MetadataInfo) {
@@ -43,7 +50,44 @@ func (c *WaveDataflow) Type() metadata.MetadataType {
 	return DATA_FLOW_NAME
 }
 
+func (c *WaveDataflow) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the dataflow name from metadata
+	dataflowName := c.MetadataInfo.Name()
+	if dataflowName == "" {
+		return nil, fmt.Errorf("dataflow name is empty")
+	}
+
+	// Get the directory name for wave dataflows
+	dirName := registry.GetCanonicalDirectoryName(DATA_FLOW_NAME)
+
+	// Load source content if we haven't already
+	if c.SourceContent == nil {
+		c.SourceContent = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".wdf")
+	}
+
+	// Marshal the XML metadata using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dataflow metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for WaveDataflow
+		return helpers.GenerateMetadataFilePaths(dirName, string(dataflowName), ".wdf-meta.xml", ".wdf", xmlContent, c.SourceContent), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func OpenDataflow(path string) (*WaveDataflow, error) {
 	p := &WaveDataflow{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated content files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/wave/dataset.go
+++ b/metadata/wave/dataset.go
@@ -2,9 +2,12 @@ package wave
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const DATA_SET_NAME = "WaveDataset"
@@ -23,15 +26,19 @@ type WaveDataset struct {
 	MasterLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
-	Description struct {
+	Description *struct {
 		Text string `xml:",chardata"`
 	} `xml:"description"`
-	DatasetType struct {
+	DatasetType *struct {
 		Text string `xml:",chardata"`
 	} `xml:"type"`
-	TemplateAssetSourceName struct {
+	TemplateAssetSourceName *struct {
 		Text string `xml:",chardata"`
 	} `xml:"templateAssetSourceName"`
+
+	// Fields for handling companion files
+	SourcePath    string `xml:"-"`
+	SourceContent []byte `xml:"-"`
 }
 
 func (c *WaveDataset) SetMetadata(m metadata.MetadataInfo) {
@@ -42,7 +49,44 @@ func (c *WaveDataset) Type() metadata.MetadataType {
 	return DATA_SET_NAME
 }
 
+func (c *WaveDataset) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the dataset name from metadata
+	datasetName := c.MetadataInfo.Name()
+	if datasetName == "" {
+		return nil, fmt.Errorf("dataset name is empty")
+	}
+
+	// Get the directory name for wave datasets
+	dirName := registry.GetCanonicalDirectoryName(DATA_SET_NAME)
+
+	// Load source content if we haven't already
+	if c.SourceContent == nil {
+		c.SourceContent = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".wds")
+	}
+
+	// Marshal the XML metadata using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dataset metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for WaveDataset
+		return helpers.GenerateMetadataFilePaths(dirName, string(datasetName), ".wds-meta.xml", ".wds", xmlContent, c.SourceContent), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func OpenDataset(path string) (*WaveDataset, error) {
 	p := &WaveDataset{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated content files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/metadata/wave/recipe.go
+++ b/metadata/wave/recipe.go
@@ -2,9 +2,12 @@ package wave
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	"github.com/ForceCLI/force-md/internal"
 	"github.com/ForceCLI/force-md/metadata"
+	"github.com/ForceCLI/force-md/metadata/helpers"
+	"github.com/ForceCLI/force-md/registry"
 )
 
 const RECIPE_NAME = "WaveRecipe"
@@ -30,6 +33,10 @@ type WaveRecipe struct {
 	MasterLabel struct {
 		Text string `xml:",chardata"`
 	} `xml:"masterLabel"`
+
+	// Fields for handling companion files
+	SourcePath    string `xml:"-"`
+	SourceContent []byte `xml:"-"`
 }
 
 func (c *WaveRecipe) SetMetadata(m metadata.MetadataInfo) {
@@ -40,7 +47,44 @@ func (c *WaveRecipe) Type() metadata.MetadataType {
 	return RECIPE_NAME
 }
 
+func (c *WaveRecipe) Files(format metadata.Format) (map[string][]byte, error) {
+	// Get the recipe name from metadata
+	recipeName := c.MetadataInfo.Name()
+	if recipeName == "" {
+		return nil, fmt.Errorf("recipe name is empty")
+	}
+
+	// Get the directory name for wave recipes
+	dirName := registry.GetCanonicalDirectoryName(RECIPE_NAME)
+
+	// Load source content if we haven't already
+	if c.SourceContent == nil {
+		c.SourceContent = helpers.LoadCompanionFile(c.SourcePath, "-meta.xml", ".wdpr")
+	}
+
+	// Marshal the XML metadata using internal.Marshal to get proper formatting
+	xmlContent, err := internal.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal recipe metadata: %w", err)
+	}
+
+	switch format {
+	case metadata.SourceFormat, metadata.MetadataFormat:
+		// Both formats use the same file structure for WaveRecipe
+		return helpers.GenerateMetadataFilePaths(dirName, string(recipeName), ".wdpr-meta.xml", ".wdpr", xmlContent, c.SourceContent), nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %v", format)
+	}
+}
+
 func OpenRecipe(path string) (*WaveRecipe, error) {
 	p := &WaveRecipe{}
-	return p, metadata.ParseMetadataXml(p, path)
+	if err := metadata.ParseMetadataXml(p, path); err != nil {
+		return nil, err
+	}
+
+	// Store the source path - Files() will use this to find associated content files
+	p.SourcePath = path
+
+	return p, nil
 }

--- a/registry/files.go
+++ b/registry/files.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"encoding/xml"
+	"fmt"
+	"path/filepath"
+)
+
+// FilesHelper provides a helper for implementing the Files() method for metadata types
+// that consist of a single XML file without associated code files
+type FilesHelper struct {
+	MetadataType string
+	Name         string
+	Content      interface{} // The metadata struct to marshal
+}
+
+// GenerateFiles generates the files map for a metadata component
+func (h *FilesHelper) GenerateFiles(format string) (map[string][]byte, error) {
+	if h.Name == "" {
+		return nil, fmt.Errorf("metadata name is empty")
+	}
+
+	// Get the directory name
+	dirName := GetCanonicalDirectoryName(h.MetadataType)
+
+	// Get the file suffix
+	suffix := GetMetadataSuffix(h.MetadataType)
+	if suffix == "" {
+		// Default suffix based on type name
+		suffix = h.MetadataType
+	}
+
+	// Marshal the XML content
+	xmlContent, err := xml.MarshalIndent(h.Content, "", "    ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s metadata: %w", h.MetadataType, err)
+	}
+	// Add XML declaration
+	xmlContent = append([]byte(xml.Header), xmlContent...)
+
+	files := make(map[string][]byte)
+
+	// For most metadata types, the file naming is the same for both formats
+	// They all use -meta.xml suffix
+	fileName := h.Name + "." + suffix + "-meta.xml"
+	files[filepath.Join(dirName, fileName)] = xmlContent
+
+	return files, nil
+}

--- a/registry/metadataRegistry.json
+++ b/registry/metadataRegistry.json
@@ -1,0 +1,4955 @@
+{
+  "childTypes": {
+    "aiscoringmodeldefversion": "aiscoringmodeldefinition",
+    "assignmentrule": "assignmentrules",
+    "autoresponserule": "autoresponserules",
+    "botversion": "bot",
+    "businessprocess": "customobject",
+    "compactlayout": "customobject",
+    "customfield": "customobject",
+    "customfieldtranslation": "customobjecttranslation",
+    "customlabel": "customlabels",
+    "digitalexperience": "digitalexperiencebundle",
+    "escalationrule": "escalationrules",
+    "extdatatranfieldtemplate": "extdatatranobjecttemplate",
+    "fieldset": "customobject",
+    "formsection": "form",
+    "index": "customobject",
+    "listview": "customobject",
+    "managedtopic": "managedtopics",
+    "matchingrule": "matchingrules",
+    "mktdatatranfield": "mktdatatranobject",
+    "recordtype": "customobject",
+    "recordtypetranslation": "customobjecttranslation",
+    "sharingcriteriarule": "sharingrules",
+    "sharingguestrule": "sharingrules",
+    "sharingownerrule": "sharingrules",
+    "sharingreason": "customobject",
+    "sharingterritoryrule": "sharingrules",
+    "validationrule": "customobject",
+    "validationruletranslation": "customobjecttranslation",
+    "weblink": "customobject",
+    "workflowalert": "workflow",
+    "workflowfieldupdate": "workflow",
+    "workflowflowaction": "workflow",
+    "workflowknowledgepublish": "workflow",
+    "workflowoutboundmessage": "workflow",
+    "workflowrule": "workflow",
+    "workflowsend": "workflow",
+    "workflowtask": "workflow",
+    "workskillroutingattribute": "workskillrouting"
+  },
+  "strictDirectoryNames": {
+    "ActionableEventOrchDefSettings": "actionableeventorchdef",
+    "ActionableEventTypeDefSettings": "actionableeventtypedef",
+    "IndustriesManufacturingSettings": "industriesmanufacturingsettings",
+    "ObjectHierarchyRelationship": "objecthierarchyrelationship",
+    "accessControlPolicies": "accesscontrolpolicy",
+    "appointmentAssignmentPolicies": "appointmentassignmentpolicy",
+    "appointmentSchedulingPolicies": "appointmentschedulingpolicy",
+    "aura": "auradefinitionbundle",
+    "botBlocks": "botblock",
+    "botTemplates": "bottemplate",
+    "bots": "bot",
+    "contentTypes": "contenttypebundle",
+    "documents": "document",
+    "emailservices": "emailservicesfunction",
+    "experiencePropertyTypeBundles": "experiencepropertytypebundle",
+    "experiences": "experiencebundle",
+    "fieldRestrictionRules": "fieldrestrictionrule",
+    "genAiFunctions": "genaifunction",
+    "genAiPlannerBundles": "genaiplannerbundle",
+    "integrationHub": "integrationhubsettings",
+    "lwc": "lightningcomponentbundle",
+    "mktDataSources": "datasource",
+    "objectTranslations": "customobjecttranslation",
+    "objects": "customobject",
+    "restrictionRules": "restrictionrule",
+    "siteDotComSites": "sitedotcom",
+    "sites": "customsite",
+    "staticresources": "staticresource",
+    "waveTemplates": "wavetemplatebundle",
+    "appTemplates": "appframeworktemplatebundle",
+    "lightningTypes": "lightningtypebundle"
+  },
+  "suffixes": {
+    "Canvas": "canvasmetadata",
+    "CaseSubjectParticle": "casesubjectparticle",
+    "ChannelObjectLinkingRule": "channelobjectlinkingrule",
+    "ChatterExtension": "chatterextension",
+    "ConversationChannelDefinition": "conversationchanneldefinition",
+    "ConversationVendorFieldDefinition": "conversationvendorfielddef",
+    "ConversationVendorInformation": "conversationvendorinfo",
+    "DataPackageKitObject": "datapackagekitobject",
+    "EmbeddedServiceBranding": "embeddedservicebranding",
+    "EmbeddedServiceConfig": "embeddedserviceconfig",
+    "EmbeddedServiceFieldService": "embeddedservicefieldservice",
+    "EmbeddedServiceFlowConfig": "embeddedserviceflowconfig",
+    "EmbeddedServiceLiveAgent": "embeddedserviceliveagent",
+    "EmbeddedServiceMenuSettings": "embeddedservicemenusettings",
+    "IPAddressRange": "ipaddressrange",
+    "IdentityVerificationProcDef": "identityverificationprocdef",
+    "LeadConvertSetting": "leadconvertsettings",
+    "MobileApplicationDetail": "mobileapplicationdetail",
+    "OmniExtTrackingDef": "omniexttrackingdef",
+    "OmniTrackingGroup": "omnitrackinggroup",
+    "RecordAggregationDefinition": "recordaggregationdefinition",
+    "RetrievalSummaryDefinition": "retrievalsummarydefinition",
+    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration",
+    "SearchableObjDataSyncInfoSetting": "searchableobjdatasyncinfo",
+    "accountForecastSetting": "accountforecastsettings",
+    "accountRelationshipShareRule": "accountrelationshipsharerule",
+    "accountingFieldMapping": "accountingfieldmapping",
+    "accountingModelConfig": "accountingmodelconfig",
+    "acctMgrTargetSetting": "acctmgrtargetsettings",
+    "actionLauncherItemDef": "actionlauncheritemdef",
+    "actionLinkGroupTemplate": "actionlinkgrouptemplate",
+    "actionableListDefinition": "actionablelistdefinition",
+    "activationPlatform": "activationplatform",
+    "actnblListKeyPrfmIndDef": "actnbllistkeyprfminddef",
+    "advAccountForecastSet": "advaccountforecastset",
+    "advAcctForecastDimSource": "advacctforecastdimsource",
+    "advAcctForecastPeriodGroup": "advacctforecastperiodgroup",
+    "affinityScoreDefinition": "affinityscoredefinition",
+    "ai": "aiapplication",
+    "aiAssistantTemplate": "aiassistanttemplate",
+    "aiScoringModelDefVersion": "aiscoringmodeldefversion",
+    "aiScoringModelDefinition": "aiscoringmodeldefinition",
+    "aiUsecaseDefinitions": "aiusecasedefinition",
+    "aiapplicationconfig": "aiapplicationconfig",
+    "animationRule": "animationrule",
+    "app": "customapplication",
+    "appMenu": "appmenu",
+    "applicationRecordTypeConfig": "applicationrecordtypeconfig",
+    "applicationSubtypeDefinition": "applicationsubtypedefinition",
+    "approvalProcess": "approvalprocess",
+    "apt": "actionplantemplate",
+    "aq": "assessmentquestion",
+    "aqs": "assessmentquestionset",
+    "assessmentConfiguration": "assessmentconfiguration",
+    "asset": "contentasset",
+    "assignmentRule": "assignmentrule",
+    "assignmentRules": "assignmentrules",
+    "assistantContextItem": "assistantcontextitem",
+    "assistantDefinition": "assistantdefinition",
+    "assistantRecommendationType": "assistantrecommendationtype",
+    "assistantSkillQuickAction": "assistantskillquickaction",
+    "assistantSkillSobjectAction": "assistantskillsobjectaction",
+    "assistantVersion": "assistantversion",
+    "audience": "audience",
+    "authprovider": "authprovider",
+    "autoResponseRule": "autoresponserule",
+    "autoResponseRules": "autoresponserules",
+    "batchCalcJobDefinition": "batchcalcjobdefinition",
+    "batchProcessJobDefinition": "batchprocessjobdefinition",
+    "benefitAction": "benefitaction",
+    "blacklistedConsumer": "blacklistedconsumer",
+    "bot": "bot",
+    "botBlock": "botblock",
+    "botTemplate": "bottemplate",
+    "botVersion": "botversion",
+    "brandingSet": "brandingset",
+    "briefcaseDefinition": "briefcasedefinition",
+    "buildingEnergyIntensityConfig": "bldgenrgyintensitycnfg",
+    "businessProcessFeedbackConfiguration": "businessprocessfeedbackconfiguration",
+    "businessProcessGroup": "businessprocessgroup",
+    "businessProcessTypeDefinition": "businessprocesstypedefinition",
+    "cachePartition": "platformcachepartition",
+    "callCenter": "callcenter",
+    "callCenterRoutingMap": "callcenterroutingmap",
+    "callCoachingMediaProvider": "callcoachingmediaprovider",
+    "callCtrAgentFavTrfrDest": "callctragentfavtrfrdest",
+    "campaignInfluenceModel": "campaigninfluencemodel",
+    "careBenefitVerifySettings": "carebenefitverifysettings",
+    "careLimitType": "carelimittype",
+    "careProviderAfflRoleConfig": "careproviderafflroleconfig",
+    "careProviderSearchConfig": "careprovidersearchconfig",
+    "careRequestConfiguration": "carerequestconfiguration",
+    "careSystemFieldMapping": "caresystemfieldmapping",
+    "catalogedApi": "catalogedapi",
+    "catalogedApiVersion": "catalogedapiversion",
+    "catalogedApiArtifactVersionInfo": "catalogedapiartifactversioninfo",
+    "catalogFilterCondition": "svccatalogfiltercondition",
+    "catalogFilterCriteria": "svccatalogfiltercriteria",
+    "catalogItem": "svccatalogitemdef",
+    "catalogItemDefFiltrCrit": "svccatalogitemdeffiltrcrit",
+    "category": "svccatalogcategory",
+    "channelLayout": "channellayout",
+    "clauseCatgConfiguration": "clausecatgconfiguration",
+    "cleanDataService": "cleandataservice",
+    "cls": "apexclass",
+    "cmsConnectSource": "cmsconnectsource",
+    "collection": "waveanalyticassetcollection",
+    "commandaction": "commandaction",
+    "community": "community",
+    "communityTemplateDefinition": "communitytemplatedefinition",
+    "communityThemeDefinition": "communitythemedefinition",
+    "component": "apexcomponent",
+    "config": "notificationtypeconfig",
+    "connectedApp": "connectedapp",
+    "contextDefinition": "contextdefinition",
+    "contextUseCaseMapping": "contextusecasemapping",
+    "contractType": "contracttype",
+    "conversationMessageDefinition": "conversationmessagedefinition",
+    "corsWhitelistOrigin": "corswhitelistorigin",
+    "crt": "certificate",
+    "cspTrustedSite": "csptrustedsite",
+    "customApplicationComponent": "customapplicationcomponent",
+    "customExperience": "customexperience",
+    "customHelpMenuSection": "customhelpmenusection",
+    "customPermission": "custompermission",
+    "custompageweblink": "custompageweblink",
+    "dashboard": "dashboard",
+    "dashboardFolder": "dashboardfolder",
+    "dataCalcInsightTemplate": "datacalcinsighttemplate",
+    "dataconnector": "dataconnector",
+    "dataConnectorIngestApi": "dataconnectoringestapi",
+    "dataKitObjectDependency": "datakitobjectdependency",
+    "dataKitObjectTemplate": "datakitobjecttemplate",
+    "dataObjectBuildOrgTemplate": "dataobjectbuildorgtemplate",
+    "dataPackageKitDefinition": "datapackagekitdefinition",
+    "dataPipeline": "datapipeline",
+    "dataSource": "externaldatasource",
+    "dataSourceBundleDefinition": "datasourcebundledefinition",
+    "dataSourceObject": "datasourceobject",
+    "dataSourceTenant": "datasourcetenant",
+    "dataSrcDataModelFieldMap": "datasrcdatamodelfieldmap",
+    "dataStreamDefinition": "datastreamdefinition",
+    "dataStreamTemplate": "datastreamtemplate",
+    "datacategorygroup": "datacategorygroup",
+    "datatype": "customdatatype",
+    "decisionMatrixDefinition": "decisionmatrixdefinition",
+    "decisionMatrixVersion": "decisionmatrixdefinitionversion",
+    "decisionTable": "decisiontable",
+    "decisionTableDatasetLink": "decisiontabledatasetlink",
+    "delegateGroup": "delegategroup",
+    "delivery": "eventdelivery",
+    "deployment": "recordactiondeployment",
+    "digitalExperience": "digitalexperiencebundle",
+    "digitalExperienceConfig": "digitalexperienceconfig",
+    "disclosureDefinition": "disclosuredefinition",
+    "disclosureDefinitionVersion": "disclosuredefinitionversion",
+    "disclosureType": "disclosuretype",
+    "documentCategory": "documentcategory",
+    "documentCategoryDocumentType": "documentcategorydocumenttype",
+    "documentFolder": "documentfolder",
+    "documentGenerationSetting": "documentgenerationsetting",
+    "documentType": "documenttype",
+    "dt": "documenttemplate",
+    "duplicateRule": "duplicaterule",
+    "dwl": "dataweaveresource",
+    "dynamicTrigger": "dynamictrigger",
+    "eSignatureConfig": "esignatureconfig",
+    "eSignatureEnvelopeConfig": "esignatureenvelopeconfig",
+    "eca": "externalclientapplication",
+    "ecaGlblOauth": "extlclntappglobaloauthsettings",
+    "ecaMobile": "extlclntappmobilesettings",
+    "ecaMobilePlcy": "extlclntappmobileconfigurablepolicies",
+    "ecaNotifications": "extlclntappnotificationsettings",
+    "ecaOauth": "extlclntappoauthsettings",
+    "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
+    "ecaPlcy": "extlclntappconfigurablepolicies",
+    "ecaSamlPlcy": "extlclntappsamlconfigurablepolicies",
+    "ecaSmpl": "extlclntappsamplesettings",
+    "ecaSmplPlcy": "extlclntappsampleconfigurablepolicies",
+    "email": "emailtemplate",
+    "emailFolder": "emailfolder",
+    "employeeDataSyncProfile": "employeedatasyncprofile",
+    "enablementMeasureDefinition": "enablementmeasuredefinition",
+    "enablementProgramDefinition": "enablementprogramdefinition",
+    "enblProgramTaskSubCategory": "enblprogramtasksubcategory",
+    "entitlementProcess": "entitlementprocess",
+    "entitlementTemplate": "entitlementtemplate",
+    "entityImplements": "entityimplements",
+    "escalationRule": "escalationrule",
+    "escalationRules": "escalationrules",
+    "eventRelay": "eventrelayconfig",
+    "eventType": "eventtype",
+    "explainabilityActionDefinition": "explainabilityactiondefinition",
+    "explainabilityActionVersion": "explainabilityactionversion",
+    "explainabilityMsgTemplate": "explainabilitymsgtemplate",
+    "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetMessageToken": "expressionsetmessagetoken",
+    "expressionSetObjectAlias": "expressionsetobjectalias",
+    "expressionSetVersion": "expressionsetdefinitionversion",
+    "extDataTranFieldTemplate": "extdatatranfieldtemplate",
+    "extDataTranObjectTemplate": "extdatatranobjecttemplate",
+    "externalAIModel": "externalaimodel",
+    "externalAuthIdentityProvider": "externalauthidentityprovider",
+    "externalCredential": "externalcredential",
+    "externalDataConnector": "externaldataconnector",
+    "externalDataTranObject": "externaldatatranobject",
+    "externalDocStorageConfig": "externaldocstorageconfig",
+    "externalServiceRegistration": "externalserviceregistration",
+    "featureParameterBoolean": "featureparameterboolean",
+    "featureParameterDate": "featureparameterdate",
+    "featureParameterInteger": "featureparameterinteger",
+    "feedFilter": "customfeedfilter",
+    "fieldServiceMobileExtension": "fieldservicemobileextension",
+    "fieldSrcTrgtRelationship": "fieldsrctrgtrelationship",
+    "fieldTranslation": "customfieldtranslation",
+    "flexipage": "flexipage",
+    "flow": "flow",
+    "flowCategory": "flowcategory",
+    "flowDefinition": "flowdefinition",
+    "flowtest": "flowtest",
+    "forecastingFilter": "forecastingfilter",
+    "forecastingFilterCondition": "forecastingfiltercondition",
+    "forecastingGroup": "forecastinggroup",
+    "forecastingSourceDefinition": "forecastingsourcedefinition",
+    "forecastingType": "forecastingtype",
+    "forecastingTypeSource": "forecastingtypesource",
+    "form": "form",
+    "formSection": "formsection",
+    "fuelType": "fueltype",
+    "fuelTypeSustnUom": "fueltypesustnuom",
+    "fulfillmentFlow": "svccatalogfulfillmentflow",
+    "function": "functionreference",
+    "fundraisingConfig": "fundraisingconfig",
+    "gatewayProviderPaymentMethodType": "gatewayproviderpaymentmethodtype",
+    "genAiPlanner": "genaiplanner",
+    "genAiPlugin": "genaiplugin",
+    "genAiPromptTemplate": "genaiprompttemplate",
+    "genAiPromptTemplateActivation": "genaiprompttemplateactv",
+    "geodata": "eclairgeodata",
+    "globalPicklist": "globalpicklist",
+    "globalValueSet": "globalvalueset",
+    "globalValueSetTranslation": "globalvaluesettranslation",
+    "goal": "discoverygoal",
+    "group": "group",
+    "homePageComponent": "homepagecomponent",
+    "homePageLayout": "homepagelayout",
+    "icon": "icon",
+    "iframeWhiteListUrlSettings": "iframewhitelisturlsettings",
+    "inboundCertificate": "inboundcertificate",
+    "inboundNetworkConnection": "inboundnetworkconnection",
+    "indx": "customindex",
+    "insightType": "insighttype",
+    "installedPackage": "installedpackage",
+    "integrationProviderDefinition": "integrationproviderdef",
+    "internalDataConnector": "internaldataconnector",
+    "internalOrganization": "internalorganization",
+    "keywords": "keywordlist",
+    "labels": "customlabels",
+    "layout": "layout",
+    "learningAchievementConfig": "learningachievementconfig",
+    "learningItemType": "learningitemtype",
+    "letter": "letterhead",
+    "licenseDefinition": "licensedefinition",
+    "lightningBolt": "lightningbolt",
+    "lightningExperienceTheme": "lightningexperiencetheme",
+    "lightningOnboardingConfig": "lightningonboardingconfig",
+    "liveChatAgentConfig": "livechatagentconfig",
+    "liveChatButton": "livechatbutton",
+    "liveChatDeployment": "livechatdeployment",
+    "liveChatSensitiveDataRule": "livechatsensitivedatarule",
+    "locationUse": "locationuse",
+    "loyaltyProgramSetup": "loyaltyprogramsetup",
+    "managedContentType": "managedcontenttype",
+    "managedEventSubscription": "managedeventsubscription",
+    "managedTopic": "managedtopic",
+    "managedTopics": "managedtopics",
+    "marketSegmentDefinition": "marketsegmentdefinition",
+    "marketingResourceType": "marketingresourcetype",
+    "marketingappextension": "marketingappextension",
+    "matchingRule": "matchingrules",
+    "md": "custommetadata",
+    "messageChannel": "lightningmessagechannel",
+    "messagingChannel": "messagingchannel",
+    "mfgProgramTemplate": "mfgprogramtemplate",
+    "milestoneType": "milestonetype",
+    "mktCalcInsightObjectDef": "mktcalcinsightobjectdef",
+    "mktDataConnection": "mktdataconnection",
+    "mktDataConnectionSrcParam": "mktdataconnectionsrcparam",
+    "mktDataTranField": "mktdatatranfield",
+    "mktDataTranObject": "mktdatatranobject",
+    "mlDataDefinition": "mldatadefinition",
+    "mlDomain": "mldomain",
+    "mlPrediction": "mlpredictiondefinition",
+    "mlRecommendation": "mlrecommendationdefinition",
+    "mobSecurityCertPinConfig": "mobsecuritycertpinconfig",
+    "mobileSecurityAssignment": "mobilesecurityassignment",
+    "mobileSecurityPolicy": "mobilesecuritypolicy",
+    "mobileSecurityPolicySet": "mobilesecuritypolicyset",
+    "model": "discoveryaimodel",
+    "mutingpermissionset": "mutingpermissionset",
+    "myDomainDiscoverableLogin": "mydomaindiscoverablelogin",
+    "namedCredential": "namedcredential",
+    "navigationMenu": "navigationmenu",
+    "network": "network",
+    "networkBranding": "networkbranding",
+    "notifications": "apexemailnotifications",
+    "notiftype": "customnotificationtype",
+    "oauthcustomscope": "oauthcustomscope",
+    "oauthtokenexchangehandler": "oauthtokenexchangehandler",
+    "object": "customobject",
+    "objectSourceTargetMap": "objectsourcetargetmap",
+    "objIntegProviderDefMapping": "objintegproviderdefmapping",
+    "objectTranslation": "customobjecttranslation",
+    "ocrSampleDocument": "ocrsampledocument",
+    "ocrTemplate": "ocrtemplate",
+    "oip": "omniintegrationprocedure",
+    "omniInteractionAccessConfig": "omniinteractionaccessconfig",
+    "omniInteractionConfig": "omniinteractionconfig",
+    "omniSupervisorConfig": "omnisupervisorconfig",
+    "orchestration": "orchestration",
+    "orchestrationContext": "orchestrationcontext",
+    "os": "omniscript",
+    "ouc": "omniuicard",
+    "outboundNetworkConnection": "outboundnetworkconnection",
+    "page": "apexpage",
+    "participantRole": "participantrole",
+    "pathAssistant": "pathassistant",
+    "paymentGatewayProvider": "paymentgatewayprovider",
+    "permissionSetLicenseDefinition": "permissionsetlicensedefinition",
+    "permissionset": "permissionset",
+    "permissionsetgroup": "permissionsetgroup",
+    "personAccountOwnerPowerUser": "personaccountownerpoweruser",
+    "pipelineInspMetricConfig": "pipelineinspmetricconfig",
+    "platformEventChannel": "platformeventchannel",
+    "platformEventChannelMember": "platformeventchannelmember",
+    "platformEventSubscriberConfig": "platformeventsubscriberconfig",
+    "policy": "appointmentassignmentpolicy",
+    "portal": "portal",
+    "portalDelegablePermissionSet": "portaldelegablepermissionset",
+    "postTemplate": "posttemplate",
+    "presenceDeclineReason": "presencedeclinereason",
+    "presenceUserConfig": "presenceuserconfig",
+    "pricingActionParameters": "pricingactionparameters",
+    "pricingRecipe": "pricingrecipe",
+    "processflowmigration": "processflowmigration",
+    "productAttrDisplayConfig": "productattrdisplayconfig",
+    "productAttributeSet": "productattributeset",
+    "productSpecificationRecType": "productspecificationrectype",
+    "productSpecificationType": "productspecificationtype",
+    "productSpecificationTypeDefinition": "productspecificationtypedefinition",
+    "profile": "profile",
+    "profilePasswordPolicy": "profilepasswordpolicy",
+    "profileSessionSetting": "profilesessionsetting",
+    "prompt": "prompt",
+    "queue": "queue",
+    "queueRoutingConfig": "queueroutingconfig",
+    "quickAction": "quickaction",
+    "recAlrtDataSrcExpSetDef": "recalrtdatasrcexpsetdef",
+    "recommendationStrategy": "recommendationstrategy",
+    "recordAlertCategory": "recordalertcategory",
+    "recordAlertDataSource": "recordalertdatasource",
+    "recordAlertTemplate": "recordalerttemplate",
+    "redirectWhitelistUrl": "redirectwhitelisturl",
+    "refdash": "referenceddashboard",
+    "registeredExternalService": "registeredexternalservice",
+    "relatedRecordAssocCriteria": "relatedrecordassoccriteria",
+    "relationshipGraphDefinition": "relationshipgraphdefinition",
+    "remoteSite": "remotesitesetting",
+    "report": "report",
+    "reportFolder": "reportfolder",
+    "reportType": "reporttype",
+    "role": "role",
+    "rpt": "omnidatatransform",
+    "rule": "moderationrule",
+    "s3DataConnector": "dataconnectors3",
+    "salesAgreementSetting": "salesagreementsettings",
+    "samlssoconfig": "samlssoconfig",
+    "scf": "scontrol",
+    "schedulingObjective": "schedulingobjective",
+    "schedulingRule": "schedulingrule",
+    "scoreCategory": "scorecategory",
+    "searchCustomization": "searchcustomization",
+    "searchOrgWideObjectConfig": "searchorgwideobjectconfig",
+    "serviceAISetupDescription": "serviceaisetupdefinition",
+    "serviceAISetupField": "serviceaisetupfield",
+    "serviceChannel": "servicechannel",
+    "servicePresenceStatus": "servicepresencestatus",
+    "serviceprocess": "serviceprocess",
+    "settings": "settings",
+    "sharingCriteriaRule": "sharingcriteriarule",
+    "sharingGuestRule": "sharingguestrule",
+    "sharingOwnerRule": "sharingownerrule",
+    "sharingRules": "sharingrules",
+    "sharingSet": "sharingset",
+    "sharingTerritoryRule": "sharingterritoryrule",
+    "site": "sitedotcom",
+    "skill": "skill",
+    "skilltype": "skilltype",
+    "slackapp": "slackapp",
+    "snapshot": "analyticsnapshot",
+    "stageDefinition": "stagedefinition",
+    "standardValueSet": "standardvalueset",
+    "standardValueSetTranslation": "standardvaluesettranslation",
+    "stationaryAssetEnvSourceConfig": "stnryassetenvsrccnfg",
+    "story": "discoverystory",
+    "streamingAppDataConnector": "streamingappdataconnector",
+    "subscription": "eventsubscription",
+    "sustainabilityUom": "sustainabilityuom",
+    "sustnUomConversion": "sustnuomconversion",
+    "synonymDictionary": "synonymdictionary",
+    "tab": "customtab",
+    "territory": "territory",
+    "territory2": "territory2",
+    "territory2Model": "territory2model",
+    "territory2Rule": "territory2rule",
+    "territory2Type": "territory2type",
+    "testSuite": "apextestsuite",
+    "timeSheetTemplate": "timesheettemplate",
+    "timelineObjectDefinition": "timelineobjectdefinition",
+    "topicsForObjects": "topicsforobjects",
+    "transactionSecurityPolicy": "transactionsecuritypolicy",
+    "translation": "translations",
+    "trigger": "apextrigger",
+    "type": "integrationhubsettingstype",
+    "uiFormatSpecificationSet": "uiformatspecificationset",
+    "uiObjectRelationConfig": "uiobjectrelationconfig",
+    "uiplugin": "uiplugin",
+    "uiview": "uiviewdefinition",
+    "userAuthCertificate": "userauthcertificate",
+    "userCriteria": "usercriteria",
+    "userProfileSearchScope": "userprofilesearchscope",
+    "userProvisioningConfig": "userprovisioningconfig",
+    "useraccesspolicy": "useraccesspolicy",
+    "vehicleAssetEmssnSourceConfig": "vehicleassetemssnsrccnfg",
+    "view": "viewdefinition",
+    "virtualVisitConfig": "virtualvisitconfig",
+    "visualizationPlugin": "visualizationplugin",
+    "wapp": "waveapplication",
+    "wcomp": "wavecomponent",
+    "wdash": "wavedashboard",
+    "wdf": "wavedataflow",
+    "wdpr": "waverecipe",
+    "wds": "wavedataset",
+    "webStoreBundle": "webstorebundle",
+    "webStoreTemplate": "webstoretemplate",
+    "workflowFlowAutomation": "workflowflowautomation",
+    "weblink": "custompageweblink",
+    "wlens": "wavelens",
+    "workSkillRouting": "workskillrouting",
+    "workSkillRoutingAttribute": "workskillroutingattribute",
+    "workflow": "workflow",
+    "workflowAlert": "workflowalert",
+    "workflowFieldUpdate": "workflowfieldupdate",
+    "workflowFlowAction": "workflowflowaction",
+    "workflowKnowledgePublish": "workflowknowledgepublish",
+    "workflowOutboundMessage": "workflowoutboundmessage",
+    "workflowRule": "workflowrule",
+    "workflowSend": "workflowsend",
+    "workflowTask": "workflowtask",
+    "xmd": "wavexmd",
+    "xml": "emailservicesfunction",
+    "xorghub": "xorghub",
+    "ecaPush": "extlclntapppushsettings",
+    "ecaPushPlcy": "extlclntapppushconfigurablepolicies",
+    "ChoiceList": "choicelist",
+    "ConvIntelligenceSignalRule": "convintelligencesignalrule",
+    "PublicKeyCertificate": "publickeycertificate",
+    "PublicKeyCertificateSet": "publickeycertificateset",
+    "aiEvaluationDefinition": "aievaluationdefinition",
+    "uadash": "analyticsdashboard",
+    "uaviz": "analyticsvisualization",
+    "uawork": "analyticsworkspace",
+    "lifeSciConfigCategory": "lifesciconfigcategory",
+    "lifeSciConfigRecord": "lifesciconfigrecord",
+    "invocableactionextension": "invocableactionextension",
+    "fieldServiceMobileConfig": "fieldservicemobileconfig",
+    "dgtAssetMgmtProvider": "dgtassetmgmtprovider",
+    "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt",
+    "ecaCanvas": "extlclntappcanvasstngs",
+    "apiNamedQuery": "apinamedquery",
+    "ExternalStoragePrvdConfigSet": "externalstorageprvdconfig",
+    "ruleLibraryDefinition": "rulelibrarydefinition"
+  },
+  "types": {
+    "accesscontrolpolicy": {
+      "directoryName": "accessControlPolicies",
+      "id": "accesscontrolpolicy",
+      "inFolder": false,
+      "name": "AccessControlPolicy",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "accountforecastsettings": {
+      "directoryName": "AccountForecastSettings",
+      "id": "accountforecastsettings",
+      "name": "AccountForecastSettings",
+      "strictDirectoryName": false,
+      "suffix": "accountForecastSetting"
+    },
+    "accountingfieldmapping": {
+      "directoryName": "accountingFieldMappings",
+      "id": "accountingfieldmapping",
+      "inFolder": false,
+      "name": "AccountingFieldMapping",
+      "strictDirectoryName": false,
+      "suffix": "accountingFieldMapping"
+    },
+    "accountingmodelconfig": {
+      "directoryName": "accountingModelConfigs",
+      "id": "accountingmodelconfig",
+      "inFolder": false,
+      "name": "AccountingModelConfig",
+      "strictDirectoryName": false,
+      "suffix": "accountingModelConfig"
+    },
+    "accountrelationshipsharerule": {
+      "directoryName": "accountRelationshipShareRules",
+      "id": "accountrelationshipsharerule",
+      "name": "AccountRelationshipShareRule",
+      "strictDirectoryName": false,
+      "suffix": "accountRelationshipShareRule"
+    },
+    "acctmgrtargetsettings": {
+      "directoryName": "acctMgrTargetSettings",
+      "id": "acctmgrtargetsettings",
+      "name": "AcctMgrTargetSettings",
+      "strictDirectoryName": false,
+      "suffix": "acctMgrTargetSetting"
+    },
+    "actionableeventorchdef": {
+      "directoryName": "ActionableEventOrchDefSettings",
+      "id": "actionableeventorchdef",
+      "inFolder": false,
+      "name": "ActionableEventOrchDef",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "actionableeventtypedef": {
+      "directoryName": "ActionableEventTypeDefSettings",
+      "id": "actionableeventtypedef",
+      "inFolder": false,
+      "name": "ActionableEventTypeDef",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "actionablelistdefinition": {
+      "directoryName": "actionableListDefinitions",
+      "id": "actionablelistdefinition",
+      "inFolder": false,
+      "name": "ActionableListDefinition",
+      "strictDirectoryName": false,
+      "suffix": "actionableListDefinition"
+    },
+    "actionlauncheritemdef": {
+      "directoryName": "ActionLauncherItemDef",
+      "id": "actionlauncheritemdef",
+      "inFolder": false,
+      "name": "ActionLauncherItemDef",
+      "strictDirectoryName": false,
+      "suffix": "actionLauncherItemDef"
+    },
+    "actionlinkgrouptemplate": {
+      "directoryName": "actionLinkGroupTemplates",
+      "id": "actionlinkgrouptemplate",
+      "inFolder": false,
+      "name": "ActionLinkGroupTemplate",
+      "strictDirectoryName": false,
+      "suffix": "actionLinkGroupTemplate"
+    },
+    "actionplantemplate": {
+      "directoryName": "actionPlanTemplates",
+      "id": "actionplantemplate",
+      "name": "ActionPlanTemplate",
+      "strictDirectoryName": false,
+      "suffix": "apt"
+    },
+    "activationplatform": {
+      "directoryName": "activationPlatforms",
+      "id": "activationplatform",
+      "inFolder": false,
+      "name": "ActivationPlatform",
+      "strictDirectoryName": false,
+      "suffix": "activationPlatform"
+    },
+    "actnbllistkeyprfminddef": {
+      "directoryName": "actnblListKeyPrfmIndDefs",
+      "id": "actnbllistkeyprfminddef",
+      "inFolder": false,
+      "name": "ActnblListKeyPrfmIndDef",
+      "strictDirectoryName": false,
+      "suffix": "actnblListKeyPrfmIndDef"
+    },
+    "advaccountforecastset": {
+      "directoryName": "AdvAccountForecastSet",
+      "id": "advaccountforecastset",
+      "inFolder": false,
+      "name": "AdvAccountForecastSet",
+      "suffix": "advAccountForecastSet"
+    },
+    "advacctforecastdimsource": {
+      "directoryName": "AdvAcctForecastDimSource",
+      "id": "advacctforecastdimsource",
+      "inFolder": false,
+      "name": "AdvAcctForecastDimSource",
+      "strictDirectoryName": false,
+      "suffix": "advAcctForecastDimSource"
+    },
+    "advacctforecastperiodgroup": {
+      "directoryName": "AdvAcctForecastPeriodGroup",
+      "id": "advacctforecastperiodgroup",
+      "inFolder": false,
+      "name": "AdvAcctForecastPeriodGroup",
+      "suffix": "advAcctForecastPeriodGroup"
+    },
+    "affinityscoredefinition": {
+      "directoryName": "affinityScoreDefinitions",
+      "id": "affinityscoredefinition",
+      "inFolder": false,
+      "name": "AffinityScoreDefinition",
+      "strictDirectoryName": false,
+      "suffix": "affinityScoreDefinition"
+    },
+    "aiapplication": {
+      "directoryName": "aiApplications",
+      "id": "aiapplication",
+      "inFolder": false,
+      "name": "AIApplication",
+      "strictDirectoryName": false,
+      "suffix": "ai"
+    },
+    "aiapplicationconfig": {
+      "directoryName": "aiApplicationConfigs",
+      "id": "aiapplicationconfig",
+      "inFolder": false,
+      "name": "AIApplicationConfig",
+      "strictDirectoryName": false,
+      "suffix": "aiapplicationconfig"
+    },
+    "aiassistanttemplate": {
+      "directoryName": "aiAssistantTemplates",
+      "id": "aiassistanttemplate",
+      "inFolder": false,
+      "name": "AIAssistantTemplate",
+      "suffix": "aiAssistantTemplate"
+    },
+    "aiscoringmodeldefinition": {
+      "children": {
+        "directories": {
+          "aiScoringModelDefVersions": "aiscoringmodeldefversion"
+        },
+        "suffixes": {
+          "aiScoringModelDefVersion": "aiscoringmodeldefversion"
+        },
+        "types": {
+          "aiscoringmodeldefversion": {
+            "directoryName": "aiScoringModelDefVersions",
+            "id": "aiscoringmodeldefversion",
+            "name": "AIScoringModelDefVersion",
+            "suffix": "aiScoringModelDefVersion",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "aiScoringModelDefVersions"
+          }
+        }
+      },
+      "directoryName": "aiScoringModelDefinitions",
+      "id": "aiscoringmodeldefinition",
+      "inFolder": false,
+      "name": "AIScoringModelDefinition",
+      "suffix": "aiScoringModelDefinition",
+      "supportsWildcardAndName": true
+    },
+    "aiusecasedefinition": {
+      "directoryName": "aiUsecaseDefinitions",
+      "id": "aiusecasedefinition",
+      "inFolder": false,
+      "name": "AIUsecaseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "aiUsecaseDefinitions"
+    },
+    "analyticsnapshot": {
+      "directoryName": "analyticSnapshots",
+      "id": "analyticsnapshot",
+      "inFolder": false,
+      "name": "AnalyticSnapshot",
+      "strictDirectoryName": false,
+      "suffix": "snapshot"
+    },
+    "animationrule": {
+      "directoryName": "animationRules",
+      "id": "animationrule",
+      "inFolder": false,
+      "name": "AnimationRule",
+      "strictDirectoryName": false,
+      "suffix": "animationRule"
+    },
+    "apexclass": {
+      "directoryName": "classes",
+      "id": "apexclass",
+      "inFolder": false,
+      "name": "ApexClass",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "cls",
+      "supportsWildcardAndName": true
+    },
+    "apexcomponent": {
+      "directoryName": "components",
+      "id": "apexcomponent",
+      "inFolder": false,
+      "name": "ApexComponent",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "component"
+    },
+    "apexemailnotifications": {
+      "directoryName": "apexEmailNotifications",
+      "id": "apexemailnotifications",
+      "inFolder": false,
+      "name": "ApexEmailNotifications",
+      "strictDirectoryName": false,
+      "suffix": "notifications"
+    },
+    "apexpage": {
+      "directoryName": "pages",
+      "id": "apexpage",
+      "inFolder": false,
+      "name": "ApexPage",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "page",
+      "supportsWildcardAndName": true
+    },
+    "apextestsuite": {
+      "directoryName": "testSuites",
+      "id": "apextestsuite",
+      "inFolder": false,
+      "name": "ApexTestSuite",
+      "strictDirectoryName": false,
+      "suffix": "testSuite"
+    },
+    "apextrigger": {
+      "directoryName": "triggers",
+      "id": "apextrigger",
+      "inFolder": false,
+      "name": "ApexTrigger",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "trigger"
+    },
+    "applicationrecordtypeconfig": {
+      "directoryName": "ApplicationRecordTypeConfig",
+      "id": "applicationrecordtypeconfig",
+      "inFolder": false,
+      "name": "ApplicationRecordTypeConfig",
+      "suffix": "applicationRecordTypeConfig"
+    },
+    "applicationsubtypedefinition": {
+      "directoryName": "ApplicationSubtypeDefinitions",
+      "id": "applicationsubtypedefinition",
+      "inFolder": false,
+      "name": "ApplicationSubtypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "applicationSubtypeDefinition"
+    },
+    "appmenu": {
+      "directoryName": "appMenus",
+      "id": "appmenu",
+      "inFolder": false,
+      "name": "AppMenu",
+      "strictDirectoryName": false,
+      "suffix": "appMenu"
+    },
+    "appointmentassignmentpolicy": {
+      "directoryName": "appointmentAssignmentPolicies",
+      "id": "appointmentassignmentpolicy",
+      "inFolder": false,
+      "name": "AppointmentAssignmentPolicy",
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "appointmentschedulingpolicy": {
+      "directoryName": "appointmentSchedulingPolicies",
+      "id": "appointmentschedulingpolicy",
+      "inFolder": false,
+      "name": "AppointmentSchedulingPolicy",
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "approvalprocess": {
+      "directoryName": "approvalProcesses",
+      "id": "approvalprocess",
+      "inFolder": false,
+      "name": "ApprovalProcess",
+      "strictDirectoryName": false,
+      "suffix": "approvalProcess"
+    },
+    "assessmentconfiguration": {
+      "directoryName": "AssessmentConfigurations",
+      "id": "assessmentconfiguration",
+      "inFolder": false,
+      "name": "AssessmentConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "assessmentConfiguration"
+    },
+    "assessmentquestion": {
+      "directoryName": "AssessmentQuestions",
+      "id": "assessmentquestion",
+      "inFolder": false,
+      "name": "AssessmentQuestion",
+      "strictDirectoryName": false,
+      "suffix": "aq"
+    },
+    "assessmentquestionset": {
+      "directoryName": "AssessmentQuestionSets",
+      "id": "assessmentquestionset",
+      "inFolder": false,
+      "name": "AssessmentQuestionSet",
+      "strictDirectoryName": false,
+      "suffix": "aqs"
+    },
+    "assignmentrules": {
+      "children": {
+        "directories": {
+          "assignmentRules": "assignmentrule"
+        },
+        "suffixes": {
+          "assignmentRule": "assignmentrule"
+        },
+        "types": {
+          "assignmentrule": {
+            "directoryName": "assignmentRules",
+            "id": "assignmentrule",
+            "name": "AssignmentRule",
+            "suffix": "assignmentRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "assignmentRule"
+          }
+        }
+      },
+      "directoryName": "assignmentRules",
+      "id": "assignmentrules",
+      "inFolder": false,
+      "name": "AssignmentRules",
+      "strictDirectoryName": false,
+      "suffix": "assignmentRules"
+    },
+    "assistantcontextitem": {
+      "directoryName": "assistantContextItems",
+      "id": "assistantcontextitem",
+      "inFolder": false,
+      "name": "AssistantContextItem",
+      "suffix": "assistantContextItem"
+    },
+    "assistantdefinition": {
+      "directoryName": "assistantDefinitions",
+      "id": "assistantdefinition",
+      "inFolder": false,
+      "name": "AssistantDefinition",
+      "suffix": "assistantDefinition"
+    },
+    "assistantrecommendationtype": {
+      "directoryName": "assistantRecommendationTypes",
+      "id": "assistantrecommendationtype",
+      "inFolder": false,
+      "name": "AssistantRecommendationType",
+      "suffix": "assistantRecommendationType"
+    },
+    "assistantskillquickaction": {
+      "directoryName": "assistantSkillQuickActions",
+      "id": "assistantskillquickaction",
+      "inFolder": false,
+      "name": "AssistantSkillQuickAction",
+      "suffix": "assistantSkillQuickAction"
+    },
+    "assistantskillsobjectaction": {
+      "directoryName": "assistantSkillSobjectActions",
+      "id": "assistantskillsobjectaction",
+      "inFolder": false,
+      "name": "AssistantSkillSobjectAction",
+      "suffix": "assistantSkillSobjectAction"
+    },
+    "assistantversion": {
+      "directoryName": "assistantVersions",
+      "id": "assistantversion",
+      "inFolder": false,
+      "name": "AssistantVersion",
+      "suffix": "assistantVersion"
+    },
+    "audience": {
+      "directoryName": "audience",
+      "id": "audience",
+      "inFolder": false,
+      "name": "Audience",
+      "strictDirectoryName": false,
+      "suffix": "audience"
+    },
+    "auradefinitionbundle": {
+      "directoryName": "aura",
+      "id": "auradefinitionbundle",
+      "inFolder": false,
+      "name": "AuraDefinitionBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "authprovider": {
+      "directoryName": "authproviders",
+      "id": "authprovider",
+      "inFolder": false,
+      "name": "AuthProvider",
+      "strictDirectoryName": false,
+      "suffix": "authprovider"
+    },
+    "autoresponserules": {
+      "children": {
+        "directories": {
+          "autoResponseRules": "autoresponserule"
+        },
+        "suffixes": {
+          "autoResponseRule": "autoresponserule"
+        },
+        "types": {
+          "autoresponserule": {
+            "directoryName": "autoResponseRules",
+            "id": "autoresponserule",
+            "name": "AutoResponseRule",
+            "suffix": "autoResponseRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "autoResponseRule"
+          }
+        }
+      },
+      "directoryName": "autoResponseRules",
+      "id": "autoresponserules",
+      "inFolder": false,
+      "name": "AutoResponseRules",
+      "strictDirectoryName": false,
+      "suffix": "autoResponseRules"
+    },
+    "batchcalcjobdefinition": {
+      "directoryName": "batchCalcJobDefinitions",
+      "id": "batchcalcjobdefinition",
+      "inFolder": false,
+      "name": "BatchCalcJobDefinition",
+      "strictDirectoryName": false,
+      "suffix": "batchCalcJobDefinition"
+    },
+    "batchprocessjobdefinition": {
+      "directoryName": "batchProcessJobDefinitions",
+      "id": "batchprocessjobdefinition",
+      "name": "BatchProcessJobDefinition",
+      "strictDirectoryName": false,
+      "suffix": "batchProcessJobDefinition"
+    },
+    "benefitaction": {
+      "directoryName": "benefitActions",
+      "id": "benefitaction",
+      "name": "BenefitAction",
+      "strictDirectoryName": false,
+      "suffix": "benefitAction"
+    },
+    "blacklistedconsumer": {
+      "directoryName": "blacklistedConsumers",
+      "id": "blacklistedconsumer",
+      "inFolder": false,
+      "name": "BlacklistedConsumer",
+      "strictDirectoryName": false,
+      "suffix": "blacklistedConsumer"
+    },
+    "bldgenrgyintensitycnfg": {
+      "directoryName": "buildingEnergyIntensityConfigs",
+      "id": "bldgenrgyintensitycnfg",
+      "inFolder": false,
+      "name": "BldgEnrgyIntensityCnfg",
+      "strictDirectoryName": false,
+      "suffix": "buildingEnergyIntensityConfig"
+    },
+    "bot": {
+      "children": {
+        "directories": {
+          "botVersions": "botversion"
+        },
+        "suffixes": {
+          "botVersion": "botversion"
+        },
+        "types": {
+          "botversion": {
+            "directoryName": "botVersions",
+            "id": "botversion",
+            "name": "BotVersion",
+            "suffix": "botVersion"
+          }
+        }
+      },
+      "directoryName": "bots",
+      "id": "bot",
+      "inFolder": false,
+      "name": "Bot",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "topLevel",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "bot"
+    },
+    "botblock": {
+      "directoryName": "botBlocks",
+      "id": "botblock",
+      "inFolder": false,
+      "name": "BotBlock",
+      "strictDirectoryName": true,
+      "suffix": "botBlock"
+    },
+    "bottemplate": {
+      "directoryName": "botTemplates",
+      "id": "bottemplate",
+      "inFolder": false,
+      "name": "BotTemplate",
+      "strictDirectoryName": true,
+      "suffix": "botTemplate"
+    },
+    "brandingset": {
+      "directoryName": "brandingSets",
+      "id": "brandingset",
+      "inFolder": false,
+      "name": "BrandingSet",
+      "strictDirectoryName": false,
+      "suffix": "brandingSet"
+    },
+    "briefcasedefinition": {
+      "directoryName": "briefcaseDefinitions",
+      "id": "briefcasedefinition",
+      "name": "BriefcaseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "briefcaseDefinition"
+    },
+    "businessprocessfeedbackconfiguration": {
+      "directoryName": "businessProcessFeedbackConfigurations",
+      "id": "businessprocessfeedbackconfiguration",
+      "name": "BusinessProcessFeedbackConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessFeedbackConfiguration"
+    },
+    "businessprocessgroup": {
+      "directoryName": "businessProcessGroups",
+      "id": "businessprocessgroup",
+      "name": "BusinessProcessGroup",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessGroup"
+    },
+    "businessprocesstypedefinition": {
+      "directoryName": "BusinessProcessTypeDefinitions",
+      "id": "businessprocesstypedefinition",
+      "inFolder": false,
+      "name": "BusinessProcessTypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessTypeDefinition"
+    },
+    "callcenter": {
+      "directoryName": "callCenters",
+      "id": "callcenter",
+      "inFolder": false,
+      "name": "CallCenter",
+      "strictDirectoryName": false,
+      "suffix": "callCenter",
+      "supportsWildcardAndName": true
+    },
+    "callcenterroutingmap": {
+      "directoryName": "callCenterRoutingMaps",
+      "id": "callcenterroutingmap",
+      "inFolder": false,
+      "name": "CallCenterRoutingMap",
+      "suffix": "callCenterRoutingMap"
+    },
+    "callcoachingmediaprovider": {
+      "directoryName": "callCoachingMediaProviders",
+      "id": "callcoachingmediaprovider",
+      "inFolder": false,
+      "name": "CallCoachingMediaProvider",
+      "strictDirectoryName": false,
+      "suffix": "callCoachingMediaProvider"
+    },
+    "callctragentfavtrfrdest": {
+      "directoryName": "callCtrAgentFavTrfrDests",
+      "id": "callctragentfavtrfrdest",
+      "inFolder": false,
+      "name": "CallCtrAgentFavTrfrDest",
+      "strictDirectoryName": false,
+      "suffix": "callCtrAgentFavTrfrDest"
+    },
+    "campaigninfluencemodel": {
+      "directoryName": "campaignInfluenceModels",
+      "id": "campaigninfluencemodel",
+      "inFolder": false,
+      "name": "CampaignInfluenceModel",
+      "suffix": "campaignInfluenceModel"
+    },
+    "canvasmetadata": {
+      "directoryName": "Canvases",
+      "id": "canvasmetadata",
+      "inFolder": false,
+      "name": "CanvasMetadata",
+      "strictDirectoryName": false,
+      "suffix": "Canvas"
+    },
+    "carebenefitverifysettings": {
+      "directoryName": "careBenefitVerifySettings",
+      "id": "carebenefitverifysettings",
+      "inFolder": false,
+      "name": "CareBenefitVerifySettings",
+      "suffix": "careBenefitVerifySettings"
+    },
+    "carelimittype": {
+      "directoryName": "careLimitTypes",
+      "id": "carelimittype",
+      "inFolder": false,
+      "name": "CareLimitType",
+      "strictDirectoryName": false,
+      "suffix": "careLimitType"
+    },
+    "careproviderafflroleconfig": {
+      "directoryName": "careProviderAfflRoleConfigs",
+      "id": "careproviderafflroleconfig",
+      "inFolder": false,
+      "name": "CareProviderAfflRoleConfig",
+      "strictDirectoryName": false,
+      "suffix": "careProviderAfflRoleConfig"
+    },
+    "careprovidersearchconfig": {
+      "directoryName": "careProviderSearchConfigs",
+      "id": "careprovidersearchconfig",
+      "name": "CareProviderSearchConfig",
+      "strictDirectoryName": false,
+      "suffix": "careProviderSearchConfig"
+    },
+    "carerequestconfiguration": {
+      "directoryName": "careRequestConfigurations",
+      "id": "carerequestconfiguration",
+      "inFolder": false,
+      "name": "CareRequestConfiguration",
+      "suffix": "careRequestConfiguration"
+    },
+    "caresystemfieldmapping": {
+      "directoryName": "careSystemFieldMappings",
+      "id": "caresystemfieldmapping",
+      "name": "CareSystemFieldMapping",
+      "strictDirectoryName": false,
+      "suffix": "careSystemFieldMapping"
+    },
+    "casesubjectparticle": {
+      "directoryName": "CaseSubjectParticles",
+      "id": "casesubjectparticle",
+      "inFolder": false,
+      "name": "CaseSubjectParticle",
+      "strictDirectoryName": false,
+      "suffix": "CaseSubjectParticle"
+    },
+    "certificate": {
+      "directoryName": "certs",
+      "id": "certificate",
+      "inFolder": false,
+      "name": "Certificate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "crt"
+    },
+    "channellayout": {
+      "directoryName": "channelLayouts",
+      "id": "channellayout",
+      "inFolder": false,
+      "name": "ChannelLayout",
+      "strictDirectoryName": false,
+      "suffix": "channelLayout"
+    },
+    "channelobjectlinkingrule": {
+      "directoryName": "ChannelObjectLinkingRules",
+      "id": "channelobjectlinkingrule",
+      "name": "ChannelObjectLinkingRule",
+      "strictDirectoryName": false,
+      "suffix": "ChannelObjectLinkingRule"
+    },
+    "chatterextension": {
+      "directoryName": "ChatterExtensions",
+      "id": "chatterextension",
+      "inFolder": false,
+      "name": "ChatterExtension",
+      "strictDirectoryName": false,
+      "suffix": "ChatterExtension"
+    },
+    "clausecatgconfiguration": {
+      "directoryName": "clauseCatgConfigurations",
+      "id": "clausecatgconfiguration",
+      "inFolder": false,
+      "name": "ClauseCatgConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "clauseCatgConfiguration"
+    },
+    "cleandataservice": {
+      "directoryName": "cleanDataServices",
+      "id": "cleandataservice",
+      "inFolder": false,
+      "name": "CleanDataService",
+      "strictDirectoryName": false,
+      "suffix": "cleanDataService"
+    },
+    "cmsconnectsource": {
+      "directoryName": "cmsConnectSource",
+      "id": "cmsconnectsource",
+      "inFolder": false,
+      "name": "CMSConnectSource",
+      "strictDirectoryName": false,
+      "suffix": "cmsConnectSource"
+    },
+    "commandaction": {
+      "directoryName": "commandActions",
+      "id": "commandaction",
+      "inFolder": false,
+      "name": "CommandAction",
+      "suffix": "commandaction"
+    },
+    "community": {
+      "directoryName": "communities",
+      "id": "community",
+      "inFolder": false,
+      "name": "Community",
+      "strictDirectoryName": false,
+      "suffix": "community"
+    },
+    "communitytemplatedefinition": {
+      "directoryName": "communityTemplateDefinitions",
+      "id": "communitytemplatedefinition",
+      "inFolder": false,
+      "name": "CommunityTemplateDefinition",
+      "strictDirectoryName": false,
+      "suffix": "communityTemplateDefinition"
+    },
+    "communitythemedefinition": {
+      "directoryName": "communityThemeDefinitions",
+      "id": "communitythemedefinition",
+      "inFolder": false,
+      "name": "CommunityThemeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "communityThemeDefinition"
+    },
+    "connectedapp": {
+      "directoryName": "connectedApps",
+      "id": "connectedapp",
+      "inFolder": false,
+      "name": "ConnectedApp",
+      "strictDirectoryName": false,
+      "suffix": "connectedApp"
+    },
+    "contentasset": {
+      "directoryName": "contentassets",
+      "id": "contentasset",
+      "inFolder": false,
+      "name": "ContentAsset",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "asset"
+    },
+    "contextdefinition": {
+      "directoryName": "contextDefinitions",
+      "id": "contextdefinition",
+      "inFolder": false,
+      "name": "ContextDefinition",
+      "strictDirectoryName": false,
+      "suffix": "contextDefinition"
+    },
+    "contextusecasemapping": {
+      "directoryName": "contextUseCaseMappings",
+      "id": "contextusecasemapping",
+      "inFolder": false,
+      "name": "ContextUseCaseMapping",
+      "strictDirectoryName": false,
+      "suffix": "contextUseCaseMapping"
+    },
+    "contracttype": {
+      "directoryName": "contractTypes",
+      "id": "contracttype",
+      "inFolder": false,
+      "name": "ContractType",
+      "strictDirectoryName": false,
+      "suffix": "contractType"
+    },
+    "conversationchanneldefinition": {
+      "directoryName": "conversationChannelDefinitions",
+      "id": "conversationchanneldefinition",
+      "inFolder": false,
+      "name": "ConversationChannelDefinition",
+      "strictDirectoryName": false,
+      "suffix": "ConversationChannelDefinition"
+    },
+    "conversationmessagedefinition": {
+      "directoryName": "conversationMessageDefinitions",
+      "id": "conversationmessagedefinition",
+      "inFolder": false,
+      "name": "ConversationMessageDefinition",
+      "strictDirectoryName": false,
+      "suffix": "conversationMessageDefinition"
+    },
+    "conversationvendorfielddef": {
+      "directoryName": "ConversationVendorFieldDefinitions",
+      "id": "conversationvendorfielddef",
+      "name": "ConversationVendorFieldDef",
+      "strictDirectoryName": false,
+      "suffix": "ConversationVendorFieldDefinition"
+    },
+    "conversationvendorinfo": {
+      "directoryName": "ConversationVendorInformation",
+      "id": "conversationvendorinfo",
+      "name": "ConversationVendorInfo",
+      "strictDirectoryName": false,
+      "suffix": "ConversationVendorInformation"
+    },
+    "corswhitelistorigin": {
+      "directoryName": "corsWhitelistOrigins",
+      "id": "corswhitelistorigin",
+      "inFolder": false,
+      "name": "CorsWhitelistOrigin",
+      "strictDirectoryName": false,
+      "suffix": "corsWhitelistOrigin"
+    },
+    "csptrustedsite": {
+      "directoryName": "cspTrustedSites",
+      "id": "csptrustedsite",
+      "inFolder": false,
+      "name": "CspTrustedSite",
+      "strictDirectoryName": false,
+      "suffix": "cspTrustedSite"
+    },
+    "customapplication": {
+      "directoryName": "applications",
+      "id": "customapplication",
+      "inFolder": false,
+      "name": "CustomApplication",
+      "strictDirectoryName": false,
+      "suffix": "app",
+      "supportsWildcardAndName": true
+    },
+    "customapplicationcomponent": {
+      "directoryName": "customApplicationComponents",
+      "id": "customapplicationcomponent",
+      "inFolder": false,
+      "name": "CustomApplicationComponent",
+      "suffix": "customApplicationComponent"
+    },
+    "customdatatype": {
+      "directoryName": "datatypes",
+      "id": "customdatatype",
+      "inFolder": false,
+      "name": "CustomDataType",
+      "suffix": "datatype"
+    },
+    "customexperience": {
+      "directoryName": "customExperiences",
+      "id": "customexperience",
+      "inFolder": false,
+      "name": "CustomExperience",
+      "suffix": "customExperience"
+    },
+    "customfeedfilter": {
+      "directoryName": "feedFilters",
+      "id": "customfeedfilter",
+      "inFolder": false,
+      "name": "CustomFeedFilter",
+      "suffix": "feedFilter"
+    },
+    "customhelpmenusection": {
+      "directoryName": "customHelpMenuSections",
+      "id": "customhelpmenusection",
+      "inFolder": false,
+      "name": "CustomHelpMenuSection",
+      "strictDirectoryName": false,
+      "suffix": "customHelpMenuSection"
+    },
+    "customindex": {
+      "directoryName": "customindex",
+      "id": "customindex",
+      "inFolder": false,
+      "name": "CustomIndex",
+      "strictDirectoryName": false,
+      "suffix": "indx"
+    },
+    "customlabels": {
+      "children": {
+        "directories": {
+          "labels": "customlabel"
+        },
+        "suffixes": {
+          "labels": "customlabel"
+        },
+        "types": {
+          "customlabel": {
+            "directoryName": "labels",
+            "id": "customlabel",
+            "ignoreParentName": true,
+            "name": "CustomLabel",
+            "suffix": "labels",
+            "supportsWildcardAndName": true,
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "labels"
+          }
+        }
+      },
+      "directoryName": "labels",
+      "id": "customlabels",
+      "ignoreParsedFullName": true,
+      "inFolder": false,
+      "name": "CustomLabels",
+      "strategies": {
+        "adapter": "default",
+        "recomposition": "startEmpty",
+        "transformer": "nonDecomposed"
+      },
+      "strictDirectoryName": false,
+      "suffix": "labels"
+    },
+    "custommetadata": {
+      "directoryName": "customMetadata",
+      "id": "custommetadata",
+      "inFolder": false,
+      "name": "CustomMetadata",
+      "strictDirectoryName": false,
+      "suffix": "md",
+      "supportsWildcardAndName": true
+    },
+    "customnotificationtype": {
+      "directoryName": "notificationtypes",
+      "id": "customnotificationtype",
+      "inFolder": false,
+      "name": "CustomNotificationType",
+      "strictDirectoryName": false,
+      "suffix": "notiftype"
+    },
+    "customobject": {
+      "children": {
+        "directories": {
+          "businessProcesses": "businessprocess",
+          "compactLayouts": "compactlayout",
+          "fieldSets": "fieldset",
+          "fields": "customfield",
+          "indexes": "index",
+          "listViews": "listview",
+          "recordTypes": "recordtype",
+          "sharingReasons": "sharingreason",
+          "validationRules": "validationrule",
+          "webLinks": "weblink"
+        },
+        "suffixes": {
+          "businessProcess": "businessprocess",
+          "compactLayout": "compactlayout",
+          "field": "customfield",
+          "fieldSet": "fieldset",
+          "index": "index",
+          "indexe": "index",
+          "listView": "listview",
+          "recordType": "recordtype",
+          "sharingReason": "sharingreason",
+          "validationRule": "validationrule",
+          "webLink": "weblink"
+        },
+        "types": {
+          "businessprocess": {
+            "directoryName": "businessProcesses",
+            "id": "businessprocess",
+            "name": "BusinessProcess",
+            "suffix": "businessProcess"
+          },
+          "compactlayout": {
+            "directoryName": "compactLayouts",
+            "id": "compactlayout",
+            "name": "CompactLayout",
+            "suffix": "compactLayout"
+          },
+          "customfield": {
+            "directoryName": "fields",
+            "id": "customfield",
+            "name": "CustomField",
+            "suffix": "field"
+          },
+          "fieldset": {
+            "directoryName": "fieldSets",
+            "id": "fieldset",
+            "name": "FieldSet",
+            "suffix": "fieldSet"
+          },
+          "index": {
+            "directoryName": "indexes",
+            "id": "index",
+            "legacySuffix": "indexe",
+            "name": "Index",
+            "suffix": "index"
+          },
+          "listview": {
+            "directoryName": "listViews",
+            "id": "listview",
+            "name": "ListView",
+            "suffix": "listView"
+          },
+          "recordtype": {
+            "directoryName": "recordTypes",
+            "id": "recordtype",
+            "name": "RecordType",
+            "suffix": "recordType"
+          },
+          "sharingreason": {
+            "directoryName": "sharingReasons",
+            "id": "sharingreason",
+            "name": "SharingReason",
+            "suffix": "sharingReason"
+          },
+          "validationrule": {
+            "directoryName": "validationRules",
+            "id": "validationrule",
+            "name": "ValidationRule",
+            "suffix": "validationRule"
+          },
+          "weblink": {
+            "directoryName": "webLinks",
+            "id": "weblink",
+            "name": "WebLink",
+            "suffix": "webLink"
+          }
+        }
+      },
+      "directoryName": "objects",
+      "id": "customobject",
+      "inFolder": false,
+      "name": "CustomObject",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "folderPerType",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "object",
+      "supportsWildcardAndName": true
+    },
+    "customobjecttranslation": {
+      "children": {
+        "directories": {
+          "fields": "customfieldtranslation",
+          "recordTypes": "recordtypetranslation",
+          "validationRules": "validationruletranslation"
+        },
+        "suffixes": {
+          "fieldTranslation": "customfieldtranslation",
+          "recordTypeTranslation": "recordtypetranslation",
+          "validationRuleTranslation": "validationruletranslation"
+        },
+        "types": {
+          "customfieldtranslation": {
+            "directoryName": "fields",
+            "id": "customfieldtranslation",
+            "isAddressable": false,
+            "name": "CustomFieldTranslation",
+            "suffix": "fieldTranslation",
+            "unaddressableWithoutParent": true,
+            "uniqueIdElement": "name"
+          },
+          "recordtypetranslation": {
+            "directoryName": "recordTypes",
+            "id": "recordtypetranslation",
+            "isAddressable": false,
+            "name": "RecordTypeTranslation",
+            "suffix": "recordTypeTranslation",
+            "unaddressableWithoutParent": true,
+            "uniqueIdElement": "name"
+          },
+          "validationruletranslation": {
+            "directoryName": "validationRules",
+            "id": "validationruletranslation",
+            "isAddressable": false,
+            "name": "ValidationRuleTranslation",
+            "suffix": "validationRuleTranslation",
+            "unaddressableWithoutParent": true,
+            "uniqueIdElement": "name"
+          }
+        }
+      },
+      "directoryName": "objectTranslations",
+      "id": "customobjecttranslation",
+      "inFolder": false,
+      "name": "CustomObjectTranslation",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "topLevel",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "objectTranslation",
+      "supportsWildcardAndName": true
+    },
+    "custompageweblink": {
+      "directoryName": "weblinks",
+      "id": "custompageweblink",
+      "inFolder": false,
+      "legacySuffix": "custompageweblink",
+      "name": "CustomPageWebLink",
+      "strictDirectoryName": false,
+      "suffix": "weblink"
+    },
+    "custompermission": {
+      "directoryName": "customPermissions",
+      "id": "custompermission",
+      "inFolder": false,
+      "name": "CustomPermission",
+      "strictDirectoryName": false,
+      "suffix": "customPermission"
+    },
+    "customsite": {
+      "directoryName": "sites",
+      "id": "customsite",
+      "inFolder": false,
+      "name": "CustomSite",
+      "strictDirectoryName": true,
+      "suffix": "site"
+    },
+    "customtab": {
+      "directoryName": "tabs",
+      "id": "customtab",
+      "inFolder": false,
+      "name": "CustomTab",
+      "strictDirectoryName": false,
+      "suffix": "tab",
+      "supportsWildcardAndName": true
+    },
+    "dashboard": {
+      "directoryName": "dashboards",
+      "folderType": "dashboardfolder",
+      "id": "dashboard",
+      "inFolder": true,
+      "name": "Dashboard",
+      "strictDirectoryName": false,
+      "suffix": "dashboard"
+    },
+    "dashboardfolder": {
+      "directoryName": "dashboards",
+      "folderContentType": "dashboard",
+      "id": "dashboardfolder",
+      "inFolder": false,
+      "name": "DashboardFolder",
+      "strictDirectoryName": false,
+      "suffix": "dashboardFolder"
+    },
+    "datacalcinsighttemplate": {
+      "directoryName": "dataCalcInsightTemplates",
+      "id": "datacalcinsighttemplate",
+      "name": "DataCalcInsightTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataCalcInsightTemplate"
+    },
+    "datacategorygroup": {
+      "directoryName": "datacategorygroups",
+      "id": "datacategorygroup",
+      "inFolder": false,
+      "name": "DataCategoryGroup",
+      "strictDirectoryName": false,
+      "suffix": "datacategorygroup"
+    },
+    "dataconnector": {
+      "directoryName": "dataconnectors",
+      "id": "dataconnector",
+      "inFolder": false,
+      "name": "DataConnector",
+      "strictDirectoryName": false,
+      "suffix": "dataconnector"
+    },
+    "dataconnectoringestapi": {
+      "directoryName": "dataConnectorIngestApis",
+      "id": "dataconnectoringestapi",
+      "inFolder": false,
+      "name": "DataConnectorIngestApi",
+      "strictDirectoryName": false,
+      "suffix": "dataConnectorIngestApi"
+    },
+    "dataconnectors3": {
+      "directoryName": "s3DataConnectors",
+      "id": "dataconnectors3",
+      "name": "DataConnectorS3",
+      "strictDirectoryName": false,
+      "suffix": "s3DataConnector"
+    },
+    "datakitobjectdependency": {
+      "directoryName": "dataKitObjectDependencies",
+      "id": "datakitobjectdependency",
+      "inFolder": false,
+      "name": "DataKitObjectDependency",
+      "suffix": "dataKitObjectDependency"
+    },
+    "datakitobjecttemplate": {
+      "directoryName": "dataKitObjectTemplates",
+      "id": "datakitobjecttemplate",
+      "name": "DataKitObjectTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataKitObjectTemplate"
+    },
+    "dataobjectbuildorgtemplate": {
+      "directoryName": "dataObjectBuildOrgTemplates",
+      "id": "dataobjectbuildorgtemplate",
+      "name": "DataObjectBuildOrgTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataObjectBuildOrgTemplate"
+    },
+    "datapackagekitdefinition": {
+      "directoryName": "dataPackageKitDefinitions",
+      "id": "datapackagekitdefinition",
+      "name": "DataPackageKitDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataPackageKitDefinition"
+    },
+    "datapackagekitobject": {
+      "directoryName": "DataPackageKitObjects",
+      "id": "datapackagekitobject",
+      "name": "DataPackageKitObject",
+      "strictDirectoryName": false,
+      "suffix": "DataPackageKitObject"
+    },
+    "datapipeline": {
+      "directoryName": "dataPipelines",
+      "id": "datapipeline",
+      "inFolder": false,
+      "name": "DataPipeline",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "dataPipeline"
+    },
+    "datasource": {
+      "directoryName": "mktDataSources",
+      "id": "datasource",
+      "name": "DataSource",
+      "strictDirectoryName": true,
+      "suffix": "dataSource"
+    },
+    "datasourcebundledefinition": {
+      "directoryName": "dataSourceBundleDefinitions",
+      "id": "datasourcebundledefinition",
+      "name": "DataSourceBundleDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceBundleDefinition"
+    },
+    "datasourceobject": {
+      "directoryName": "dataSourceObjects",
+      "id": "datasourceobject",
+      "name": "DataSourceObject",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceObject"
+    },
+    "datasourcetenant": {
+      "directoryName": "dataSourceTenants",
+      "id": "datasourcetenant",
+      "inFolder": false,
+      "name": "DataSourceTenant",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceTenant"
+    },
+    "datasrcdatamodelfieldmap": {
+      "directoryName": "dataSrcDataModelFieldMaps",
+      "id": "datasrcdatamodelfieldmap",
+      "name": "DataSrcDataModelFieldMap",
+      "strictDirectoryName": false,
+      "suffix": "dataSrcDataModelFieldMap"
+    },
+    "datastreamdefinition": {
+      "directoryName": "dataStreamDefinitions",
+      "id": "datastreamdefinition",
+      "name": "DataStreamDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataStreamDefinition"
+    },
+    "datastreamtemplate": {
+      "directoryName": "dataStreamTemplates",
+      "id": "datastreamtemplate",
+      "name": "DataStreamTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataStreamTemplate"
+    },
+    "dataweaveresource": {
+      "directoryName": "dw",
+      "id": "dataweaveresource",
+      "inFolder": false,
+      "name": "DataWeaveResource",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "dwl"
+    },
+    "decisionmatrixdefinition": {
+      "directoryName": "decisionMatrixDefinition",
+      "id": "decisionmatrixdefinition",
+      "inFolder": false,
+      "name": "DecisionMatrixDefinition",
+      "strictDirectoryName": false,
+      "suffix": "decisionMatrixDefinition"
+    },
+    "decisionmatrixdefinitionversion": {
+      "directoryName": "decisionMatrixVersion",
+      "id": "decisionmatrixdefinitionversion",
+      "inFolder": false,
+      "name": "DecisionMatrixDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "decisionMatrixVersion"
+    },
+    "decisiontable": {
+      "directoryName": "decisionTables",
+      "id": "decisiontable",
+      "name": "DecisionTable",
+      "strictDirectoryName": false,
+      "suffix": "decisionTable"
+    },
+    "decisiontabledatasetlink": {
+      "directoryName": "decisionTableDatasetLinks",
+      "id": "decisiontabledatasetlink",
+      "name": "DecisionTableDatasetLink",
+      "strictDirectoryName": false,
+      "suffix": "decisionTableDatasetLink"
+    },
+    "delegategroup": {
+      "directoryName": "delegateGroups",
+      "id": "delegategroup",
+      "inFolder": false,
+      "name": "DelegateGroup",
+      "strictDirectoryName": false,
+      "suffix": "delegateGroup"
+    },
+    "digitalexperiencebundle": {
+      "children": {
+        "directories": {
+          "digitalExperiences": "digitalexperience"
+        },
+        "suffixes": {
+          "digitalExperience": "digitalexperience"
+        },
+        "types": {
+          "digitalexperience": {
+            "directoryName": "digitalExperiences",
+            "id": "digitalexperience",
+            "metaFileSuffix": "_meta.json",
+            "name": "DigitalExperience",
+            "strategies": {
+              "adapter": "digitalExperience"
+            },
+            "suffix": "digitalExperience",
+            "supportsPartialDelete": true
+          }
+        }
+      },
+      "directoryName": "digitalExperiences",
+      "id": "digitalexperiencebundle",
+      "inFolder": false,
+      "name": "DigitalExperienceBundle",
+      "strategies": {
+        "adapter": "digitalExperience"
+      },
+      "suffix": "digitalExperience",
+      "supportsPartialDelete": true,
+      "supportsWildcardAndName": true
+    },
+    "digitalexperienceconfig": {
+      "directoryName": "digitalExperienceConfigs",
+      "id": "digitalexperienceconfig",
+      "inFolder": false,
+      "name": "DigitalExperienceConfig",
+      "strictDirectoryName": false,
+      "suffix": "digitalExperienceConfig"
+    },
+    "disclosuredefinition": {
+      "directoryName": "disclosureDefinitions",
+      "id": "disclosuredefinition",
+      "inFolder": false,
+      "name": "DisclosureDefinition",
+      "strictDirectoryName": false,
+      "suffix": "disclosureDefinition"
+    },
+    "disclosuredefinitionversion": {
+      "directoryName": "disclosureDefinitionVersions",
+      "id": "disclosuredefinitionversion",
+      "inFolder": false,
+      "name": "DisclosureDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "disclosureDefinitionVersion"
+    },
+    "disclosuretype": {
+      "directoryName": "disclosureTypes",
+      "id": "disclosuretype",
+      "inFolder": false,
+      "name": "DisclosureType",
+      "strictDirectoryName": false,
+      "suffix": "disclosureType"
+    },
+    "discoveryaimodel": {
+      "directoryName": "discovery",
+      "id": "discoveryaimodel",
+      "name": "DiscoveryAIModel",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "model"
+    },
+    "discoverygoal": {
+      "directoryName": "discovery",
+      "id": "discoverygoal",
+      "name": "DiscoveryGoal",
+      "strictDirectoryName": false,
+      "suffix": "goal"
+    },
+    "discoverystory": {
+      "directoryName": "discovery",
+      "id": "discoverystory",
+      "inFolder": false,
+      "name": "DiscoveryStory",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "story"
+    },
+    "document": {
+      "directoryName": "documents",
+      "folderType": "documentfolder",
+      "id": "document",
+      "inFolder": true,
+      "name": "Document",
+      "strategies": {
+        "adapter": "mixedContent"
+      },
+      "strictDirectoryName": true,
+      "suffix": "document"
+    },
+    "documentcategory": {
+      "directoryName": "documentCategory",
+      "id": "documentcategory",
+      "inFolder": false,
+      "name": "DocumentCategory",
+      "strictDirectoryName": false,
+      "suffix": "documentCategory"
+    },
+    "documentcategorydocumenttype": {
+      "directoryName": "documentCategoryDocumentTypes",
+      "id": "documentcategorydocumenttype",
+      "inFolder": false,
+      "name": "DocumentCategoryDocumentType",
+      "strictDirectoryName": false,
+      "suffix": "documentCategoryDocumentType"
+    },
+    "documentfolder": {
+      "directoryName": "documents",
+      "folderContentType": "document",
+      "id": "documentfolder",
+      "inFolder": false,
+      "name": "DocumentFolder",
+      "strictDirectoryName": false,
+      "suffix": "documentFolder"
+    },
+    "documentgenerationsetting": {
+      "directoryName": "documentGenerationSettings",
+      "id": "documentgenerationsetting",
+      "inFolder": false,
+      "name": "DocumentGenerationSetting",
+      "suffix": "documentGenerationSetting"
+    },
+    "documenttemplate": {
+      "directoryName": "documentTemplates",
+      "id": "documenttemplate",
+      "inFolder": false,
+      "name": "DocumentTemplate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "dt"
+    },
+    "documenttype": {
+      "directoryName": "documentTypes",
+      "id": "documenttype",
+      "name": "DocumentType",
+      "strictDirectoryName": false,
+      "suffix": "documentType"
+    },
+    "duplicaterule": {
+      "directoryName": "duplicateRules",
+      "id": "duplicaterule",
+      "inFolder": false,
+      "name": "DuplicateRule",
+      "strictDirectoryName": false,
+      "suffix": "duplicateRule"
+    },
+    "dynamictrigger": {
+      "directoryName": "dynamicTriggers",
+      "id": "dynamictrigger",
+      "name": "DynamicTrigger",
+      "strictDirectoryName": false,
+      "suffix": "dynamicTrigger"
+    },
+    "eclairgeodata": {
+      "directoryName": "eclair",
+      "id": "eclairgeodata",
+      "inFolder": false,
+      "name": "EclairGeoData",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "geodata"
+    },
+    "emailfolder": {
+      "directoryName": "email",
+      "folderContentType": "emailtemplate",
+      "id": "emailfolder",
+      "inFolder": false,
+      "name": "EmailFolder",
+      "strictDirectoryName": false,
+      "suffix": "emailFolder"
+    },
+    "emailservicesfunction": {
+      "directoryName": "emailservices",
+      "id": "emailservicesfunction",
+      "inFolder": false,
+      "name": "EmailServicesFunction",
+      "strictDirectoryName": true,
+      "suffix": "xml"
+    },
+    "emailtemplate": {
+      "directoryName": "email",
+      "folderType": "emailfolder",
+      "id": "emailtemplate",
+      "inFolder": true,
+      "name": "EmailTemplate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "email"
+    },
+    "emailtemplatefolder": {
+      "aliasFor": "emailfolder",
+      "directoryName": "email",
+      "folderContentType": "emailtemplate",
+      "id": "emailtemplatefolder",
+      "inFolder": false,
+      "name": "EmailTemplateFolder",
+      "strictDirectoryName": false,
+      "suffix": "emailTemplateFolder"
+    },
+    "embeddedservicebranding": {
+      "directoryName": "EmbeddedServiceBranding",
+      "id": "embeddedservicebranding",
+      "inFolder": false,
+      "name": "EmbeddedServiceBranding",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceBranding"
+    },
+    "embeddedserviceconfig": {
+      "directoryName": "EmbeddedServiceConfig",
+      "id": "embeddedserviceconfig",
+      "inFolder": false,
+      "name": "EmbeddedServiceConfig",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceConfig"
+    },
+    "embeddedservicefieldservice": {
+      "directoryName": "EmbeddedServiceFieldService",
+      "id": "embeddedservicefieldservice",
+      "inFolder": false,
+      "name": "EmbeddedServiceFieldService",
+      "suffix": "EmbeddedServiceFieldService"
+    },
+    "embeddedserviceflowconfig": {
+      "directoryName": "EmbeddedServiceFlowConfig",
+      "id": "embeddedserviceflowconfig",
+      "inFolder": false,
+      "name": "EmbeddedServiceFlowConfig",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceFlowConfig"
+    },
+    "embeddedserviceliveagent": {
+      "directoryName": "EmbeddedServiceLiveAgent",
+      "id": "embeddedserviceliveagent",
+      "inFolder": false,
+      "name": "EmbeddedServiceLiveAgent",
+      "suffix": "EmbeddedServiceLiveAgent"
+    },
+    "embeddedservicemenusettings": {
+      "directoryName": "EmbeddedServiceMenuSettings",
+      "id": "embeddedservicemenusettings",
+      "inFolder": false,
+      "name": "EmbeddedServiceMenuSettings",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceMenuSettings"
+    },
+    "employeedatasyncprofile": {
+      "directoryName": "employeeDataSyncProfiles",
+      "id": "employeedatasyncprofile",
+      "inFolder": false,
+      "name": "EmployeeDataSyncProfile",
+      "strictDirectoryName": false,
+      "suffix": "employeeDataSyncProfile"
+    },
+    "enablementmeasuredefinition": {
+      "directoryName": "enablementMeasureDefinitions",
+      "id": "enablementmeasuredefinition",
+      "inFolder": false,
+      "name": "EnablementMeasureDefinition",
+      "strictDirectoryName": false,
+      "suffix": "enablementMeasureDefinition"
+    },
+    "enablementprogramdefinition": {
+      "directoryName": "enablementProgramDefinitions",
+      "id": "enablementprogramdefinition",
+      "inFolder": false,
+      "name": "EnablementProgramDefinition",
+      "strictDirectoryName": false,
+      "suffix": "enablementProgramDefinition"
+    },
+    "enblprogramtasksubcategory": {
+      "directoryName": "enblProgramTaskSubCategories",
+      "id": "enblprogramtasksubcategory",
+      "inFolder": false,
+      "name": "EnblProgramTaskSubCategory",
+      "strictDirectoryName": false,
+      "suffix": "enblProgramTaskSubCategory"
+    },
+    "entitlementprocess": {
+      "directoryName": "entitlementProcesses",
+      "id": "entitlementprocess",
+      "inFolder": false,
+      "name": "EntitlementProcess",
+      "suffix": "entitlementProcess"
+    },
+    "entitlementtemplate": {
+      "directoryName": "entitlementTemplates",
+      "id": "entitlementtemplate",
+      "inFolder": false,
+      "name": "EntitlementTemplate",
+      "suffix": "entitlementTemplate"
+    },
+    "entityimplements": {
+      "directoryName": "entityImplements",
+      "id": "entityimplements",
+      "inFolder": false,
+      "name": "EntityImplements",
+      "strictDirectoryName": false,
+      "suffix": "entityImplements"
+    },
+    "escalationrules": {
+      "children": {
+        "directories": {
+          "escalationRules": "escalationrule"
+        },
+        "suffixes": {
+          "escalationRule": "escalationrule"
+        },
+        "types": {
+          "escalationrule": {
+            "directoryName": "escalationRules",
+            "id": "escalationrule",
+            "name": "EscalationRule",
+            "suffix": "escalationRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "escalationRule"
+          }
+        }
+      },
+      "directoryName": "escalationRules",
+      "id": "escalationrules",
+      "inFolder": false,
+      "name": "EscalationRules",
+      "strictDirectoryName": false,
+      "suffix": "escalationRules"
+    },
+    "esignatureconfig": {
+      "directoryName": "eSignatureConfigs",
+      "id": "esignatureconfig",
+      "inFolder": false,
+      "name": "ESignatureConfig",
+      "strictDirectoryName": false,
+      "suffix": "eSignatureConfig"
+    },
+    "esignatureenvelopeconfig": {
+      "directoryName": "eSignatureEnvelopeConfigs",
+      "id": "esignatureenvelopeconfig",
+      "inFolder": false,
+      "name": "ESignatureEnvelopeConfig",
+      "strictDirectoryName": false,
+      "suffix": "eSignatureEnvelopeConfig"
+    },
+    "eventdelivery": {
+      "directoryName": "eventDeliveries",
+      "id": "eventdelivery",
+      "inFolder": false,
+      "name": "EventDelivery",
+      "suffix": "delivery"
+    },
+    "eventrelayconfig": {
+      "directoryName": "eventRelays",
+      "id": "eventrelayconfig",
+      "inFolder": false,
+      "name": "EventRelayConfig",
+      "strictDirectoryName": false,
+      "suffix": "eventRelay"
+    },
+    "eventsubscription": {
+      "directoryName": "eventSubscriptions",
+      "id": "eventsubscription",
+      "inFolder": false,
+      "name": "EventSubscription",
+      "suffix": "subscription"
+    },
+    "eventtype": {
+      "directoryName": "eventTypes",
+      "id": "eventtype",
+      "inFolder": false,
+      "name": "EventType",
+      "suffix": "eventType"
+    },
+    "experiencebundle": {
+      "directoryName": "experiences",
+      "id": "experiencebundle",
+      "inFolder": false,
+      "name": "ExperienceBundle",
+      "strategies": {
+        "adapter": "mixedContent"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "experiencepropertytypebundle": {
+      "directoryName": "experiencePropertyTypeBundles",
+      "id": "experiencepropertytypebundle",
+      "inFolder": false,
+      "metaFileSuffix": "schema.json",
+      "name": "ExperiencePropertyTypeBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "explainabilityactiondefinition": {
+      "directoryName": "ExplainabilityActionDefinitions",
+      "id": "explainabilityactiondefinition",
+      "inFolder": false,
+      "name": "ExplainabilityActionDefinition",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityActionDefinition"
+    },
+    "explainabilityactionversion": {
+      "directoryName": "ExplainabilityActionVersions",
+      "id": "explainabilityactionversion",
+      "inFolder": false,
+      "name": "ExplainabilityActionVersion",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityActionVersion"
+    },
+    "explainabilitymsgtemplate": {
+      "directoryName": "ExplainabilityMsgTemplates",
+      "id": "explainabilitymsgtemplate",
+      "inFolder": false,
+      "name": "ExplainabilityMsgTemplate",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityMsgTemplate"
+    },
+    "expressionsetdefinition": {
+      "directoryName": "expressionSetDefinition",
+      "id": "expressionsetdefinition",
+      "inFolder": false,
+      "name": "ExpressionSetDefinition",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetDefinition"
+    },
+    "expressionsetdefinitionversion": {
+      "directoryName": "expressionSetVersion",
+      "id": "expressionsetdefinitionversion",
+      "inFolder": false,
+      "name": "ExpressionSetDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetVersion"
+    },
+    "expressionsetmessagetoken": {
+      "directoryName": "expressionSetMessageToken",
+      "id": "expressionsetmessagetoken",
+      "inFolder": false,
+      "name": "ExpressionSetMessageToken",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetMessageToken"
+    },
+    "expressionsetobjectalias": {
+      "directoryName": "expressionSetObjectAlias",
+      "id": "expressionsetobjectalias",
+      "name": "ExpressionSetObjectAlias",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetObjectAlias"
+    },
+    "extdatatranobjecttemplate": {
+      "children": {
+        "directories": {
+          "extDataTranFieldTemplates": "extdatatranfieldtemplate"
+        },
+        "suffixes": {
+          "extDataTranFieldTemplate": "extdatatranfieldtemplate"
+        },
+        "types": {
+          "extdatatranfieldtemplate": {
+            "directoryName": "extDataTranFieldTemplates",
+            "id": "extdatatranfieldtemplate",
+            "name": "extDataTranFieldTemplate",
+            "suffix": "extDataTranFieldTemplate"
+          }
+        }
+      },
+      "directoryName": "extDataTranObjectTemplates",
+      "id": "extdatatranobjecttemplate",
+      "name": "ExtDataTranObjectTemplate",
+      "strictDirectoryName": false,
+      "suffix": "extDataTranObjectTemplate"
+    },
+    "externalaimodel": {
+      "directoryName": "externalAIModels",
+      "id": "externalaimodel",
+      "inFolder": false,
+      "name": "ExternalAIModel",
+      "strictDirectoryName": false,
+      "suffix": "externalAIModel"
+    },
+    "externalauthidentityprovider": {
+      "directoryName": "externalAuthIdentityProviders",
+      "id": "externalauthidentityprovider",
+      "inFolder": false,
+      "name": "ExternalAuthIdentityProvider",
+      "strictDirectoryName": false,
+      "suffix": "externalAuthIdentityProvider"
+    },
+    "externalclientapplication": {
+      "directoryName": "externalClientApps",
+      "id": "externalclientapplication",
+      "inFolder": false,
+      "name": "ExternalClientApplication",
+      "strictDirectoryName": false,
+      "suffix": "eca"
+    },
+    "externalcredential": {
+      "directoryName": "externalCredentials",
+      "id": "externalcredential",
+      "inFolder": false,
+      "name": "ExternalCredential",
+      "strictDirectoryName": false,
+      "suffix": "externalCredential"
+    },
+    "externaldataconnector": {
+      "directoryName": "externalDataConnectors",
+      "id": "externaldataconnector",
+      "name": "ExternalDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "externalDataConnector"
+    },
+    "externaldatasource": {
+      "directoryName": "dataSources",
+      "id": "externaldatasource",
+      "inFolder": false,
+      "name": "ExternalDataSource",
+      "strictDirectoryName": false,
+      "suffix": "dataSource"
+    },
+    "externaldatatranobject": {
+      "directoryName": "externalDataTranObjects",
+      "id": "externaldatatranobject",
+      "inFolder": false,
+      "name": "ExternalDataTranObject",
+      "strictDirectoryName": false,
+      "suffix": "externalDataTranObject"
+    },
+    "externaldocstorageconfig": {
+      "directoryName": "externalDocStorageConfigs",
+      "id": "externaldocstorageconfig",
+      "inFolder": false,
+      "name": "ExternalDocStorageConfig",
+      "strictDirectoryName": false,
+      "suffix": "externalDocStorageConfig"
+    },
+    "externalserviceregistration": {
+      "directoryName": "externalServiceRegistrations",
+      "id": "externalserviceregistration",
+      "inFolder": false,
+      "name": "ExternalServiceRegistration",
+      "strictDirectoryName": false,
+      "suffix": "externalServiceRegistration"
+    },
+    "extlclntappconfigurablepolicies": {
+      "directoryName": "extlClntAppPolicies",
+      "id": "extlclntappconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaPlcy"
+    },
+    "extlclntappglobaloauthsettings": {
+      "directoryName": "extlClntAppGlobalOauthSets",
+      "id": "extlclntappglobaloauthsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppGlobalOauthSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaGlblOauth"
+    },
+    "extlclntappmobileconfigurablepolicies": {
+      "directoryName": "extlClntAppMobilePolicies",
+      "id": "extlclntappmobileconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppMobileConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaMobilePlcy"
+    },
+    "extlclntappmobilesettings": {
+      "directoryName": "extlClntAppMobileSettings",
+      "id": "extlclntappmobilesettings",
+      "inFolder": false,
+      "name": "ExtlClntAppMobileSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaMobile"
+    },
+    "extlclntappnotificationsettings": {
+      "directoryName": "extlClntAppNotifSettings",
+      "id": "extlclntappnotificationsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppNotificationSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaNotifications"
+    },
+    "extlclntappoauthconfigurablepolicies": {
+      "directoryName": "extlClntAppOauthPolicies",
+      "id": "extlclntappoauthconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppOauthConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaOauthPlcy"
+    },
+    "extlclntappoauthsettings": {
+      "directoryName": "extlClntAppOauthSettings",
+      "id": "extlclntappoauthsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppOauthSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaOauth"
+    },
+    "extlclntappsamlconfigurablepolicies": {
+      "directoryName": "extlClntAppSamlConfigurablePolicies",
+      "id": "extlclntappsamlconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppSamlConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaSamlPlcy"
+    },
+    "extlclntappsampleconfigurablepolicies": {
+      "directoryName": "extlClntAppSamplePolicies",
+      "id": "extlclntappsampleconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppSampleConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaSmplPlcy"
+    },
+    "extlclntappsamplesettings": {
+      "directoryName": "extlClntAppSampleSettings",
+      "id": "extlclntappsamplesettings",
+      "inFolder": false,
+      "name": "ExtlClntAppSampleSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaSmpl"
+    },
+    "featureparameterboolean": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterboolean",
+      "inFolder": false,
+      "name": "FeatureParameterBoolean",
+      "suffix": "featureParameterBoolean"
+    },
+    "featureparameterdate": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterdate",
+      "inFolder": false,
+      "name": "FeatureParameterDate",
+      "suffix": "featureParameterDate"
+    },
+    "featureparameterinteger": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterinteger",
+      "inFolder": false,
+      "name": "FeatureParameterInteger",
+      "suffix": "featureParameterInteger"
+    },
+    "fieldrestrictionrule": {
+      "directoryName": "fieldRestrictionRules",
+      "id": "fieldrestrictionrule",
+      "inFolder": false,
+      "name": "FieldRestrictionRule",
+      "strictDirectoryName": true,
+      "suffix": "rule"
+    },
+    "fieldservicemobileextension": {
+      "directoryName": "fieldServiceMobileExtensions",
+      "id": "fieldservicemobileextension",
+      "name": "FieldServiceMobileExtension",
+      "strictDirectoryName": false,
+      "suffix": "fieldServiceMobileExtension"
+    },
+    "fieldsrctrgtrelationship": {
+      "directoryName": "fieldSrcTrgtRelationships",
+      "id": "fieldsrctrgtrelationship",
+      "name": "FieldSrcTrgtRelationship",
+      "strictDirectoryName": false,
+      "suffix": "fieldSrcTrgtRelationship"
+    },
+    "flexipage": {
+      "directoryName": "flexipages",
+      "id": "flexipage",
+      "inFolder": false,
+      "name": "FlexiPage",
+      "strictDirectoryName": false,
+      "suffix": "flexipage"
+    },
+    "flow": {
+      "directoryName": "flows",
+      "id": "flow",
+      "inFolder": false,
+      "name": "Flow",
+      "strictDirectoryName": false,
+      "suffix": "flow",
+      "supportsWildcardAndName": true
+    },
+    "flowcategory": {
+      "directoryName": "flowCategories",
+      "id": "flowcategory",
+      "inFolder": false,
+      "name": "FlowCategory",
+      "strictDirectoryName": false,
+      "suffix": "flowCategory"
+    },
+    "flowdefinition": {
+      "directoryName": "flowDefinitions",
+      "id": "flowdefinition",
+      "inFolder": false,
+      "name": "FlowDefinition",
+      "strictDirectoryName": false,
+      "suffix": "flowDefinition",
+      "supportsWildcardAndName": true
+    },
+    "flowtest": {
+      "directoryName": "flowtests",
+      "id": "flowtest",
+      "inFolder": false,
+      "name": "FlowTest",
+      "strictDirectoryName": false,
+      "suffix": "flowtest"
+    },
+    "forecastingfilter": {
+      "directoryName": "forecastingFilters",
+      "id": "forecastingfilter",
+      "inFolder": false,
+      "name": "ForecastingFilter",
+      "strictDirectoryName": false,
+      "suffix": "forecastingFilter"
+    },
+    "forecastingfiltercondition": {
+      "directoryName": "forecastingFilterConditions",
+      "id": "forecastingfiltercondition",
+      "inFolder": false,
+      "name": "ForecastingFilterCondition",
+      "strictDirectoryName": false,
+      "suffix": "forecastingFilterCondition"
+    },
+    "forecastinggroup": {
+      "directoryName": "forecastingGroups",
+      "id": "forecastinggroup",
+      "inFolder": false,
+      "name": "ForecastingGroup",
+      "strictDirectoryName": false,
+      "suffix": "forecastingGroup"
+    },
+    "forecastingsourcedefinition": {
+      "directoryName": "forecastingSourceDefinitions",
+      "id": "forecastingsourcedefinition",
+      "inFolder": false,
+      "name": "ForecastingSourceDefinition",
+      "suffix": "forecastingSourceDefinition"
+    },
+    "forecastingtype": {
+      "directoryName": "forecastingTypes",
+      "id": "forecastingtype",
+      "inFolder": false,
+      "name": "ForecastingType",
+      "suffix": "forecastingType"
+    },
+    "forecastingtypesource": {
+      "directoryName": "forecastingTypeSources",
+      "id": "forecastingtypesource",
+      "inFolder": false,
+      "name": "ForecastingTypeSource",
+      "suffix": "forecastingTypeSource"
+    },
+    "form": {
+      "children": {
+        "directories": {
+          "formSections": "formsection"
+        },
+        "suffixes": {
+          "formSection": "formsection"
+        },
+        "types": {
+          "formsection": {
+            "directoryName": "formSections",
+            "id": "formsection",
+            "name": "FormSection",
+            "suffix": "formSection"
+          }
+        }
+      },
+      "directoryName": "forms",
+      "id": "form",
+      "inFolder": false,
+      "name": "Form",
+      "suffix": "form"
+    },
+    "fueltype": {
+      "directoryName": "fuelTypes",
+      "id": "fueltype",
+      "inFolder": false,
+      "name": "FuelType",
+      "strictDirectoryName": false,
+      "suffix": "fuelType"
+    },
+    "fueltypesustnuom": {
+      "directoryName": "fuelTypeSustnUoms",
+      "id": "fueltypesustnuom",
+      "inFolder": false,
+      "name": "FuelTypeSustnUom",
+      "strictDirectoryName": false,
+      "suffix": "fuelTypeSustnUom"
+    },
+    "functionreference": {
+      "directoryName": "functions",
+      "id": "functionreference",
+      "name": "FunctionReference",
+      "strictDirectoryName": false,
+      "suffix": "function"
+    },
+    "fundraisingconfig": {
+      "directoryName": "fundraisingConfigs",
+      "id": "fundraisingconfig",
+      "inFolder": false,
+      "name": "FundraisingConfig",
+      "strictDirectoryName": false,
+      "suffix": "fundraisingConfig"
+    },
+    "gatewayproviderpaymentmethodtype": {
+      "directoryName": "gatewayProviderPaymentMethodTypes",
+      "id": "gatewayproviderpaymentmethodtype",
+      "name": "GatewayProviderPaymentMethodType",
+      "strictDirectoryName": false,
+      "suffix": "gatewayProviderPaymentMethodType"
+    },
+    "genaifunction": {
+      "directoryName": "genAiFunctions",
+      "id": "genaifunction",
+      "inFolder": false,
+      "name": "GenAiFunction",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true
+    },
+    "genaiplanner": {
+      "directoryName": "genAiPlanners",
+      "id": "genaiplanner",
+      "inFolder": false,
+      "name": "GenAiPlanner",
+      "suffix": "genAiPlanner"
+    },
+    "genaiplannerbundle": {
+      "directoryName": "genAiPlannerBundles",
+      "id": "genaiplannerbundle",
+      "inFolder": false,
+      "name": "GenAiPlannerBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true
+    },
+    "genaiplugin": {
+      "directoryName": "genAiPlugins",
+      "id": "genaiplugin",
+      "inFolder": false,
+      "name": "GenAiPlugin",
+      "strictDirectoryName": false,
+      "suffix": "genAiPlugin"
+    },
+    "genaiprompttemplate": {
+      "directoryName": "genAiPromptTemplates",
+      "id": "genaiprompttemplate",
+      "inFolder": false,
+      "name": "GenAiPromptTemplate",
+      "strictDirectoryName": false,
+      "suffix": "genAiPromptTemplate"
+    },
+    "genaiprompttemplateactv": {
+      "directoryName": "genAiPromptTemplateActivations",
+      "id": "genaiprompttemplateactv",
+      "inFolder": false,
+      "name": "GenAiPromptTemplateActv",
+      "strictDirectoryName": false,
+      "suffix": "genAiPromptTemplateActivation"
+    },
+    "globalpicklist": {
+      "directoryName": "globalPicklists",
+      "id": "globalpicklist",
+      "inFolder": false,
+      "name": "GlobalPicklist",
+      "suffix": "globalPicklist"
+    },
+    "globalvalueset": {
+      "directoryName": "globalValueSets",
+      "id": "globalvalueset",
+      "inFolder": false,
+      "name": "GlobalValueSet",
+      "strictDirectoryName": false,
+      "suffix": "globalValueSet",
+      "supportsWildcardAndName": true
+    },
+    "globalvaluesettranslation": {
+      "directoryName": "globalValueSetTranslations",
+      "id": "globalvaluesettranslation",
+      "inFolder": false,
+      "name": "GlobalValueSetTranslation",
+      "strictDirectoryName": false,
+      "suffix": "globalValueSetTranslation",
+      "supportsWildcardAndName": true
+    },
+    "group": {
+      "directoryName": "groups",
+      "id": "group",
+      "inFolder": false,
+      "name": "Group",
+      "strictDirectoryName": false,
+      "suffix": "group"
+    },
+    "homepagecomponent": {
+      "directoryName": "homePageComponents",
+      "id": "homepagecomponent",
+      "inFolder": false,
+      "name": "HomePageComponent",
+      "strictDirectoryName": false,
+      "suffix": "homePageComponent"
+    },
+    "homepagelayout": {
+      "directoryName": "homePageLayouts",
+      "id": "homepagelayout",
+      "inFolder": false,
+      "name": "HomePageLayout",
+      "strictDirectoryName": false,
+      "suffix": "homePageLayout"
+    },
+    "icon": {
+      "directoryName": "icons",
+      "id": "icon",
+      "name": "Icon",
+      "strictDirectoryName": false,
+      "suffix": "icon"
+    },
+    "identityverificationprocdef": {
+      "directoryName": "IdentityVerificationProcDefs",
+      "id": "identityverificationprocdef",
+      "inFolder": false,
+      "name": "IdentityVerificationProcDef",
+      "strictDirectoryName": false,
+      "suffix": "IdentityVerificationProcDef"
+    },
+    "iframewhitelisturlsettings": {
+      "directoryName": "iframeWhiteListUrlSettings",
+      "id": "iframewhitelisturlsettings",
+      "inFolder": false,
+      "name": "IframeWhiteListUrlSettings",
+      "strictDirectoryName": false,
+      "suffix": "iframeWhiteListUrlSettings"
+    },
+    "inboundcertificate": {
+      "directoryName": "inboundCertificates",
+      "id": "inboundcertificate",
+      "inFolder": false,
+      "name": "InboundCertificate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "inboundCertificate"
+    },
+    "inboundnetworkconnection": {
+      "directoryName": "inboundNetworkConnections",
+      "id": "inboundnetworkconnection",
+      "inFolder": false,
+      "name": "InboundNetworkConnection",
+      "strictDirectoryName": false,
+      "suffix": "inboundNetworkConnection"
+    },
+    "industriesmanufacturingsettings": {
+      "directoryName": "IndustriesManufacturingSettings",
+      "id": "industriesmanufacturingsettings",
+      "name": "IndustriesManufacturingSettings",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "insighttype": {
+      "directoryName": "insightTypes",
+      "id": "insighttype",
+      "inFolder": false,
+      "name": "InsightType",
+      "suffix": "insightType"
+    },
+    "installedpackage": {
+      "directoryName": "installedPackages",
+      "id": "installedpackage",
+      "inFolder": false,
+      "name": "InstalledPackage",
+      "strictDirectoryName": false,
+      "suffix": "installedPackage"
+    },
+    "integrationhubsettings": {
+      "directoryName": "integrationHub",
+      "id": "integrationhubsettings",
+      "inFolder": false,
+      "name": "IntegrationHubSettings",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "integrationhubsettingstype": {
+      "directoryName": "integrationHub",
+      "id": "integrationhubsettingstype",
+      "inFolder": false,
+      "name": "IntegrationHubSettingsType",
+      "suffix": "type"
+    },
+    "integrationproviderdef": {
+      "directoryName": "integrationProviderDefinitions",
+      "id": "integrationproviderdef",
+      "inFolder": false,
+      "name": "IntegrationProviderDef",
+      "strictDirectoryName": false,
+      "suffix": "integrationProviderDefinition"
+    },
+    "internaldataconnector": {
+      "directoryName": "internalDataConnectors",
+      "id": "internaldataconnector",
+      "inFolder": false,
+      "name": "InternalDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "internalDataConnector"
+    },
+    "internalorganization": {
+      "directoryName": "internalOrganizations",
+      "id": "internalorganization",
+      "inFolder": false,
+      "name": "InternalOrganization",
+      "suffix": "internalOrganization"
+    },
+    "ipaddressrange": {
+      "directoryName": "IPAddressRanges",
+      "id": "ipaddressrange",
+      "inFolder": false,
+      "name": "IPAddressRange",
+      "strictDirectoryName": false,
+      "suffix": "IPAddressRange"
+    },
+    "keywordlist": {
+      "directoryName": "moderation",
+      "id": "keywordlist",
+      "inFolder": false,
+      "name": "KeywordList",
+      "strictDirectoryName": false,
+      "suffix": "keywords"
+    },
+    "layout": {
+      "directoryName": "layouts",
+      "id": "layout",
+      "inFolder": false,
+      "name": "Layout",
+      "strictDirectoryName": false,
+      "suffix": "layout",
+      "supportsWildcardAndName": true
+    },
+    "leadconvertsettings": {
+      "directoryName": "LeadConvertSettings",
+      "id": "leadconvertsettings",
+      "inFolder": false,
+      "name": "LeadConvertSettings",
+      "strictDirectoryName": false,
+      "suffix": "LeadConvertSetting"
+    },
+    "learningachievementconfig": {
+      "directoryName": "learningAchievementConfigs",
+      "id": "learningachievementconfig",
+      "inFolder": false,
+      "name": "LearningAchievementConfig",
+      "strictDirectoryName": false,
+      "suffix": "learningAchievementConfig"
+    },
+    "learningitemtype": {
+      "directoryName": "learningItemTypes",
+      "id": "learningitemtype",
+      "inFolder": false,
+      "name": "LearningItemType",
+      "strictDirectoryName": false,
+      "suffix": "learningItemType"
+    },
+    "letterhead": {
+      "directoryName": "letterhead",
+      "id": "letterhead",
+      "inFolder": false,
+      "name": "Letterhead",
+      "strictDirectoryName": false,
+      "suffix": "letter",
+      "supportsWildcardAndName": true
+    },
+    "licensedefinition": {
+      "directoryName": "licenseDefinitions",
+      "id": "licensedefinition",
+      "inFolder": false,
+      "name": "LicenseDefinition",
+      "suffix": "licenseDefinition"
+    },
+    "lightningbolt": {
+      "directoryName": "lightningBolts",
+      "id": "lightningbolt",
+      "inFolder": false,
+      "name": "LightningBolt",
+      "strictDirectoryName": false,
+      "suffix": "lightningBolt"
+    },
+    "lightningcomponentbundle": {
+      "directoryName": "lwc",
+      "id": "lightningcomponentbundle",
+      "inFolder": false,
+      "name": "LightningComponentBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "lightningexperiencetheme": {
+      "directoryName": "lightningExperienceThemes",
+      "id": "lightningexperiencetheme",
+      "inFolder": false,
+      "name": "LightningExperienceTheme",
+      "strictDirectoryName": false,
+      "suffix": "lightningExperienceTheme"
+    },
+    "lightningmessagechannel": {
+      "directoryName": "messageChannels",
+      "id": "lightningmessagechannel",
+      "inFolder": false,
+      "name": "LightningMessageChannel",
+      "strictDirectoryName": false,
+      "suffix": "messageChannel"
+    },
+    "lightningonboardingconfig": {
+      "directoryName": "lightningOnboardingConfigs",
+      "id": "lightningonboardingconfig",
+      "inFolder": false,
+      "name": "LightningOnboardingConfig",
+      "strictDirectoryName": false,
+      "suffix": "lightningOnboardingConfig"
+    },
+    "livechatagentconfig": {
+      "directoryName": "liveChatAgentConfigs",
+      "id": "livechatagentconfig",
+      "inFolder": false,
+      "name": "LiveChatAgentConfig",
+      "suffix": "liveChatAgentConfig"
+    },
+    "livechatbutton": {
+      "directoryName": "liveChatButtons",
+      "id": "livechatbutton",
+      "inFolder": false,
+      "name": "LiveChatButton",
+      "suffix": "liveChatButton"
+    },
+    "livechatdeployment": {
+      "directoryName": "liveChatDeployments",
+      "id": "livechatdeployment",
+      "inFolder": false,
+      "name": "LiveChatDeployment",
+      "suffix": "liveChatDeployment"
+    },
+    "livechatsensitivedatarule": {
+      "directoryName": "liveChatSensitiveDataRule",
+      "id": "livechatsensitivedatarule",
+      "inFolder": false,
+      "name": "LiveChatSensitiveDataRule",
+      "suffix": "liveChatSensitiveDataRule"
+    },
+    "locationuse": {
+      "directoryName": "locationUses",
+      "id": "locationuse",
+      "inFolder": false,
+      "name": "LocationUse",
+      "strictDirectoryName": false,
+      "suffix": "locationUse"
+    },
+    "loyaltyprogramsetup": {
+      "directoryName": "loyaltyProgramSetups",
+      "id": "loyaltyprogramsetup",
+      "name": "LoyaltyProgramSetup",
+      "strictDirectoryName": false,
+      "suffix": "loyaltyProgramSetup"
+    },
+    "managedcontenttype": {
+      "directoryName": "managedContentTypes",
+      "id": "managedcontenttype",
+      "inFolder": false,
+      "name": "ManagedContentType",
+      "strictDirectoryName": false,
+      "suffix": "managedContentType"
+    },
+    "managedeventsubscription": {
+      "directoryName": "managedEventSubscriptions",
+      "id": "managedeventsubscription",
+      "inFolder": false,
+      "name": "ManagedEventSubscription",
+      "strictDirectoryName": false,
+      "suffix": "managedEventSubscription"
+    },
+    "managedtopics": {
+      "children": {
+        "directories": {
+          "managedTopics": "managedtopic"
+        },
+        "suffixes": {
+          "managedTopic": "managedtopic"
+        },
+        "types": {
+          "managedtopic": {
+            "directoryName": "managedTopics",
+            "id": "managedtopic",
+            "name": "ManagedTopic",
+            "suffix": "managedTopic"
+          }
+        }
+      },
+      "directoryName": "managedTopics",
+      "id": "managedtopics",
+      "inFolder": false,
+      "name": "ManagedTopics",
+      "strictDirectoryName": false,
+      "suffix": "managedTopics"
+    },
+    "marketingappextension": {
+      "directoryName": "marketingappextensions",
+      "id": "marketingappextension",
+      "inFolder": false,
+      "name": "MarketingAppExtension",
+      "suffix": "marketingappextension"
+    },
+    "marketingresourcetype": {
+      "directoryName": "marketingResourceType",
+      "id": "marketingresourcetype",
+      "inFolder": false,
+      "name": "MarketingResourceType",
+      "suffix": "marketingResourceType"
+    },
+    "marketsegmentdefinition": {
+      "directoryName": "marketSegmentDefinitions",
+      "id": "marketsegmentdefinition",
+      "inFolder": false,
+      "name": "MarketSegmentDefinition",
+      "strictDirectoryName": false,
+      "suffix": "marketSegmentDefinition"
+    },
+    "matchingrules": {
+      "children": {
+        "directories": {
+          "matchingRules": "matchingrule"
+        },
+        "suffixes": {
+          "matchingRule": "matchingrule"
+        },
+        "types": {
+          "matchingrule": {
+            "directoryName": "matchingRules",
+            "id": "matchingrule",
+            "name": "MatchingRule",
+            "suffix": "matchingRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "matchingRules"
+          }
+        }
+      },
+      "directoryName": "matchingRules",
+      "id": "matchingrules",
+      "inFolder": false,
+      "name": "MatchingRules",
+      "strictDirectoryName": false,
+      "suffix": "matchingRule"
+    },
+    "messagingchannel": {
+      "directoryName": "messagingChannels",
+      "id": "messagingchannel",
+      "inFolder": false,
+      "name": "MessagingChannel",
+      "strictDirectoryName": false,
+      "suffix": "messagingChannel"
+    },
+    "mfgprogramtemplate": {
+      "directoryName": "MfgProgramTemplate",
+      "id": "mfgprogramtemplate",
+      "inFolder": false,
+      "name": "MfgProgramTemplate",
+      "strictDirectoryName": false,
+      "suffix": "mfgProgramTemplate"
+    },
+    "milestonetype": {
+      "directoryName": "milestoneTypes",
+      "id": "milestonetype",
+      "inFolder": false,
+      "name": "MilestoneType",
+      "suffix": "milestoneType"
+    },
+    "mktcalcinsightobjectdef": {
+      "directoryName": "mktCalcInsightObjectDefs",
+      "id": "mktcalcinsightobjectdef",
+      "inFolder": false,
+      "name": "MktCalcInsightObjectDef",
+      "suffix": "mktCalcInsightObjectDef"
+    },
+    "mktdataconnection": {
+      "directoryName": "mktDataConnections",
+      "id": "mktdataconnection",
+      "inFolder": false,
+      "name": "MktDataConnection",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnection"
+    },
+    "mktdataconnectionsrcparam": {
+      "directoryName": "mktDataConnectionSrcParams",
+      "id": "mktdataconnectionsrcparam",
+      "inFolder": false,
+      "name": "MktDataConnectionSrcParam",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnectionSrcParam"
+    },
+    "mktdatatranobject": {
+      "children": {
+        "directories": {
+          "mktDataTranFields": "mktdatatranfield"
+        },
+        "suffixes": {
+          "mktDataTranField": "mktdatatranfield"
+        },
+        "types": {
+          "mktdatatranfield": {
+            "directoryName": "mktDataTranFields",
+            "id": "mktdatatranfield",
+            "name": "MktDataTranField",
+            "suffix": "mktDataTranField"
+          }
+        }
+      },
+      "directoryName": "mktDataTranObjects",
+      "id": "mktdatatranobject",
+      "name": "MktDataTranObject",
+      "strictDirectoryName": false,
+      "suffix": "mktDataTranObject"
+    },
+    "mldatadefinition": {
+      "directoryName": "mlDataDefinitions",
+      "id": "mldatadefinition",
+      "inFolder": false,
+      "name": "MLDataDefinition",
+      "strictDirectoryName": false,
+      "suffix": "mlDataDefinition"
+    },
+    "mldomain": {
+      "directoryName": "mlDomains",
+      "id": "mldomain",
+      "inFolder": false,
+      "name": "MlDomain",
+      "suffix": "mlDomain"
+    },
+    "mlpredictiondefinition": {
+      "directoryName": "mlPredictions",
+      "id": "mlpredictiondefinition",
+      "inFolder": false,
+      "name": "MLPredictionDefinition",
+      "strictDirectoryName": false,
+      "suffix": "mlPrediction"
+    },
+    "mlrecommendationdefinition": {
+      "directoryName": "mlRecommendations",
+      "id": "mlrecommendationdefinition",
+      "inFolder": false,
+      "name": "MLRecommendationDefinition",
+      "suffix": "mlRecommendation"
+    },
+    "mobileapplicationdetail": {
+      "directoryName": "MobileApplicationDetails",
+      "id": "mobileapplicationdetail",
+      "inFolder": false,
+      "name": "MobileApplicationDetail",
+      "strictDirectoryName": false,
+      "suffix": "MobileApplicationDetail"
+    },
+    "mobilesecurityassignment": {
+      "directoryName": "mobileSecurityAssignments",
+      "id": "mobilesecurityassignment",
+      "inFolder": false,
+      "name": "MobileSecurityAssignment",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityAssignment"
+    },
+    "mobilesecuritypolicy": {
+      "directoryName": "mobileSecurityPolicies",
+      "id": "mobilesecuritypolicy",
+      "inFolder": false,
+      "name": "MobileSecurityPolicy",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityPolicy"
+    },
+    "mobilesecuritypolicyset": {
+      "directoryName": "mobileSecurityPolicySets",
+      "id": "mobilesecuritypolicyset",
+      "inFolder": false,
+      "name": "MobileSecurityPolicySet",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityPolicySet"
+    },
+    "mobsecuritycertpinconfig": {
+      "directoryName": "mobSecurityCertPinConfigs",
+      "id": "mobsecuritycertpinconfig",
+      "inFolder": false,
+      "name": "MobSecurityCertPinConfig",
+      "strictDirectoryName": false,
+      "suffix": "mobSecurityCertPinConfig"
+    },
+    "moderationrule": {
+      "directoryName": "moderation",
+      "id": "moderationrule",
+      "inFolder": false,
+      "name": "ModerationRule",
+      "strictDirectoryName": false,
+      "suffix": "rule"
+    },
+    "mutingpermissionset": {
+      "directoryName": "mutingpermissionsets",
+      "id": "mutingpermissionset",
+      "inFolder": false,
+      "name": "MutingPermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "mutingpermissionset"
+    },
+    "mydomaindiscoverablelogin": {
+      "directoryName": "myDomainDiscoverableLogins",
+      "id": "mydomaindiscoverablelogin",
+      "inFolder": false,
+      "name": "MyDomainDiscoverableLogin",
+      "strictDirectoryName": false,
+      "suffix": "myDomainDiscoverableLogin"
+    },
+    "namedcredential": {
+      "directoryName": "namedCredentials",
+      "id": "namedcredential",
+      "inFolder": false,
+      "name": "NamedCredential",
+      "strictDirectoryName": false,
+      "suffix": "namedCredential"
+    },
+    "navigationmenu": {
+      "directoryName": "navigationMenus",
+      "id": "navigationmenu",
+      "inFolder": false,
+      "name": "NavigationMenu",
+      "strictDirectoryName": false,
+      "suffix": "navigationMenu"
+    },
+    "network": {
+      "directoryName": "networks",
+      "id": "network",
+      "inFolder": false,
+      "name": "Network",
+      "strictDirectoryName": false,
+      "suffix": "network"
+    },
+    "networkbranding": {
+      "directoryName": "networkBranding",
+      "id": "networkbranding",
+      "inFolder": false,
+      "name": "NetworkBranding",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "networkBranding"
+    },
+    "notificationtypeconfig": {
+      "directoryName": "notificationTypeConfig",
+      "id": "notificationtypeconfig",
+      "inFolder": false,
+      "name": "NotificationTypeConfig",
+      "strictDirectoryName": false,
+      "suffix": "config"
+    },
+    "oauthcustomscope": {
+      "directoryName": "oauthcustomscopes",
+      "id": "oauthcustomscope",
+      "inFolder": false,
+      "name": "OauthCustomScope",
+      "strictDirectoryName": false,
+      "suffix": "oauthcustomscope"
+    },
+    "oauthtokenexchangehandler": {
+      "directoryName": "oauthtokenexchangehandlers",
+      "id": "oauthtokenexchangehandler",
+      "inFolder": false,
+      "name": "OauthTokenExchangeHandler",
+      "strictDirectoryName": false,
+      "suffix": "oauthtokenexchangehandler"
+    },
+    "objecthierarchyrelationship": {
+      "directoryName": "ObjectHierarchyRelationship",
+      "id": "objecthierarchyrelationship",
+      "name": "ObjectHierarchyRelationship",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "objectsourcetargetmap": {
+      "directoryName": "objectSourceTargetMaps",
+      "id": "objectsourcetargetmap",
+      "name": "ObjectSourceTargetMap",
+      "strictDirectoryName": false,
+      "suffix": "objectSourceTargetMap"
+    },
+    "objintegproviderdefmapping": {
+      "directoryName": "objIntegProviderDefMappings",
+      "id": "objintegproviderdefmapping",
+      "name": "ObjIntegProviderDefMapping",
+      "strictDirectoryName": false,
+      "suffix": "objIntegProviderDefMapping"
+    },
+    "ocrsampledocument": {
+      "directoryName": "ocrSampleDocuments",
+      "id": "ocrsampledocument",
+      "name": "OcrSampleDocument",
+      "strictDirectoryName": false,
+      "suffix": "ocrSampleDocument"
+    },
+    "ocrtemplate": {
+      "directoryName": "ocrTemplates",
+      "id": "ocrtemplate",
+      "name": "OcrTemplate",
+      "strictDirectoryName": false,
+      "suffix": "ocrTemplate"
+    },
+    "omnidatatransform": {
+      "directoryName": "omniDataTransforms",
+      "id": "omnidatatransform",
+      "inFolder": false,
+      "name": "OmniDataTransform",
+      "strictDirectoryName": false,
+      "suffix": "rpt"
+    },
+    "omniexttrackingdef": {
+      "directoryName": "OmniExtTrackingDefs",
+      "id": "omniexttrackingdef",
+      "inFolder": false,
+      "name": "OmniExtTrackingDef",
+      "strictDirectoryName": false,
+      "suffix": "OmniExtTrackingDef"
+    },
+    "omniintegrationprocedure": {
+      "directoryName": "omniIntegrationProcedures",
+      "id": "omniintegrationprocedure",
+      "inFolder": false,
+      "name": "OmniIntegrationProcedure",
+      "strictDirectoryName": false,
+      "suffix": "oip"
+    },
+    "omniinteractionaccessconfig": {
+      "directoryName": "OmniInteractionAccessConfig",
+      "id": "omniinteractionaccessconfig",
+      "inFolder": false,
+      "name": "OmniInteractionAccessConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniInteractionAccessConfig"
+    },
+    "omniinteractionconfig": {
+      "directoryName": "OmniInteractionConfig",
+      "id": "omniinteractionconfig",
+      "inFolder": false,
+      "name": "OmniInteractionConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniInteractionConfig"
+    },
+    "omniscript": {
+      "directoryName": "omniScripts",
+      "id": "omniscript",
+      "inFolder": false,
+      "name": "OmniScript",
+      "strictDirectoryName": false,
+      "suffix": "os"
+    },
+    "omnisupervisorconfig": {
+      "directoryName": "omniSupervisorConfigs",
+      "id": "omnisupervisorconfig",
+      "inFolder": false,
+      "name": "OmniSupervisorConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniSupervisorConfig"
+    },
+    "omnitrackinggroup": {
+      "directoryName": "OmniTrackingGroups",
+      "id": "omnitrackinggroup",
+      "inFolder": false,
+      "name": "OmniTrackingGroup",
+      "strictDirectoryName": false,
+      "suffix": "OmniTrackingGroup"
+    },
+    "omniuicard": {
+      "directoryName": "omniUiCard",
+      "id": "omniuicard",
+      "inFolder": false,
+      "name": "OmniUiCard",
+      "strictDirectoryName": false,
+      "suffix": "ouc"
+    },
+    "orchestration": {
+      "directoryName": "iot",
+      "id": "orchestration",
+      "inFolder": false,
+      "name": "Orchestration",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "orchestration"
+    },
+    "orchestrationcontext": {
+      "directoryName": "iot",
+      "id": "orchestrationcontext",
+      "inFolder": false,
+      "name": "OrchestrationContext",
+      "suffix": "orchestrationContext"
+    },
+    "outboundnetworkconnection": {
+      "directoryName": "outboundNetworkConnections",
+      "id": "outboundnetworkconnection",
+      "inFolder": false,
+      "name": "OutboundNetworkConnection",
+      "strictDirectoryName": false,
+      "suffix": "outboundNetworkConnection"
+    },
+    "participantrole": {
+      "directoryName": "participantRoles",
+      "id": "participantrole",
+      "name": "ParticipantRole",
+      "strictDirectoryName": false,
+      "suffix": "participantRole"
+    },
+    "pathassistant": {
+      "directoryName": "pathAssistants",
+      "id": "pathassistant",
+      "inFolder": false,
+      "name": "PathAssistant",
+      "strictDirectoryName": false,
+      "suffix": "pathAssistant",
+      "supportsWildcardAndName": true
+    },
+    "paymentgatewayprovider": {
+      "directoryName": "paymentGatewayProviders",
+      "id": "paymentgatewayprovider",
+      "inFolder": false,
+      "name": "PaymentGatewayProvider",
+      "suffix": "paymentGatewayProvider"
+    },
+    "permissionset": {
+      "directoryName": "permissionsets",
+      "id": "permissionset",
+      "inFolder": false,
+      "name": "PermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "permissionset"
+    },
+    "permissionsetgroup": {
+      "directoryName": "permissionsetgroups",
+      "id": "permissionsetgroup",
+      "inFolder": false,
+      "name": "PermissionSetGroup",
+      "strictDirectoryName": false,
+      "suffix": "permissionsetgroup"
+    },
+    "permissionsetlicensedefinition": {
+      "directoryName": "permissionSetLicenseDefinitions",
+      "id": "permissionsetlicensedefinition",
+      "inFolder": false,
+      "name": "PermissionSetLicenseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "permissionSetLicenseDefinition"
+    },
+    "personaccountownerpoweruser": {
+      "directoryName": "personAccountOwnerPowerUsers",
+      "id": "personaccountownerpoweruser",
+      "inFolder": false,
+      "name": "PersonAccountOwnerPowerUser",
+      "strictDirectoryName": false,
+      "suffix": "personAccountOwnerPowerUser"
+    },
+    "pipelineinspmetricconfig": {
+      "directoryName": "pipelineInspMetricConfigs",
+      "id": "pipelineinspmetricconfig",
+      "inFolder": false,
+      "name": "PipelineInspMetricConfig",
+      "strictDirectoryName": false,
+      "suffix": "pipelineInspMetricConfig"
+    },
+    "platformcachepartition": {
+      "directoryName": "cachePartitions",
+      "id": "platformcachepartition",
+      "inFolder": false,
+      "name": "PlatformCachePartition",
+      "strictDirectoryName": false,
+      "suffix": "cachePartition"
+    },
+    "platformeventchannel": {
+      "directoryName": "platformEventChannels",
+      "id": "platformeventchannel",
+      "inFolder": false,
+      "name": "PlatformEventChannel",
+      "strictDirectoryName": false,
+      "suffix": "platformEventChannel"
+    },
+    "platformeventchannelmember": {
+      "directoryName": "platformEventChannelMembers",
+      "id": "platformeventchannelmember",
+      "inFolder": false,
+      "name": "PlatformEventChannelMember",
+      "strictDirectoryName": false,
+      "suffix": "platformEventChannelMember"
+    },
+    "platformeventsubscriberconfig": {
+      "directoryName": "PlatformEventSubscriberConfigs",
+      "id": "platformeventsubscriberconfig",
+      "inFolder": false,
+      "name": "PlatformEventSubscriberConfig",
+      "strictDirectoryName": false,
+      "suffix": "platformEventSubscriberConfig"
+    },
+    "portal": {
+      "directoryName": "portals",
+      "id": "portal",
+      "inFolder": false,
+      "name": "Portal",
+      "suffix": "portal"
+    },
+    "portaldelegablepermissionset": {
+      "directoryName": "portalDelegablePermissionSet",
+      "id": "portaldelegablepermissionset",
+      "inFolder": false,
+      "name": "PortalDelegablePermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "portalDelegablePermissionSet"
+    },
+    "posttemplate": {
+      "directoryName": "postTemplates",
+      "id": "posttemplate",
+      "inFolder": false,
+      "name": "PostTemplate",
+      "strictDirectoryName": false,
+      "suffix": "postTemplate"
+    },
+    "presencedeclinereason": {
+      "directoryName": "presenceDeclineReasons",
+      "id": "presencedeclinereason",
+      "inFolder": false,
+      "name": "PresenceDeclineReason",
+      "suffix": "presenceDeclineReason"
+    },
+    "presenceuserconfig": {
+      "directoryName": "presenceUserConfigs",
+      "id": "presenceuserconfig",
+      "inFolder": false,
+      "name": "PresenceUserConfig",
+      "suffix": "presenceUserConfig"
+    },
+    "pricingactionparameters": {
+      "directoryName": "pricingActionParameters",
+      "id": "pricingactionparameters",
+      "inFolder": false,
+      "name": "PricingActionParameters",
+      "strictDirectoryName": false,
+      "suffix": "pricingActionParameters"
+    },
+    "pricingrecipe": {
+      "directoryName": "pricingRecipe",
+      "id": "pricingrecipe",
+      "name": "PricingRecipe",
+      "strictDirectoryName": false,
+      "suffix": "pricingRecipe"
+    },
+    "processflowmigration": {
+      "directoryName": "processflowmigrations",
+      "id": "processflowmigration",
+      "inFolder": false,
+      "name": "ProcessFlowMigration",
+      "strictDirectoryName": false,
+      "suffix": "processflowmigration"
+    },
+    "productattrdisplayconfig": {
+      "directoryName": "productAttrDisplayConfigs",
+      "id": "productattrdisplayconfig",
+      "inFolder": false,
+      "name": "ProductAttrDisplayConfig",
+      "strictDirectoryName": false,
+      "suffix": "productAttrDisplayConfig"
+    },
+    "productattributeset": {
+      "directoryName": "productAttributeSets",
+      "id": "productattributeset",
+      "inFolder": false,
+      "name": "ProductAttributeSet",
+      "strictDirectoryName": false,
+      "suffix": "productAttributeSet"
+    },
+    "productspecificationrectype": {
+      "directoryName": "productSpecificationRecTypes",
+      "id": "productspecificationrectype",
+      "inFolder": false,
+      "name": "ProductSpecificationRecType",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationRecType"
+    },
+    "productspecificationtype": {
+      "directoryName": "productSpecificationTypes",
+      "id": "productspecificationtype",
+      "inFolder": false,
+      "name": "ProductSpecificationType",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationType"
+    },
+    "productspecificationtypedefinition": {
+      "directoryName": "productSpecificationTypeDefinitions",
+      "id": "productspecificationtypedefinition",
+      "inFolder": false,
+      "name": "ProductSpecificationTypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationTypeDefinition"
+    },
+    "profile": {
+      "directoryName": "profiles",
+      "id": "profile",
+      "inFolder": false,
+      "name": "Profile",
+      "strictDirectoryName": false,
+      "suffix": "profile"
+    },
+    "profilepasswordpolicy": {
+      "directoryName": "profilePasswordPolicies",
+      "id": "profilepasswordpolicy",
+      "inFolder": false,
+      "name": "ProfilePasswordPolicy",
+      "strictDirectoryName": false,
+      "suffix": "profilePasswordPolicy"
+    },
+    "profilesessionsetting": {
+      "directoryName": "profileSessionSettings",
+      "id": "profilesessionsetting",
+      "inFolder": false,
+      "name": "ProfileSessionSetting",
+      "strictDirectoryName": false,
+      "suffix": "profileSessionSetting"
+    },
+    "prompt": {
+      "directoryName": "prompts",
+      "id": "prompt",
+      "inFolder": false,
+      "name": "Prompt",
+      "strictDirectoryName": false,
+      "suffix": "prompt"
+    },
+    "queue": {
+      "directoryName": "queues",
+      "id": "queue",
+      "inFolder": false,
+      "name": "Queue",
+      "strictDirectoryName": false,
+      "suffix": "queue"
+    },
+    "queueroutingconfig": {
+      "directoryName": "queueRoutingConfigs",
+      "id": "queueroutingconfig",
+      "inFolder": false,
+      "name": "QueueRoutingConfig",
+      "suffix": "queueRoutingConfig"
+    },
+    "quickaction": {
+      "directoryName": "quickActions",
+      "id": "quickaction",
+      "inFolder": false,
+      "name": "QuickAction",
+      "strictDirectoryName": false,
+      "suffix": "quickAction",
+      "supportsWildcardAndName": true
+    },
+    "recalrtdatasrcexpsetdef": {
+      "directoryName": "recAlrtDataSrcExpSetDefs",
+      "id": "recalrtdatasrcexpsetdef",
+      "inFolder": false,
+      "name": "RecAlrtDataSrcExpSetDef",
+      "strictDirectoryName": false,
+      "suffix": "recAlrtDataSrcExpSetDef"
+    },
+    "recommendationstrategy": {
+      "directoryName": "recommendationStrategies",
+      "id": "recommendationstrategy",
+      "inFolder": false,
+      "name": "RecommendationStrategy",
+      "strictDirectoryName": false,
+      "suffix": "recommendationStrategy"
+    },
+    "recordactiondeployment": {
+      "directoryName": "recordActionDeployments",
+      "id": "recordactiondeployment",
+      "inFolder": false,
+      "name": "RecordActionDeployment",
+      "strictDirectoryName": false,
+      "suffix": "deployment"
+    },
+    "recordaggregationdefinition": {
+      "directoryName": "RecordAggregationDefinitions",
+      "id": "recordaggregationdefinition",
+      "inFolder": false,
+      "name": "RecordAggregationDefinition",
+      "strictDirectoryName": false,
+      "suffix": "RecordAggregationDefinition"
+    },
+    "recordalertcategory": {
+      "directoryName": "recordAlertCategories",
+      "id": "recordalertcategory",
+      "inFolder": false,
+      "name": "RecordAlertCategory",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertCategory"
+    },
+    "recordalertdatasource": {
+      "directoryName": "recordAlertDataSources",
+      "id": "recordalertdatasource",
+      "inFolder": false,
+      "name": "RecordAlertDataSource",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertDataSource"
+    },
+    "recordalerttemplate": {
+      "directoryName": "recordAlertTemplates",
+      "id": "recordalerttemplate",
+      "inFolder": false,
+      "name": "RecordAlertTemplate",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertTemplate"
+    },
+    "redirectwhitelisturl": {
+      "directoryName": "redirectWhitelistUrls",
+      "id": "redirectwhitelisturl",
+      "inFolder": false,
+      "name": "RedirectWhitelistUrl",
+      "strictDirectoryName": false,
+      "suffix": "redirectWhitelistUrl"
+    },
+    "referenceddashboard": {
+      "directoryName": "wave",
+      "id": "referenceddashboard",
+      "inFolder": false,
+      "name": "ReferencedDashboard",
+      "strictDirectoryName": false,
+      "suffix": "refdash"
+    },
+    "registeredexternalservice": {
+      "directoryName": "registeredExternalServices",
+      "id": "registeredexternalservice",
+      "inFolder": false,
+      "name": "RegisteredExternalService",
+      "strictDirectoryName": false,
+      "suffix": "registeredExternalService"
+    },
+    "relatedrecordassoccriteria": {
+      "directoryName": "relatedRecordAssocCriteria",
+      "id": "relatedrecordassoccriteria",
+      "inFolder": false,
+      "name": "RelatedRecordAssocCriteria",
+      "strictDirectoryName": false,
+      "suffix": "relatedRecordAssocCriteria"
+    },
+    "relationshipgraphdefinition": {
+      "directoryName": "relationshipGraphDefinitions",
+      "id": "relationshipgraphdefinition",
+      "inFolder": false,
+      "name": "RelationshipGraphDefinition",
+      "strictDirectoryName": false,
+      "suffix": "relationshipGraphDefinition"
+    },
+    "remotesitesetting": {
+      "directoryName": "remoteSiteSettings",
+      "id": "remotesitesetting",
+      "inFolder": false,
+      "name": "RemoteSiteSetting",
+      "strictDirectoryName": false,
+      "suffix": "remoteSite",
+      "supportsWildcardAndName": true
+    },
+    "report": {
+      "directoryName": "reports",
+      "folderType": "reportfolder",
+      "id": "report",
+      "inFolder": true,
+      "name": "Report",
+      "strictDirectoryName": false,
+      "suffix": "report"
+    },
+    "reportfolder": {
+      "directoryName": "reports",
+      "folderContentType": "report",
+      "id": "reportfolder",
+      "inFolder": false,
+      "name": "ReportFolder",
+      "strictDirectoryName": false,
+      "suffix": "reportFolder"
+    },
+    "reporttype": {
+      "directoryName": "reportTypes",
+      "id": "reporttype",
+      "inFolder": false,
+      "name": "ReportType",
+      "strictDirectoryName": false,
+      "suffix": "reportType",
+      "supportsWildcardAndName": true
+    },
+    "restrictionrule": {
+      "directoryName": "restrictionRules",
+      "id": "restrictionrule",
+      "name": "RestrictionRule",
+      "strictDirectoryName": true,
+      "suffix": "rule"
+    },
+    "retrievalsummarydefinition": {
+      "directoryName": "RetrievalSummaryDefinitions",
+      "id": "retrievalsummarydefinition",
+      "inFolder": false,
+      "name": "RetrievalSummaryDefinition",
+      "strictDirectoryName": false,
+      "suffix": "RetrievalSummaryDefinition"
+    },
+    "role": {
+      "directoryName": "roles",
+      "id": "role",
+      "inFolder": false,
+      "name": "Role",
+      "strictDirectoryName": false,
+      "suffix": "role"
+    },
+    "salesagreementsettings": {
+      "directoryName": "salesAgreementSettings",
+      "id": "salesagreementsettings",
+      "name": "SalesAgreementSettings",
+      "strictDirectoryName": false,
+      "suffix": "salesAgreementSetting"
+    },
+    "samlssoconfig": {
+      "directoryName": "samlssoconfigs",
+      "id": "samlssoconfig",
+      "inFolder": false,
+      "name": "SamlSsoConfig",
+      "strictDirectoryName": false,
+      "suffix": "samlssoconfig"
+    },
+    "schedulingobjective": {
+      "directoryName": "SchedulingObjectives",
+      "id": "schedulingobjective",
+      "inFolder": false,
+      "name": "SchedulingObjective",
+      "strictDirectoryName": false,
+      "suffix": "schedulingObjective"
+    },
+    "schedulingrule": {
+      "directoryName": "SchedulingRules",
+      "id": "schedulingrule",
+      "name": "SchedulingRule",
+      "strictDirectoryName": false,
+      "suffix": "schedulingRule"
+    },
+    "scontrol": {
+      "directoryName": "scontrols",
+      "id": "scontrol",
+      "inFolder": false,
+      "name": "Scontrol",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "scf"
+    },
+    "scorecategory": {
+      "directoryName": "scoreCategories",
+      "id": "scorecategory",
+      "inFolder": false,
+      "name": "ScoreCategory",
+      "suffix": "scoreCategory"
+    },
+    "searchableobjdatasyncinfo": {
+      "directoryName": "SearchableObjDataSyncInfoSettings",
+      "id": "searchableobjdatasyncinfo",
+      "inFolder": false,
+      "name": "SearchableObjDataSyncInfo",
+      "strictDirectoryName": false,
+      "suffix": "SearchableObjDataSyncInfoSetting"
+    },
+    "searchcriteriaconfiguration": {
+      "directoryName": "SearchCriteriaConfigurationSettings",
+      "id": "searchcriteriaconfiguration",
+      "inFolder": false,
+      "name": "SearchCriteriaConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "SearchCriteriaConfigurationSetting"
+    },
+    "searchcustomization": {
+      "directoryName": "searchCustomizations",
+      "id": "searchcustomization",
+      "inFolder": false,
+      "name": "SearchCustomization",
+      "strictDirectoryName": false,
+      "suffix": "searchCustomization"
+    },
+    "searchorgwideobjectconfig": {
+      "directoryName": "searchOrgWideConfiguration",
+      "id": "searchorgwideobjectconfig",
+      "inFolder": false,
+      "name": "SearchOrgWideObjectConfig",
+      "strictDirectoryName": false,
+      "suffix": "searchOrgWideObjectConfig"
+    },
+    "serviceaisetupdefinition": {
+      "directoryName": "serviceAISetupDescriptions",
+      "id": "serviceaisetupdefinition",
+      "inFolder": false,
+      "name": "ServiceAISetupDefinition",
+      "strictDirectoryName": false,
+      "suffix": "serviceAISetupDescription"
+    },
+    "serviceaisetupfield": {
+      "directoryName": "serviceAISetupFields",
+      "id": "serviceaisetupfield",
+      "inFolder": false,
+      "name": "ServiceAISetupField",
+      "strictDirectoryName": false,
+      "suffix": "serviceAISetupField"
+    },
+    "servicechannel": {
+      "directoryName": "serviceChannels",
+      "id": "servicechannel",
+      "inFolder": false,
+      "name": "ServiceChannel",
+      "suffix": "serviceChannel"
+    },
+    "servicepresencestatus": {
+      "directoryName": "servicePresenceStatuses",
+      "id": "servicepresencestatus",
+      "inFolder": false,
+      "name": "ServicePresenceStatus",
+      "suffix": "servicePresenceStatus"
+    },
+    "serviceprocess": {
+      "directoryName": "serviceprocess",
+      "id": "serviceprocess",
+      "inFolder": false,
+      "name": "ServiceProcess",
+      "strictDirectoryName": false,
+      "suffix": "serviceprocess"
+    },
+    "settings": {
+      "directoryName": "settings",
+      "id": "settings",
+      "inFolder": false,
+      "name": "Settings",
+      "strictDirectoryName": false,
+      "suffix": "settings"
+    },
+    "sharingrules": {
+      "children": {
+        "directories": {
+          "sharingCriteriaRules": "sharingRules",
+          "sharingGuestRules": "sharingRules",
+          "sharingOwnerRules": "sharingRules",
+          "sharingTerritoryRules": "sharingRules"
+        },
+        "suffixes": {
+          "sharingCriteriaRule": "sharingcriteriarule",
+          "sharingGuestRule": "sharingguestrule",
+          "sharingOwnerRule": "sharingownerrule",
+          "sharingTerritoryRule": "sharingterritoryrule"
+        },
+        "types": {
+          "sharingcriteriarule": {
+            "directoryName": "sharingRules",
+            "id": "sharingcriteriarule",
+            "name": "SharingCriteriaRule",
+            "suffix": "sharingCriteriaRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingCriteriaRules"
+          },
+          "sharingguestrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingguestrule",
+            "name": "SharingGuestRule",
+            "suffix": "sharingGuestRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingGuestRules"
+          },
+          "sharingownerrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingownerrule",
+            "name": "SharingOwnerRule",
+            "suffix": "sharingOwnerRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingOwnerRules"
+          },
+          "sharingterritoryrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingterritoryrule",
+            "name": "SharingTerritoryRule",
+            "suffix": "sharingTerritoryRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingTerritoryRules"
+          }
+        }
+      },
+      "directoryName": "sharingRules",
+      "id": "sharingrules",
+      "inFolder": false,
+      "name": "SharingRules",
+      "strictDirectoryName": false,
+      "suffix": "sharingRules",
+      "supportsWildcardAndName": true
+    },
+    "sharingset": {
+      "directoryName": "sharingSets",
+      "id": "sharingset",
+      "inFolder": false,
+      "name": "SharingSet",
+      "strictDirectoryName": false,
+      "suffix": "sharingSet"
+    },
+    "sitedotcom": {
+      "directoryName": "siteDotComSites",
+      "id": "sitedotcom",
+      "inFolder": false,
+      "name": "SiteDotCom",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": true,
+      "suffix": "site"
+    },
+    "skill": {
+      "directoryName": "skills",
+      "id": "skill",
+      "inFolder": false,
+      "name": "Skill",
+      "suffix": "skill"
+    },
+    "skilltype": {
+      "directoryName": "skilltypes",
+      "id": "skilltype",
+      "inFolder": false,
+      "name": "SkillType",
+      "suffix": "skilltype"
+    },
+    "slackapp": {
+      "directoryName": "slackapps",
+      "id": "slackapp",
+      "inFolder": false,
+      "name": "SlackApp",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "slackapp"
+    },
+    "stagedefinition": {
+      "directoryName": "stageDefinitions",
+      "id": "stagedefinition",
+      "inFolder": false,
+      "name": "StageDefinition",
+      "strictDirectoryName": false,
+      "suffix": "stageDefinition"
+    },
+    "standardvalueset": {
+      "directoryName": "standardValueSets",
+      "id": "standardvalueset",
+      "inFolder": false,
+      "name": "StandardValueSet",
+      "strictDirectoryName": false,
+      "suffix": "standardValueSet"
+    },
+    "standardvaluesettranslation": {
+      "directoryName": "standardValueSetTranslations",
+      "id": "standardvaluesettranslation",
+      "inFolder": false,
+      "name": "StandardValueSetTranslation",
+      "strictDirectoryName": false,
+      "suffix": "standardValueSetTranslation"
+    },
+    "staticresource": {
+      "directoryName": "staticresources",
+      "id": "staticresource",
+      "inFolder": false,
+      "name": "StaticResource",
+      "strategies": {
+        "adapter": "mixedContent",
+        "transformer": "staticResource"
+      },
+      "strictDirectoryName": true,
+      "suffix": "resource",
+      "supportsPartialDelete": true
+    },
+    "stnryassetenvsrccnfg": {
+      "directoryName": "stationaryAssetEnvSourceConfigs",
+      "id": "stnryassetenvsrccnfg",
+      "inFolder": false,
+      "name": "StnryAssetEnvSrcCnfg",
+      "strictDirectoryName": false,
+      "suffix": "stationaryAssetEnvSourceConfig"
+    },
+    "streamingappdataconnector": {
+      "directoryName": "streamingAppDataConnectors",
+      "id": "streamingappdataconnector",
+      "inFolder": false,
+      "name": "StreamingAppDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "streamingAppDataConnector"
+    },
+    "sustainabilityuom": {
+      "directoryName": "sustainabilityUoms",
+      "id": "sustainabilityuom",
+      "inFolder": false,
+      "name": "SustainabilityUom",
+      "strictDirectoryName": false,
+      "suffix": "sustainabilityUom"
+    },
+    "sustnuomconversion": {
+      "directoryName": "sustnUomConversions",
+      "id": "sustnuomconversion",
+      "inFolder": false,
+      "name": "SustnUomConversion",
+      "strictDirectoryName": false,
+      "suffix": "sustnUomConversion"
+    },
+    "svccatalogcategory": {
+      "directoryName": "svcCatalogCategories",
+      "id": "svccatalogcategory",
+      "inFolder": false,
+      "name": "SvcCatalogCategory",
+      "strictDirectoryName": false,
+      "suffix": "category"
+    },
+    "svccatalogfiltercondition": {
+      "directoryName": "svcCatalogFilterConditions",
+      "id": "svccatalogfiltercondition",
+      "inFolder": false,
+      "name": "SvcCatalogFilterCondition",
+      "strictDirectoryName": false,
+      "suffix": "catalogFilterCondition"
+    },
+    "svccatalogfiltercriteria": {
+      "directoryName": "svcCatalogFilterCriterias",
+      "id": "svccatalogfiltercriteria",
+      "inFolder": false,
+      "name": "SvcCatalogFilterCriteria",
+      "strictDirectoryName": false,
+      "suffix": "catalogFilterCriteria"
+    },
+    "svccatalogfulfillmentflow": {
+      "directoryName": "svcCatalogFulfillmentFlows",
+      "id": "svccatalogfulfillmentflow",
+      "inFolder": false,
+      "name": "SvcCatalogFulfillmentFlow",
+      "strictDirectoryName": false,
+      "suffix": "fulfillmentFlow"
+    },
+    "svccatalogitemdef": {
+      "directoryName": "svcCatalogItems",
+      "id": "svccatalogitemdef",
+      "inFolder": false,
+      "name": "SvcCatalogItemDef",
+      "strictDirectoryName": false,
+      "suffix": "catalogItem"
+    },
+    "svccatalogitemdeffiltrcrit": {
+      "directoryName": "svcCatalogItemDefFiltrCrits",
+      "id": "svccatalogitemdeffiltrcrit",
+      "inFolder": false,
+      "name": "SvcCatalogItemDefFiltrCrit",
+      "strictDirectoryName": false,
+      "suffix": "catalogItemDefFiltrCrit"
+    },
+    "synonymdictionary": {
+      "directoryName": "synonymDictionaries",
+      "id": "synonymdictionary",
+      "inFolder": false,
+      "name": "SynonymDictionary",
+      "strictDirectoryName": false,
+      "suffix": "synonymDictionary"
+    },
+    "territory": {
+      "directoryName": "territories",
+      "id": "territory",
+      "inFolder": false,
+      "name": "Territory",
+      "suffix": "territory"
+    },
+    "territory2": {
+      "directoryName": "territories",
+      "folderType": "territory2model",
+      "id": "territory2",
+      "inFolder": false,
+      "name": "Territory2",
+      "suffix": "territory2"
+    },
+    "territory2model": {
+      "directoryName": "territory2Models",
+      "folderType": "territory2model",
+      "id": "territory2model",
+      "inFolder": false,
+      "name": "Territory2Model",
+      "suffix": "territory2Model"
+    },
+    "territory2rule": {
+      "directoryName": "rules",
+      "folderType": "territory2model",
+      "id": "territory2rule",
+      "inFolder": false,
+      "name": "Territory2Rule",
+      "suffix": "territory2Rule"
+    },
+    "territory2type": {
+      "directoryName": "territory2Types",
+      "id": "territory2type",
+      "inFolder": false,
+      "name": "Territory2Type",
+      "suffix": "territory2Type"
+    },
+    "timelineobjectdefinition": {
+      "directoryName": "timelineObjectDefinitions",
+      "id": "timelineobjectdefinition",
+      "inFolder": false,
+      "name": "TimelineObjectDefinition",
+      "strictDirectoryName": false,
+      "suffix": "timelineObjectDefinition"
+    },
+    "timesheettemplate": {
+      "directoryName": "timeSheetTemplates",
+      "id": "timesheettemplate",
+      "name": "TimeSheetTemplate",
+      "strictDirectoryName": false,
+      "suffix": "timeSheetTemplate"
+    },
+    "topicsforobjects": {
+      "directoryName": "topicsForObjects",
+      "id": "topicsforobjects",
+      "inFolder": false,
+      "name": "TopicsForObjects",
+      "strictDirectoryName": false,
+      "suffix": "topicsForObjects"
+    },
+    "transactionsecuritypolicy": {
+      "directoryName": "transactionSecurityPolicies",
+      "id": "transactionsecuritypolicy",
+      "inFolder": false,
+      "name": "TransactionSecurityPolicy",
+      "suffix": "transactionSecurityPolicy"
+    },
+    "translations": {
+      "directoryName": "translations",
+      "id": "translations",
+      "inFolder": false,
+      "name": "Translations",
+      "suffix": "translation"
+    },
+    "uiformatspecificationset": {
+      "directoryName": "uiFormatSpecificationSets",
+      "id": "uiformatspecificationset",
+      "inFolder": false,
+      "name": "UiFormatSpecificationSet",
+      "strictDirectoryName": false,
+      "suffix": "uiFormatSpecificationSet"
+    },
+    "uiobjectrelationconfig": {
+      "directoryName": "uiObjectRelationConfigs",
+      "id": "uiobjectrelationconfig",
+      "inFolder": false,
+      "name": "UIObjectRelationConfig",
+      "suffix": "uiObjectRelationConfig"
+    },
+    "uiplugin": {
+      "directoryName": "uiplugins",
+      "id": "uiplugin",
+      "inFolder": false,
+      "name": "UiPlugin",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "uiplugin"
+    },
+    "uiviewdefinition": {
+      "directoryName": "uiviews",
+      "id": "uiviewdefinition",
+      "inFolder": false,
+      "name": "UiViewDefinition",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "uiview"
+    },
+    "useraccesspolicy": {
+      "directoryName": "useraccesspolicies",
+      "id": "useraccesspolicy",
+      "inFolder": false,
+      "name": "UserAccessPolicy",
+      "strictDirectoryName": false,
+      "suffix": "useraccesspolicy"
+    },
+    "userauthcertificate": {
+      "directoryName": "userAuthCertificates",
+      "id": "userauthcertificate",
+      "inFolder": false,
+      "name": "UserAuthCertificate",
+      "suffix": "userAuthCertificate"
+    },
+    "usercriteria": {
+      "directoryName": "userCriteria",
+      "id": "usercriteria",
+      "inFolder": false,
+      "name": "UserCriteria",
+      "strictDirectoryName": false,
+      "suffix": "userCriteria"
+    },
+    "userprofilesearchscope": {
+      "directoryName": "userProfileSearchScopes",
+      "id": "userprofilesearchscope",
+      "inFolder": false,
+      "name": "UserProfileSearchScope",
+      "strictDirectoryName": false,
+      "suffix": "userProfileSearchScope"
+    },
+    "userprovisioningconfig": {
+      "directoryName": "userProvisioningConfigs",
+      "id": "userprovisioningconfig",
+      "inFolder": false,
+      "name": "UserProvisioningConfig",
+      "strictDirectoryName": false,
+      "suffix": "userProvisioningConfig"
+    },
+    "vehicleassetemssnsrccnfg": {
+      "directoryName": "vehicleAssetEmssnSourceConfigs",
+      "id": "vehicleassetemssnsrccnfg",
+      "inFolder": false,
+      "name": "VehicleAssetEmssnSrcCnfg",
+      "strictDirectoryName": false,
+      "suffix": "vehicleAssetEmssnSourceConfig"
+    },
+    "viewdefinition": {
+      "directoryName": "viewdefinitions",
+      "id": "viewdefinition",
+      "inFolder": false,
+      "name": "ViewDefinition",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "view"
+    },
+    "virtualvisitconfig": {
+      "directoryName": "VirtualVisitConfigs",
+      "id": "virtualvisitconfig",
+      "inFolder": false,
+      "name": "VirtualVisitConfig",
+      "strictDirectoryName": false,
+      "suffix": "virtualVisitConfig"
+    },
+    "visualizationplugin": {
+      "directoryName": "visualizationPlugins",
+      "id": "visualizationplugin",
+      "inFolder": false,
+      "name": "VisualizationPlugin",
+      "suffix": "visualizationPlugin"
+    },
+    "waveanalyticassetcollection": {
+      "directoryName": "wave",
+      "id": "waveanalyticassetcollection",
+      "inFolder": false,
+      "name": "WaveAnalyticAssetCollection",
+      "strictDirectoryName": false,
+      "suffix": "collection"
+    },
+    "waveapplication": {
+      "directoryName": "wave",
+      "id": "waveapplication",
+      "inFolder": false,
+      "name": "WaveApplication",
+      "suffix": "wapp"
+    },
+    "wavecomponent": {
+      "directoryName": "wave",
+      "id": "wavecomponent",
+      "inFolder": false,
+      "name": "WaveComponent",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wcomp"
+    },
+    "wavedashboard": {
+      "directoryName": "wave",
+      "id": "wavedashboard",
+      "inFolder": false,
+      "name": "WaveDashboard",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdash"
+    },
+    "wavedataflow": {
+      "directoryName": "wave",
+      "id": "wavedataflow",
+      "inFolder": false,
+      "name": "WaveDataflow",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdf"
+    },
+    "wavedataset": {
+      "directoryName": "wave",
+      "id": "wavedataset",
+      "inFolder": false,
+      "name": "WaveDataset",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wds"
+    },
+    "wavelens": {
+      "directoryName": "wave",
+      "id": "wavelens",
+      "inFolder": false,
+      "name": "WaveLens",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wlens"
+    },
+    "waverecipe": {
+      "directoryName": "wave",
+      "id": "waverecipe",
+      "inFolder": false,
+      "name": "WaveRecipe",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdpr"
+    },
+    "wavetemplatebundle": {
+      "directoryName": "waveTemplates",
+      "id": "wavetemplatebundle",
+      "inFolder": false,
+      "name": "WaveTemplateBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "wavexmd": {
+      "directoryName": "wave",
+      "id": "wavexmd",
+      "inFolder": false,
+      "name": "WaveXmd",
+      "suffix": "xmd"
+    },
+    "webstorebundle": {
+      "directoryName": "webStoreBundles",
+      "id": "webstorebundle",
+      "inFolder": false,
+      "name": "WebStoreBundle",
+      "strictDirectoryName": false,
+      "suffix": "webStoreBundle"
+    },
+    "webstoretemplate": {
+      "directoryName": "webStoreTemplates",
+      "id": "webstoretemplate",
+      "name": "WebStoreTemplate",
+      "strictDirectoryName": false,
+      "suffix": "webStoreTemplate"
+    },
+    "workflowflowautomation": {
+      "directoryName": "workflowFlowAutomations",
+      "id": "workflowflowautomation",
+      "name": "WorkflowFlowAutomation",
+      "strictDirectoryName": false,
+      "suffix": "workflowFlowAutomation"
+    },
+    "workflow": {
+      "children": {
+        "directories": {
+          "workflowAlerts": "workflowalert",
+          "workflowFieldUpdates": "workflowfieldupdate",
+          "workflowFlowActions": "workflowflowaction",
+          "workflowKnowledgePublishs": "workflowknowledgepublish",
+          "workflowOutboundMessages": "workflowoutboundmessage",
+          "workflowRules": "workflowrule",
+          "workflowSends": "workflowsend",
+          "workflowTasks": "workflowtask"
+        },
+        "suffixes": {
+          "workflowAlert": "workflowalert",
+          "workflowFieldUpdate": "workflowfieldupdate",
+          "workflowFlowAction": "workflowflowaction",
+          "workflowKnowledgePublish": "workflowknowledgepublish",
+          "workflowOutboundMessage": "workflowoutboundmessage",
+          "workflowRule": "workflowrule",
+          "workflowSend": "workflowsend",
+          "workflowTask": "workflowtask"
+        },
+        "types": {
+          "workflowalert": {
+            "directoryName": "workflowAlerts",
+            "id": "workflowalert",
+            "name": "WorkflowAlert",
+            "suffix": "workflowAlert",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "alerts"
+          },
+          "workflowfieldupdate": {
+            "directoryName": "workflowFieldUpdates",
+            "id": "workflowfieldupdate",
+            "name": "WorkflowFieldUpdate",
+            "suffix": "workflowFieldUpdate",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "fieldUpdates"
+          },
+          "workflowflowaction": {
+            "directoryName": "workflowFlowActions",
+            "id": "workflowflowaction",
+            "name": "WorkflowFlowAction",
+            "suffix": "workflowFlowAction",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "flowActions"
+          },
+          "workflowknowledgepublish": {
+            "directoryName": "workflowKnowledgePublishs",
+            "id": "workflowknowledgepublish",
+            "name": "WorkflowKnowledgePublish",
+            "suffix": "workflowKnowledgePublish",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "knowledgePublishes"
+          },
+          "workflowoutboundmessage": {
+            "directoryName": "workflowOutboundMessages",
+            "id": "workflowoutboundmessage",
+            "name": "WorkflowOutboundMessage",
+            "suffix": "workflowOutboundMessage",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "outboundMessages"
+          },
+          "workflowrule": {
+            "directoryName": "workflowRules",
+            "id": "workflowrule",
+            "name": "WorkflowRule",
+            "suffix": "workflowRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "rules"
+          },
+          "workflowsend": {
+            "directoryName": "workflowSends",
+            "id": "workflowsend",
+            "name": "WorkflowSend",
+            "suffix": "workflowSend",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "send"
+          },
+          "workflowtask": {
+            "directoryName": "workflowTasks",
+            "id": "workflowtask",
+            "name": "WorkflowTask",
+            "suffix": "workflowTask",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "tasks"
+          }
+        }
+      },
+      "directoryName": "workflows",
+      "id": "workflow",
+      "inFolder": false,
+      "name": "Workflow",
+      "strictDirectoryName": false,
+      "suffix": "workflow",
+      "supportsWildcardAndName": true
+    },
+    "workskillrouting": {
+      "children": {
+        "directories": {
+          "workSkillRoutingAttributes": "workskillroutingattribute"
+        },
+        "suffixes": {
+          "workSkillRoutingAttribute": "workskillroutingattribute"
+        },
+        "types": {
+          "workskillroutingattribute": {
+            "directoryName": "workSkillRoutingAttributes",
+            "id": "workskillroutingattribute",
+            "name": "WorkSkillRoutingAttribute",
+            "suffix": "workSkillRoutingAttribute"
+          }
+        }
+      },
+      "directoryName": "workSkillRoutings",
+      "id": "workskillrouting",
+      "name": "WorkSkillRouting",
+      "strictDirectoryName": false,
+      "suffix": "workSkillRouting"
+    },
+    "xorghub": {
+      "directoryName": "xorghubs",
+      "id": "xorghub",
+      "inFolder": false,
+      "name": "XOrgHub",
+      "suffix": "xorghub"
+    },
+    "extlclntapppushsettings": {
+      "id": "extlclntapppushsettings",
+      "name": "ExtlClntAppPushSettings",
+      "suffix": "ecaPush",
+      "directoryName": "extlClntAppPushSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntapppushconfigurablepolicies": {
+      "id": "extlclntapppushconfigurablepolicies",
+      "name": "ExtlClntAppPushConfigurablePolicies",
+      "suffix": "ecaPushPlcy",
+      "directoryName": "extlClntAppPushPolicies",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "appframeworktemplatebundle": {
+      "directoryName": "appTemplates",
+      "id": "appframeworktemplatebundle",
+      "name": "AppFrameworkTemplateBundle",
+      "inFolder": false,
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "choicelist": {
+      "id": "choicelist",
+      "name": "ChoiceList",
+      "suffix": "ChoiceList",
+      "directoryName": "ChoiceList",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "convintelligencesignalrule": {
+      "id": "convintelligencesignalrule",
+      "name": "ConvIntelligenceSignalRule",
+      "suffix": "ConvIntelligenceSignalRule",
+      "directoryName": "ConvIntelligenceSignalRule",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "publickeycertificate": {
+      "id": "publickeycertificate",
+      "name": "PublicKeyCertificate",
+      "suffix": "PublicKeyCertificate",
+      "directoryName": "PublicKeyCertificate",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "publickeycertificateset": {
+      "id": "publickeycertificateset",
+      "name": "PublicKeyCertificateSet",
+      "suffix": "PublicKeyCertificateSet",
+      "directoryName": "PublicKeyCertificateSet",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "aievaluationdefinition": {
+      "id": "aievaluationdefinition",
+      "name": "AiEvaluationDefinition",
+      "suffix": "aiEvaluationDefinition",
+      "directoryName": "aiEvaluationDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsdashboard": {
+      "id": "analyticsdashboard",
+      "name": "AnalyticsDashboard",
+      "suffix": "uadash",
+      "directoryName": "analyticsDashboards",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsvisualization": {
+      "id": "analyticsvisualization",
+      "name": "AnalyticsVisualization",
+      "suffix": "uaviz",
+      "directoryName": "analyticsVisualizations",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsworkspace": {
+      "id": "analyticsworkspace",
+      "name": "AnalyticsWorkspace",
+      "suffix": "uawork",
+      "directoryName": "analyticsWorkspaces",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lightningtypebundle": {
+      "id": "lightningtypebundle",
+      "name": "LightningTypeBundle",
+      "directoryName": "lightningTypes",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "metaFileSuffix": "schema.json",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true
+    },
+    "contenttypebundle": {
+      "id": "contenttypebundle",
+      "name": "ContentTypeBundle",
+      "directoryName": "contentTypes",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "metaFileSuffix": "schema.json",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true
+    },
+    "lifesciconfigcategory": {
+      "id": "lifesciconfigcategory",
+      "name": "LifeSciConfigCategory",
+      "suffix": "lifeSciConfigCategory",
+      "directoryName": "lifeSciConfigCategories",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lifesciconfigrecord": {
+      "id": "lifesciconfigrecord",
+      "name": "LifeSciConfigRecord",
+      "suffix": "lifeSciConfigRecord",
+      "directoryName": "lifeSciConfigRecords",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "invocableactionextension": {
+      "id": "invocableactionextension",
+      "name": "InvocableActionExtension",
+      "suffix": "invocableactionextension",
+      "directoryName": "invocableactionextensions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "fieldservicemobileconfig": {
+      "id": "fieldservicemobileconfig",
+      "name": "FieldServiceMobileConfig",
+      "suffix": "fieldServiceMobileConfig",
+      "directoryName": "fieldServiceMobileConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprovider": {
+      "id": "dgtassetmgmtprovider",
+      "name": "DgtAssetMgmtProvider",
+      "suffix": "dgtAssetMgmtProvider",
+      "directoryName": "dgtAssetMgmtProviders",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprvdlghtcpnt": {
+      "id": "dgtassetmgmtprvdlghtcpnt",
+      "name": "DgtAssetMgmtPrvdLghtCpnt",
+      "suffix": "dgtAssetMgmtPrvdLghtCpnt",
+      "directoryName": "dgtAssetMgmtPrvdLghtCpnts",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappcanvasstngs": {
+      "id": "extlclntappcanvasstngs",
+      "name": "ExtlClntAppCanvasStngs",
+      "suffix": "ecaCanvas",
+      "directoryName": "extlClntAppCanvasStngs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "apinamedquery": {
+      "id": "apinamedquery",
+      "name": "ApiNamedQuery",
+      "suffix": "apiNamedQuery",
+      "directoryName": "apiNamedQueries",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "externalstorageprvdconfig": {
+      "id": "externalstorageprvdconfig",
+      "name": "ExternalStoragePrvdConfig",
+      "suffix": "ExternalStoragePrvdConfigSet",
+      "directoryName": "ExternalStoragePrvdConfig",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapi": {
+      "id": "catalogedapi",
+      "name": "CatalogedApi",
+      "suffix": "catalogedApi",
+      "directoryName": "catalogedApis",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapiversion": {
+      "id": "catalogedapiversion",
+      "name": "CatalogedApiVersion",
+      "suffix": "catalogedApiVersion",
+      "directoryName": "catalogedApiVersions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapiartifactversioninfo": {
+      "id": "catalogedapiartifactversioninfo",
+      "name": "CatalogedApiArtifactVersionInfo",
+      "suffix": "catalogedApiArtifactVersionInfo",
+      "directoryName": "catalogedApiArtifactsVersionInfo",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "rulelibrarydefinition": {
+      "id": "rulelibrarydefinition",
+      "name": "RuleLibraryDefinition",
+      "suffix": "ruleLibraryDefinition",
+      "directoryName": "ruleLibraryDefinition",
+      "inFolder": false,
+      "strictDirectoryName": false
+    }
+  }
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,100 @@
+// Package registry provides metadata type registry information without circular dependencies
+package registry
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+)
+
+// From https://github.com/forcedotcom/source-deploy-retrieve/blob/main/src/registry/metadataRegistry.json
+//
+//go:embed metadataRegistry.json
+var metadataRegistryJSON []byte
+
+type MetadataTypeInfo struct {
+	DirectoryName       string `json:"directoryName"`
+	Id                  string `json:"id"`
+	Name                string `json:"name"`
+	Suffix              string `json:"suffix,omitempty"`
+	StrictDirectoryName bool   `json:"strictDirectoryName"`
+}
+
+type MetadataRegistry struct {
+	ChildTypes           map[string]string            `json:"childTypes"`
+	StrictDirectoryNames map[string]string            `json:"strictDirectoryNames"`
+	Suffixes             map[string]string            `json:"suffixes"`
+	Types                map[string]*MetadataTypeInfo `json:"types"`
+}
+
+var registry *MetadataRegistry
+
+func init() {
+	registry = &MetadataRegistry{}
+	if err := json.Unmarshal(metadataRegistryJSON, registry); err != nil {
+		panic("Failed to unmarshal metadata registry: " + err.Error())
+	}
+}
+
+// GetMetadataDirectory returns the canonical directory name for a given metadata type.
+func GetMetadataDirectory(metadataType string) string {
+	// First check the types registry which has the directoryName
+	metadataTypeLower := strings.ToLower(metadataType)
+	if typeInfo, ok := registry.Types[metadataTypeLower]; ok && typeInfo.DirectoryName != "" {
+		return typeInfo.DirectoryName
+	}
+
+	// Then check strictDirectoryNames (maps directory -> type, so we reverse it)
+	for dir, typeValue := range registry.StrictDirectoryNames {
+		if strings.ToLower(typeValue) == metadataTypeLower {
+			return dir
+		}
+	}
+
+	// Default to lowercase with 's' for plural
+	return strings.ToLower(metadataType) + "s"
+}
+
+// GetParentType returns the parent metadata type for child types like CustomField
+func GetParentType(childType string) string {
+	childTypeLower := strings.ToLower(childType)
+	if parent, ok := registry.ChildTypes[childTypeLower]; ok {
+		return parent
+	}
+	return ""
+}
+
+// IsChildType returns true if the metadata type is a child of another type
+func IsChildType(metadataType string) bool {
+	return GetParentType(metadataType) != ""
+}
+
+// GetCanonicalDirectoryName returns the proper directory name for a metadata type
+// considering both the type itself and any parent-child relationships
+func GetCanonicalDirectoryName(metadataType string) string {
+	// First check if it's a child type
+	if parent := GetParentType(metadataType); parent != "" {
+		// For child types, return the parent's directory
+		return GetMetadataDirectory(parent)
+	}
+
+	// Otherwise return the directory for this type
+	return GetMetadataDirectory(metadataType)
+}
+
+// GetMetadataSuffix returns the file suffix for a given metadata type
+func GetMetadataSuffix(metadataType string) string {
+	// Check the types registry for the suffix
+	metadataTypeLower := strings.ToLower(metadataType)
+	if typeInfo, ok := registry.Types[metadataTypeLower]; ok && typeInfo.Suffix != "" {
+		return typeInfo.Suffix
+	}
+
+	// Check the suffixes map
+	if suffix, ok := registry.Suffixes[metadataTypeLower]; ok {
+		return suffix
+	}
+
+	// No suffix for this type
+	return ""
+}

--- a/repo/metadata_registry.go
+++ b/repo/metadata_registry.go
@@ -1,0 +1,34 @@
+package repo
+
+import (
+	"github.com/ForceCLI/force-md/registry"
+)
+
+// Re-export registry functions for backward compatibility
+// These can be removed once all callers are updated to use registry directly
+
+// GetMetadataDirectory returns the canonical directory name for a given metadata type.
+func GetMetadataDirectory(metadataType string) string {
+	return registry.GetMetadataDirectory(metadataType)
+}
+
+// GetParentType returns the parent metadata type for child types like CustomField
+func GetParentType(childType string) string {
+	return registry.GetParentType(childType)
+}
+
+// IsChildType returns true if the metadata type is a child of another type
+func IsChildType(metadataType string) bool {
+	return registry.IsChildType(metadataType)
+}
+
+// GetCanonicalDirectoryName returns the proper directory name for a metadata type
+// considering both the type itself and any parent-child relationships
+func GetCanonicalDirectoryName(metadataType string) string {
+	return registry.GetCanonicalDirectoryName(metadataType)
+}
+
+// GetMetadataSuffix returns the file suffix for a given metadata type
+func GetMetadataSuffix(metadataType string) string {
+	return registry.GetMetadataSuffix(metadataType)
+}

--- a/repo/metadata_registry_test.go
+++ b/repo/metadata_registry_test.go
@@ -1,0 +1,89 @@
+package repo
+
+import (
+	"testing"
+)
+
+func TestGetMetadataDirectory(t *testing.T) {
+	tests := []struct {
+		metadataType string
+		expected     string
+	}{
+		{"customobject", "objects"},
+		{"CustomObject", "objects"},
+		{"auradefinitionbundle", "aura"},
+		{"lightningcomponentbundle", "lwc"},
+		{"CustomApplication", "applications"},
+	}
+
+	for _, tt := range tests {
+		result := GetMetadataDirectory(tt.metadataType)
+		if result != tt.expected {
+			t.Errorf("GetMetadataDirectory(%s) = %s; want %s", tt.metadataType, result, tt.expected)
+		}
+	}
+}
+
+func TestGetParentType(t *testing.T) {
+	tests := []struct {
+		childType string
+		expected  string
+	}{
+		{"customfield", "customobject"},
+		{"CustomField", "customobject"},
+		{"validationrule", "customobject"},
+		{"recordtype", "customobject"},
+		{"workflowalert", "workflow"},
+		{"sharingcriteriarule", "sharingrules"},
+		{"notachild", ""},
+	}
+
+	for _, tt := range tests {
+		result := GetParentType(tt.childType)
+		if result != tt.expected {
+			t.Errorf("GetParentType(%s) = %s; want %s", tt.childType, result, tt.expected)
+		}
+	}
+}
+
+func TestIsChildType(t *testing.T) {
+	tests := []struct {
+		metadataType string
+		expected     bool
+	}{
+		{"customfield", true},
+		{"validationrule", true},
+		{"recordtype", true},
+		{"workflowalert", true},
+		{"customobject", false},
+		{"profile", false},
+		{"flow", false},
+	}
+
+	for _, tt := range tests {
+		result := IsChildType(tt.metadataType)
+		if result != tt.expected {
+			t.Errorf("IsChildType(%s) = %v; want %v", tt.metadataType, result, tt.expected)
+		}
+	}
+}
+
+func TestGetCanonicalDirectoryName(t *testing.T) {
+	tests := []struct {
+		metadataType string
+		expected     string
+	}{
+		{"customfield", "objects"},
+		{"validationrule", "objects"},
+		{"CustomObject", "objects"},
+		{"Profile", "profiles"},
+		{"lightningcomponentbundle", "lwc"},
+	}
+
+	for _, tt := range tests {
+		result := GetCanonicalDirectoryName(tt.metadataType)
+		if result != tt.expected {
+			t.Errorf("GetCanonicalDirectoryName(%s) = %s; want %s", tt.metadataType, result, tt.expected)
+		}
+	}
+}

--- a/repo/resources/metadataRegistry.json
+++ b/repo/resources/metadataRegistry.json
@@ -1,0 +1,4928 @@
+{
+  "childTypes": {
+    "aiscoringmodeldefversion": "aiscoringmodeldefinition",
+    "assignmentrule": "assignmentrules",
+    "autoresponserule": "autoresponserules",
+    "botversion": "bot",
+    "businessprocess": "customobject",
+    "compactlayout": "customobject",
+    "customfield": "customobject",
+    "customfieldtranslation": "customobjecttranslation",
+    "customlabel": "customlabels",
+    "digitalexperience": "digitalexperiencebundle",
+    "escalationrule": "escalationrules",
+    "extdatatranfieldtemplate": "extdatatranobjecttemplate",
+    "fieldset": "customobject",
+    "formsection": "form",
+    "index": "customobject",
+    "listview": "customobject",
+    "managedtopic": "managedtopics",
+    "matchingrule": "matchingrules",
+    "mktdatatranfield": "mktdatatranobject",
+    "recordtype": "customobject",
+    "sharingcriteriarule": "sharingrules",
+    "sharingguestrule": "sharingrules",
+    "sharingownerrule": "sharingrules",
+    "sharingreason": "customobject",
+    "sharingterritoryrule": "sharingrules",
+    "validationrule": "customobject",
+    "weblink": "customobject",
+    "workflowalert": "workflow",
+    "workflowfieldupdate": "workflow",
+    "workflowflowaction": "workflow",
+    "workflowknowledgepublish": "workflow",
+    "workflowoutboundmessage": "workflow",
+    "workflowrule": "workflow",
+    "workflowsend": "workflow",
+    "workflowtask": "workflow",
+    "workskillroutingattribute": "workskillrouting"
+  },
+  "strictDirectoryNames": {
+    "ActionableEventOrchDefSettings": "actionableeventorchdef",
+    "ActionableEventTypeDefSettings": "actionableeventtypedef",
+    "IndustriesManufacturingSettings": "industriesmanufacturingsettings",
+    "ObjectHierarchyRelationship": "objecthierarchyrelationship",
+    "accessControlPolicies": "accesscontrolpolicy",
+    "appointmentAssignmentPolicies": "appointmentassignmentpolicy",
+    "appointmentSchedulingPolicies": "appointmentschedulingpolicy",
+    "aura": "auradefinitionbundle",
+    "botBlocks": "botblock",
+    "botTemplates": "bottemplate",
+    "bots": "bot",
+    "contentTypes": "contenttypebundle",
+    "documents": "document",
+    "emailservices": "emailservicesfunction",
+    "experiencePropertyTypeBundles": "experiencepropertytypebundle",
+    "experiences": "experiencebundle",
+    "fieldRestrictionRules": "fieldrestrictionrule",
+    "genAiFunctions": "genaifunction",
+    "genAiPlannerBundles": "genaiplannerbundle",
+    "integrationHub": "integrationhubsettings",
+    "lwc": "lightningcomponentbundle",
+    "mktDataSources": "datasource",
+    "objectTranslations": "customobjecttranslation",
+    "objects": "customobject",
+    "restrictionRules": "restrictionrule",
+    "siteDotComSites": "sitedotcom",
+    "sites": "customsite",
+    "staticresources": "staticresource",
+    "waveTemplates": "wavetemplatebundle",
+    "appTemplates": "appframeworktemplatebundle",
+    "lightningTypes": "lightningtypebundle"
+  },
+  "suffixes": {
+    "Canvas": "canvasmetadata",
+    "CaseSubjectParticle": "casesubjectparticle",
+    "ChannelObjectLinkingRule": "channelobjectlinkingrule",
+    "ChatterExtension": "chatterextension",
+    "ConversationChannelDefinition": "conversationchanneldefinition",
+    "ConversationVendorFieldDefinition": "conversationvendorfielddef",
+    "ConversationVendorInformation": "conversationvendorinfo",
+    "DataPackageKitObject": "datapackagekitobject",
+    "EmbeddedServiceBranding": "embeddedservicebranding",
+    "EmbeddedServiceConfig": "embeddedserviceconfig",
+    "EmbeddedServiceFieldService": "embeddedservicefieldservice",
+    "EmbeddedServiceFlowConfig": "embeddedserviceflowconfig",
+    "EmbeddedServiceLiveAgent": "embeddedserviceliveagent",
+    "EmbeddedServiceMenuSettings": "embeddedservicemenusettings",
+    "IPAddressRange": "ipaddressrange",
+    "IdentityVerificationProcDef": "identityverificationprocdef",
+    "LeadConvertSetting": "leadconvertsettings",
+    "MobileApplicationDetail": "mobileapplicationdetail",
+    "OmniExtTrackingDef": "omniexttrackingdef",
+    "OmniTrackingGroup": "omnitrackinggroup",
+    "RecordAggregationDefinition": "recordaggregationdefinition",
+    "RetrievalSummaryDefinition": "retrievalsummarydefinition",
+    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration",
+    "SearchableObjDataSyncInfoSetting": "searchableobjdatasyncinfo",
+    "accountForecastSetting": "accountforecastsettings",
+    "accountRelationshipShareRule": "accountrelationshipsharerule",
+    "accountingFieldMapping": "accountingfieldmapping",
+    "accountingModelConfig": "accountingmodelconfig",
+    "acctMgrTargetSetting": "acctmgrtargetsettings",
+    "actionLauncherItemDef": "actionlauncheritemdef",
+    "actionLinkGroupTemplate": "actionlinkgrouptemplate",
+    "actionableListDefinition": "actionablelistdefinition",
+    "activationPlatform": "activationplatform",
+    "actnblListKeyPrfmIndDef": "actnbllistkeyprfminddef",
+    "advAccountForecastSet": "advaccountforecastset",
+    "advAcctForecastDimSource": "advacctforecastdimsource",
+    "advAcctForecastPeriodGroup": "advacctforecastperiodgroup",
+    "affinityScoreDefinition": "affinityscoredefinition",
+    "ai": "aiapplication",
+    "aiAssistantTemplate": "aiassistanttemplate",
+    "aiScoringModelDefVersion": "aiscoringmodeldefversion",
+    "aiScoringModelDefinition": "aiscoringmodeldefinition",
+    "aiUsecaseDefinitions": "aiusecasedefinition",
+    "aiapplicationconfig": "aiapplicationconfig",
+    "animationRule": "animationrule",
+    "app": "customapplication",
+    "appMenu": "appmenu",
+    "applicationRecordTypeConfig": "applicationrecordtypeconfig",
+    "applicationSubtypeDefinition": "applicationsubtypedefinition",
+    "approvalProcess": "approvalprocess",
+    "apt": "actionplantemplate",
+    "aq": "assessmentquestion",
+    "aqs": "assessmentquestionset",
+    "assessmentConfiguration": "assessmentconfiguration",
+    "asset": "contentasset",
+    "assignmentRule": "assignmentrule",
+    "assignmentRules": "assignmentrules",
+    "assistantContextItem": "assistantcontextitem",
+    "assistantDefinition": "assistantdefinition",
+    "assistantRecommendationType": "assistantrecommendationtype",
+    "assistantSkillQuickAction": "assistantskillquickaction",
+    "assistantSkillSobjectAction": "assistantskillsobjectaction",
+    "assistantVersion": "assistantversion",
+    "audience": "audience",
+    "authprovider": "authprovider",
+    "autoResponseRule": "autoresponserule",
+    "autoResponseRules": "autoresponserules",
+    "batchCalcJobDefinition": "batchcalcjobdefinition",
+    "batchProcessJobDefinition": "batchprocessjobdefinition",
+    "benefitAction": "benefitaction",
+    "blacklistedConsumer": "blacklistedconsumer",
+    "bot": "bot",
+    "botBlock": "botblock",
+    "botTemplate": "bottemplate",
+    "botVersion": "botversion",
+    "brandingSet": "brandingset",
+    "briefcaseDefinition": "briefcasedefinition",
+    "buildingEnergyIntensityConfig": "bldgenrgyintensitycnfg",
+    "businessProcessFeedbackConfiguration": "businessprocessfeedbackconfiguration",
+    "businessProcessGroup": "businessprocessgroup",
+    "businessProcessTypeDefinition": "businessprocesstypedefinition",
+    "cachePartition": "platformcachepartition",
+    "callCenter": "callcenter",
+    "callCenterRoutingMap": "callcenterroutingmap",
+    "callCoachingMediaProvider": "callcoachingmediaprovider",
+    "callCtrAgentFavTrfrDest": "callctragentfavtrfrdest",
+    "campaignInfluenceModel": "campaigninfluencemodel",
+    "careBenefitVerifySettings": "carebenefitverifysettings",
+    "careLimitType": "carelimittype",
+    "careProviderAfflRoleConfig": "careproviderafflroleconfig",
+    "careProviderSearchConfig": "careprovidersearchconfig",
+    "careRequestConfiguration": "carerequestconfiguration",
+    "careSystemFieldMapping": "caresystemfieldmapping",
+    "catalogedApi": "catalogedapi",
+    "catalogedApiVersion": "catalogedapiversion",
+    "catalogedApiArtifactVersionInfo": "catalogedapiartifactversioninfo",
+    "catalogFilterCondition": "svccatalogfiltercondition",
+    "catalogFilterCriteria": "svccatalogfiltercriteria",
+    "catalogItem": "svccatalogitemdef",
+    "catalogItemDefFiltrCrit": "svccatalogitemdeffiltrcrit",
+    "category": "svccatalogcategory",
+    "channelLayout": "channellayout",
+    "clauseCatgConfiguration": "clausecatgconfiguration",
+    "cleanDataService": "cleandataservice",
+    "cls": "apexclass",
+    "cmsConnectSource": "cmsconnectsource",
+    "collection": "waveanalyticassetcollection",
+    "commandaction": "commandaction",
+    "community": "community",
+    "communityTemplateDefinition": "communitytemplatedefinition",
+    "communityThemeDefinition": "communitythemedefinition",
+    "component": "apexcomponent",
+    "config": "notificationtypeconfig",
+    "connectedApp": "connectedapp",
+    "contextDefinition": "contextdefinition",
+    "contextUseCaseMapping": "contextusecasemapping",
+    "contractType": "contracttype",
+    "conversationMessageDefinition": "conversationmessagedefinition",
+    "corsWhitelistOrigin": "corswhitelistorigin",
+    "crt": "certificate",
+    "cspTrustedSite": "csptrustedsite",
+    "customApplicationComponent": "customapplicationcomponent",
+    "customExperience": "customexperience",
+    "customHelpMenuSection": "customhelpmenusection",
+    "customPermission": "custompermission",
+    "custompageweblink": "custompageweblink",
+    "dashboard": "dashboard",
+    "dashboardFolder": "dashboardfolder",
+    "dataCalcInsightTemplate": "datacalcinsighttemplate",
+    "dataconnector": "dataconnector",
+    "dataConnectorIngestApi": "dataconnectoringestapi",
+    "dataKitObjectDependency": "datakitobjectdependency",
+    "dataKitObjectTemplate": "datakitobjecttemplate",
+    "dataObjectBuildOrgTemplate": "dataobjectbuildorgtemplate",
+    "dataPackageKitDefinition": "datapackagekitdefinition",
+    "dataPipeline": "datapipeline",
+    "dataSource": "externaldatasource",
+    "dataSourceBundleDefinition": "datasourcebundledefinition",
+    "dataSourceObject": "datasourceobject",
+    "dataSourceTenant": "datasourcetenant",
+    "dataSrcDataModelFieldMap": "datasrcdatamodelfieldmap",
+    "dataStreamDefinition": "datastreamdefinition",
+    "dataStreamTemplate": "datastreamtemplate",
+    "datacategorygroup": "datacategorygroup",
+    "datatype": "customdatatype",
+    "decisionMatrixDefinition": "decisionmatrixdefinition",
+    "decisionMatrixVersion": "decisionmatrixdefinitionversion",
+    "decisionTable": "decisiontable",
+    "decisionTableDatasetLink": "decisiontabledatasetlink",
+    "delegateGroup": "delegategroup",
+    "delivery": "eventdelivery",
+    "deployment": "recordactiondeployment",
+    "digitalExperience": "digitalexperiencebundle",
+    "digitalExperienceConfig": "digitalexperienceconfig",
+    "disclosureDefinition": "disclosuredefinition",
+    "disclosureDefinitionVersion": "disclosuredefinitionversion",
+    "disclosureType": "disclosuretype",
+    "documentCategory": "documentcategory",
+    "documentCategoryDocumentType": "documentcategorydocumenttype",
+    "documentFolder": "documentfolder",
+    "documentGenerationSetting": "documentgenerationsetting",
+    "documentType": "documenttype",
+    "dt": "documenttemplate",
+    "duplicateRule": "duplicaterule",
+    "dwl": "dataweaveresource",
+    "dynamicTrigger": "dynamictrigger",
+    "eSignatureConfig": "esignatureconfig",
+    "eSignatureEnvelopeConfig": "esignatureenvelopeconfig",
+    "eca": "externalclientapplication",
+    "ecaGlblOauth": "extlclntappglobaloauthsettings",
+    "ecaMobile": "extlclntappmobilesettings",
+    "ecaMobilePlcy": "extlclntappmobileconfigurablepolicies",
+    "ecaNotifications": "extlclntappnotificationsettings",
+    "ecaOauth": "extlclntappoauthsettings",
+    "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
+    "ecaPlcy": "extlclntappconfigurablepolicies",
+    "ecaSamlPlcy": "extlclntappsamlconfigurablepolicies",
+    "ecaSmpl": "extlclntappsamplesettings",
+    "ecaSmplPlcy": "extlclntappsampleconfigurablepolicies",
+    "email": "emailtemplate",
+    "emailFolder": "emailfolder",
+    "employeeDataSyncProfile": "employeedatasyncprofile",
+    "enablementMeasureDefinition": "enablementmeasuredefinition",
+    "enablementProgramDefinition": "enablementprogramdefinition",
+    "enblProgramTaskSubCategory": "enblprogramtasksubcategory",
+    "entitlementProcess": "entitlementprocess",
+    "entitlementTemplate": "entitlementtemplate",
+    "entityImplements": "entityimplements",
+    "escalationRule": "escalationrule",
+    "escalationRules": "escalationrules",
+    "eventRelay": "eventrelayconfig",
+    "eventType": "eventtype",
+    "explainabilityActionDefinition": "explainabilityactiondefinition",
+    "explainabilityActionVersion": "explainabilityactionversion",
+    "explainabilityMsgTemplate": "explainabilitymsgtemplate",
+    "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetMessageToken": "expressionsetmessagetoken",
+    "expressionSetObjectAlias": "expressionsetobjectalias",
+    "expressionSetVersion": "expressionsetdefinitionversion",
+    "extDataTranFieldTemplate": "extdatatranfieldtemplate",
+    "extDataTranObjectTemplate": "extdatatranobjecttemplate",
+    "externalAIModel": "externalaimodel",
+    "externalAuthIdentityProvider": "externalauthidentityprovider",
+    "externalCredential": "externalcredential",
+    "externalDataConnector": "externaldataconnector",
+    "externalDataTranObject": "externaldatatranobject",
+    "externalDocStorageConfig": "externaldocstorageconfig",
+    "externalServiceRegistration": "externalserviceregistration",
+    "featureParameterBoolean": "featureparameterboolean",
+    "featureParameterDate": "featureparameterdate",
+    "featureParameterInteger": "featureparameterinteger",
+    "feedFilter": "customfeedfilter",
+    "fieldServiceMobileExtension": "fieldservicemobileextension",
+    "fieldSrcTrgtRelationship": "fieldsrctrgtrelationship",
+    "fieldTranslation": "customfieldtranslation",
+    "flexipage": "flexipage",
+    "flow": "flow",
+    "flowCategory": "flowcategory",
+    "flowDefinition": "flowdefinition",
+    "flowtest": "flowtest",
+    "forecastingFilter": "forecastingfilter",
+    "forecastingFilterCondition": "forecastingfiltercondition",
+    "forecastingGroup": "forecastinggroup",
+    "forecastingSourceDefinition": "forecastingsourcedefinition",
+    "forecastingType": "forecastingtype",
+    "forecastingTypeSource": "forecastingtypesource",
+    "form": "form",
+    "formSection": "formsection",
+    "fuelType": "fueltype",
+    "fuelTypeSustnUom": "fueltypesustnuom",
+    "fulfillmentFlow": "svccatalogfulfillmentflow",
+    "function": "functionreference",
+    "fundraisingConfig": "fundraisingconfig",
+    "gatewayProviderPaymentMethodType": "gatewayproviderpaymentmethodtype",
+    "genAiPlanner": "genaiplanner",
+    "genAiPlugin": "genaiplugin",
+    "genAiPromptTemplate": "genaiprompttemplate",
+    "genAiPromptTemplateActivation": "genaiprompttemplateactv",
+    "geodata": "eclairgeodata",
+    "globalPicklist": "globalpicklist",
+    "globalValueSet": "globalvalueset",
+    "globalValueSetTranslation": "globalvaluesettranslation",
+    "goal": "discoverygoal",
+    "group": "group",
+    "homePageComponent": "homepagecomponent",
+    "homePageLayout": "homepagelayout",
+    "icon": "icon",
+    "iframeWhiteListUrlSettings": "iframewhitelisturlsettings",
+    "inboundCertificate": "inboundcertificate",
+    "inboundNetworkConnection": "inboundnetworkconnection",
+    "indx": "customindex",
+    "insightType": "insighttype",
+    "installedPackage": "installedpackage",
+    "integrationProviderDefinition": "integrationproviderdef",
+    "internalDataConnector": "internaldataconnector",
+    "internalOrganization": "internalorganization",
+    "keywords": "keywordlist",
+    "labels": "customlabels",
+    "layout": "layout",
+    "learningAchievementConfig": "learningachievementconfig",
+    "learningItemType": "learningitemtype",
+    "letter": "letterhead",
+    "licenseDefinition": "licensedefinition",
+    "lightningBolt": "lightningbolt",
+    "lightningExperienceTheme": "lightningexperiencetheme",
+    "lightningOnboardingConfig": "lightningonboardingconfig",
+    "liveChatAgentConfig": "livechatagentconfig",
+    "liveChatButton": "livechatbutton",
+    "liveChatDeployment": "livechatdeployment",
+    "liveChatSensitiveDataRule": "livechatsensitivedatarule",
+    "locationUse": "locationuse",
+    "loyaltyProgramSetup": "loyaltyprogramsetup",
+    "managedContentType": "managedcontenttype",
+    "managedEventSubscription": "managedeventsubscription",
+    "managedTopic": "managedtopic",
+    "managedTopics": "managedtopics",
+    "marketSegmentDefinition": "marketsegmentdefinition",
+    "marketingResourceType": "marketingresourcetype",
+    "marketingappextension": "marketingappextension",
+    "matchingRule": "matchingrules",
+    "md": "custommetadata",
+    "messageChannel": "lightningmessagechannel",
+    "messagingChannel": "messagingchannel",
+    "mfgProgramTemplate": "mfgprogramtemplate",
+    "milestoneType": "milestonetype",
+    "mktCalcInsightObjectDef": "mktcalcinsightobjectdef",
+    "mktDataConnection": "mktdataconnection",
+    "mktDataConnectionSrcParam": "mktdataconnectionsrcparam",
+    "mktDataTranField": "mktdatatranfield",
+    "mktDataTranObject": "mktdatatranobject",
+    "mlDataDefinition": "mldatadefinition",
+    "mlDomain": "mldomain",
+    "mlPrediction": "mlpredictiondefinition",
+    "mlRecommendation": "mlrecommendationdefinition",
+    "mobSecurityCertPinConfig": "mobsecuritycertpinconfig",
+    "mobileSecurityAssignment": "mobilesecurityassignment",
+    "mobileSecurityPolicy": "mobilesecuritypolicy",
+    "mobileSecurityPolicySet": "mobilesecuritypolicyset",
+    "model": "discoveryaimodel",
+    "mutingpermissionset": "mutingpermissionset",
+    "myDomainDiscoverableLogin": "mydomaindiscoverablelogin",
+    "namedCredential": "namedcredential",
+    "navigationMenu": "navigationmenu",
+    "network": "network",
+    "networkBranding": "networkbranding",
+    "notifications": "apexemailnotifications",
+    "notiftype": "customnotificationtype",
+    "oauthcustomscope": "oauthcustomscope",
+    "oauthtokenexchangehandler": "oauthtokenexchangehandler",
+    "object": "customobject",
+    "objectSourceTargetMap": "objectsourcetargetmap",
+    "objIntegProviderDefMapping": "objintegproviderdefmapping",
+    "objectTranslation": "customobjecttranslation",
+    "ocrSampleDocument": "ocrsampledocument",
+    "ocrTemplate": "ocrtemplate",
+    "oip": "omniintegrationprocedure",
+    "omniInteractionAccessConfig": "omniinteractionaccessconfig",
+    "omniInteractionConfig": "omniinteractionconfig",
+    "omniSupervisorConfig": "omnisupervisorconfig",
+    "orchestration": "orchestration",
+    "orchestrationContext": "orchestrationcontext",
+    "os": "omniscript",
+    "ouc": "omniuicard",
+    "outboundNetworkConnection": "outboundnetworkconnection",
+    "page": "apexpage",
+    "participantRole": "participantrole",
+    "pathAssistant": "pathassistant",
+    "paymentGatewayProvider": "paymentgatewayprovider",
+    "permissionSetLicenseDefinition": "permissionsetlicensedefinition",
+    "permissionset": "permissionset",
+    "permissionsetgroup": "permissionsetgroup",
+    "personAccountOwnerPowerUser": "personaccountownerpoweruser",
+    "pipelineInspMetricConfig": "pipelineinspmetricconfig",
+    "platformEventChannel": "platformeventchannel",
+    "platformEventChannelMember": "platformeventchannelmember",
+    "platformEventSubscriberConfig": "platformeventsubscriberconfig",
+    "policy": "appointmentassignmentpolicy",
+    "portal": "portal",
+    "portalDelegablePermissionSet": "portaldelegablepermissionset",
+    "postTemplate": "posttemplate",
+    "presenceDeclineReason": "presencedeclinereason",
+    "presenceUserConfig": "presenceuserconfig",
+    "pricingActionParameters": "pricingactionparameters",
+    "pricingRecipe": "pricingrecipe",
+    "processflowmigration": "processflowmigration",
+    "productAttrDisplayConfig": "productattrdisplayconfig",
+    "productAttributeSet": "productattributeset",
+    "productSpecificationRecType": "productspecificationrectype",
+    "productSpecificationType": "productspecificationtype",
+    "productSpecificationTypeDefinition": "productspecificationtypedefinition",
+    "profile": "profile",
+    "profilePasswordPolicy": "profilepasswordpolicy",
+    "profileSessionSetting": "profilesessionsetting",
+    "prompt": "prompt",
+    "queue": "queue",
+    "queueRoutingConfig": "queueroutingconfig",
+    "quickAction": "quickaction",
+    "recAlrtDataSrcExpSetDef": "recalrtdatasrcexpsetdef",
+    "recommendationStrategy": "recommendationstrategy",
+    "recordAlertCategory": "recordalertcategory",
+    "recordAlertDataSource": "recordalertdatasource",
+    "recordAlertTemplate": "recordalerttemplate",
+    "redirectWhitelistUrl": "redirectwhitelisturl",
+    "refdash": "referenceddashboard",
+    "registeredExternalService": "registeredexternalservice",
+    "relatedRecordAssocCriteria": "relatedrecordassoccriteria",
+    "relationshipGraphDefinition": "relationshipgraphdefinition",
+    "remoteSite": "remotesitesetting",
+    "report": "report",
+    "reportFolder": "reportfolder",
+    "reportType": "reporttype",
+    "role": "role",
+    "rpt": "omnidatatransform",
+    "rule": "moderationrule",
+    "s3DataConnector": "dataconnectors3",
+    "salesAgreementSetting": "salesagreementsettings",
+    "samlssoconfig": "samlssoconfig",
+    "scf": "scontrol",
+    "schedulingObjective": "schedulingobjective",
+    "schedulingRule": "schedulingrule",
+    "scoreCategory": "scorecategory",
+    "searchCustomization": "searchcustomization",
+    "searchOrgWideObjectConfig": "searchorgwideobjectconfig",
+    "serviceAISetupDescription": "serviceaisetupdefinition",
+    "serviceAISetupField": "serviceaisetupfield",
+    "serviceChannel": "servicechannel",
+    "servicePresenceStatus": "servicepresencestatus",
+    "serviceprocess": "serviceprocess",
+    "settings": "settings",
+    "sharingCriteriaRule": "sharingcriteriarule",
+    "sharingGuestRule": "sharingguestrule",
+    "sharingOwnerRule": "sharingownerrule",
+    "sharingRules": "sharingrules",
+    "sharingSet": "sharingset",
+    "sharingTerritoryRule": "sharingterritoryrule",
+    "site": "sitedotcom",
+    "skill": "skill",
+    "skilltype": "skilltype",
+    "slackapp": "slackapp",
+    "snapshot": "analyticsnapshot",
+    "stageDefinition": "stagedefinition",
+    "standardValueSet": "standardvalueset",
+    "standardValueSetTranslation": "standardvaluesettranslation",
+    "stationaryAssetEnvSourceConfig": "stnryassetenvsrccnfg",
+    "story": "discoverystory",
+    "streamingAppDataConnector": "streamingappdataconnector",
+    "subscription": "eventsubscription",
+    "sustainabilityUom": "sustainabilityuom",
+    "sustnUomConversion": "sustnuomconversion",
+    "synonymDictionary": "synonymdictionary",
+    "tab": "customtab",
+    "territory": "territory",
+    "territory2": "territory2",
+    "territory2Model": "territory2model",
+    "territory2Rule": "territory2rule",
+    "territory2Type": "territory2type",
+    "testSuite": "apextestsuite",
+    "timeSheetTemplate": "timesheettemplate",
+    "timelineObjectDefinition": "timelineobjectdefinition",
+    "topicsForObjects": "topicsforobjects",
+    "transactionSecurityPolicy": "transactionsecuritypolicy",
+    "translation": "translations",
+    "trigger": "apextrigger",
+    "type": "integrationhubsettingstype",
+    "uiFormatSpecificationSet": "uiformatspecificationset",
+    "uiObjectRelationConfig": "uiobjectrelationconfig",
+    "uiplugin": "uiplugin",
+    "uiview": "uiviewdefinition",
+    "userAuthCertificate": "userauthcertificate",
+    "userCriteria": "usercriteria",
+    "userProfileSearchScope": "userprofilesearchscope",
+    "userProvisioningConfig": "userprovisioningconfig",
+    "useraccesspolicy": "useraccesspolicy",
+    "vehicleAssetEmssnSourceConfig": "vehicleassetemssnsrccnfg",
+    "view": "viewdefinition",
+    "virtualVisitConfig": "virtualvisitconfig",
+    "visualizationPlugin": "visualizationplugin",
+    "wapp": "waveapplication",
+    "wcomp": "wavecomponent",
+    "wdash": "wavedashboard",
+    "wdf": "wavedataflow",
+    "wdpr": "waverecipe",
+    "wds": "wavedataset",
+    "webStoreBundle": "webstorebundle",
+    "webStoreTemplate": "webstoretemplate",
+    "workflowFlowAutomation": "workflowflowautomation",
+    "weblink": "custompageweblink",
+    "wlens": "wavelens",
+    "workSkillRouting": "workskillrouting",
+    "workSkillRoutingAttribute": "workskillroutingattribute",
+    "workflow": "workflow",
+    "workflowAlert": "workflowalert",
+    "workflowFieldUpdate": "workflowfieldupdate",
+    "workflowFlowAction": "workflowflowaction",
+    "workflowKnowledgePublish": "workflowknowledgepublish",
+    "workflowOutboundMessage": "workflowoutboundmessage",
+    "workflowRule": "workflowrule",
+    "workflowSend": "workflowsend",
+    "workflowTask": "workflowtask",
+    "xmd": "wavexmd",
+    "xml": "emailservicesfunction",
+    "xorghub": "xorghub",
+    "ecaPush": "extlclntapppushsettings",
+    "ecaPushPlcy": "extlclntapppushconfigurablepolicies",
+    "ChoiceList": "choicelist",
+    "ConvIntelligenceSignalRule": "convintelligencesignalrule",
+    "PublicKeyCertificate": "publickeycertificate",
+    "PublicKeyCertificateSet": "publickeycertificateset",
+    "aiEvaluationDefinition": "aievaluationdefinition",
+    "uadash": "analyticsdashboard",
+    "uaviz": "analyticsvisualization",
+    "uawork": "analyticsworkspace",
+    "lifeSciConfigCategory": "lifesciconfigcategory",
+    "lifeSciConfigRecord": "lifesciconfigrecord",
+    "invocableactionextension": "invocableactionextension",
+    "fieldServiceMobileConfig": "fieldservicemobileconfig",
+    "dgtAssetMgmtProvider": "dgtassetmgmtprovider",
+    "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt",
+    "ecaCanvas": "extlclntappcanvasstngs",
+    "apiNamedQuery": "apinamedquery",
+    "ExternalStoragePrvdConfigSet": "externalstorageprvdconfig",
+    "ruleLibraryDefinition": "rulelibrarydefinition"
+  },
+  "types": {
+    "accesscontrolpolicy": {
+      "directoryName": "accessControlPolicies",
+      "id": "accesscontrolpolicy",
+      "inFolder": false,
+      "name": "AccessControlPolicy",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "accountforecastsettings": {
+      "directoryName": "AccountForecastSettings",
+      "id": "accountforecastsettings",
+      "name": "AccountForecastSettings",
+      "strictDirectoryName": false,
+      "suffix": "accountForecastSetting"
+    },
+    "accountingfieldmapping": {
+      "directoryName": "accountingFieldMappings",
+      "id": "accountingfieldmapping",
+      "inFolder": false,
+      "name": "AccountingFieldMapping",
+      "strictDirectoryName": false,
+      "suffix": "accountingFieldMapping"
+    },
+    "accountingmodelconfig": {
+      "directoryName": "accountingModelConfigs",
+      "id": "accountingmodelconfig",
+      "inFolder": false,
+      "name": "AccountingModelConfig",
+      "strictDirectoryName": false,
+      "suffix": "accountingModelConfig"
+    },
+    "accountrelationshipsharerule": {
+      "directoryName": "accountRelationshipShareRules",
+      "id": "accountrelationshipsharerule",
+      "name": "AccountRelationshipShareRule",
+      "strictDirectoryName": false,
+      "suffix": "accountRelationshipShareRule"
+    },
+    "acctmgrtargetsettings": {
+      "directoryName": "acctMgrTargetSettings",
+      "id": "acctmgrtargetsettings",
+      "name": "AcctMgrTargetSettings",
+      "strictDirectoryName": false,
+      "suffix": "acctMgrTargetSetting"
+    },
+    "actionableeventorchdef": {
+      "directoryName": "ActionableEventOrchDefSettings",
+      "id": "actionableeventorchdef",
+      "inFolder": false,
+      "name": "ActionableEventOrchDef",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "actionableeventtypedef": {
+      "directoryName": "ActionableEventTypeDefSettings",
+      "id": "actionableeventtypedef",
+      "inFolder": false,
+      "name": "ActionableEventTypeDef",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "actionablelistdefinition": {
+      "directoryName": "actionableListDefinitions",
+      "id": "actionablelistdefinition",
+      "inFolder": false,
+      "name": "ActionableListDefinition",
+      "strictDirectoryName": false,
+      "suffix": "actionableListDefinition"
+    },
+    "actionlauncheritemdef": {
+      "directoryName": "ActionLauncherItemDef",
+      "id": "actionlauncheritemdef",
+      "inFolder": false,
+      "name": "ActionLauncherItemDef",
+      "strictDirectoryName": false,
+      "suffix": "actionLauncherItemDef"
+    },
+    "actionlinkgrouptemplate": {
+      "directoryName": "actionLinkGroupTemplates",
+      "id": "actionlinkgrouptemplate",
+      "inFolder": false,
+      "name": "ActionLinkGroupTemplate",
+      "strictDirectoryName": false,
+      "suffix": "actionLinkGroupTemplate"
+    },
+    "actionplantemplate": {
+      "directoryName": "actionPlanTemplates",
+      "id": "actionplantemplate",
+      "name": "ActionPlanTemplate",
+      "strictDirectoryName": false,
+      "suffix": "apt"
+    },
+    "activationplatform": {
+      "directoryName": "activationPlatforms",
+      "id": "activationplatform",
+      "inFolder": false,
+      "name": "ActivationPlatform",
+      "strictDirectoryName": false,
+      "suffix": "activationPlatform"
+    },
+    "actnbllistkeyprfminddef": {
+      "directoryName": "actnblListKeyPrfmIndDefs",
+      "id": "actnbllistkeyprfminddef",
+      "inFolder": false,
+      "name": "ActnblListKeyPrfmIndDef",
+      "strictDirectoryName": false,
+      "suffix": "actnblListKeyPrfmIndDef"
+    },
+    "advaccountforecastset": {
+      "directoryName": "AdvAccountForecastSet",
+      "id": "advaccountforecastset",
+      "inFolder": false,
+      "name": "AdvAccountForecastSet",
+      "suffix": "advAccountForecastSet"
+    },
+    "advacctforecastdimsource": {
+      "directoryName": "AdvAcctForecastDimSource",
+      "id": "advacctforecastdimsource",
+      "inFolder": false,
+      "name": "AdvAcctForecastDimSource",
+      "strictDirectoryName": false,
+      "suffix": "advAcctForecastDimSource"
+    },
+    "advacctforecastperiodgroup": {
+      "directoryName": "AdvAcctForecastPeriodGroup",
+      "id": "advacctforecastperiodgroup",
+      "inFolder": false,
+      "name": "AdvAcctForecastPeriodGroup",
+      "suffix": "advAcctForecastPeriodGroup"
+    },
+    "affinityscoredefinition": {
+      "directoryName": "affinityScoreDefinitions",
+      "id": "affinityscoredefinition",
+      "inFolder": false,
+      "name": "AffinityScoreDefinition",
+      "strictDirectoryName": false,
+      "suffix": "affinityScoreDefinition"
+    },
+    "aiapplication": {
+      "directoryName": "aiApplications",
+      "id": "aiapplication",
+      "inFolder": false,
+      "name": "AIApplication",
+      "strictDirectoryName": false,
+      "suffix": "ai"
+    },
+    "aiapplicationconfig": {
+      "directoryName": "aiApplicationConfigs",
+      "id": "aiapplicationconfig",
+      "inFolder": false,
+      "name": "AIApplicationConfig",
+      "strictDirectoryName": false,
+      "suffix": "aiapplicationconfig"
+    },
+    "aiassistanttemplate": {
+      "directoryName": "aiAssistantTemplates",
+      "id": "aiassistanttemplate",
+      "inFolder": false,
+      "name": "AIAssistantTemplate",
+      "suffix": "aiAssistantTemplate"
+    },
+    "aiscoringmodeldefinition": {
+      "children": {
+        "directories": {
+          "aiScoringModelDefVersions": "aiscoringmodeldefversion"
+        },
+        "suffixes": {
+          "aiScoringModelDefVersion": "aiscoringmodeldefversion"
+        },
+        "types": {
+          "aiscoringmodeldefversion": {
+            "directoryName": "aiScoringModelDefVersions",
+            "id": "aiscoringmodeldefversion",
+            "name": "AIScoringModelDefVersion",
+            "suffix": "aiScoringModelDefVersion",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "aiScoringModelDefVersions"
+          }
+        }
+      },
+      "directoryName": "aiScoringModelDefinitions",
+      "id": "aiscoringmodeldefinition",
+      "inFolder": false,
+      "name": "AIScoringModelDefinition",
+      "suffix": "aiScoringModelDefinition",
+      "supportsWildcardAndName": true
+    },
+    "aiusecasedefinition": {
+      "directoryName": "aiUsecaseDefinitions",
+      "id": "aiusecasedefinition",
+      "inFolder": false,
+      "name": "AIUsecaseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "aiUsecaseDefinitions"
+    },
+    "analyticsnapshot": {
+      "directoryName": "analyticSnapshots",
+      "id": "analyticsnapshot",
+      "inFolder": false,
+      "name": "AnalyticSnapshot",
+      "strictDirectoryName": false,
+      "suffix": "snapshot"
+    },
+    "animationrule": {
+      "directoryName": "animationRules",
+      "id": "animationrule",
+      "inFolder": false,
+      "name": "AnimationRule",
+      "strictDirectoryName": false,
+      "suffix": "animationRule"
+    },
+    "apexclass": {
+      "directoryName": "classes",
+      "id": "apexclass",
+      "inFolder": false,
+      "name": "ApexClass",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "cls",
+      "supportsWildcardAndName": true
+    },
+    "apexcomponent": {
+      "directoryName": "components",
+      "id": "apexcomponent",
+      "inFolder": false,
+      "name": "ApexComponent",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "component"
+    },
+    "apexemailnotifications": {
+      "directoryName": "apexEmailNotifications",
+      "id": "apexemailnotifications",
+      "inFolder": false,
+      "name": "ApexEmailNotifications",
+      "strictDirectoryName": false,
+      "suffix": "notifications"
+    },
+    "apexpage": {
+      "directoryName": "pages",
+      "id": "apexpage",
+      "inFolder": false,
+      "name": "ApexPage",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "page",
+      "supportsWildcardAndName": true
+    },
+    "apextestsuite": {
+      "directoryName": "testSuites",
+      "id": "apextestsuite",
+      "inFolder": false,
+      "name": "ApexTestSuite",
+      "strictDirectoryName": false,
+      "suffix": "testSuite"
+    },
+    "apextrigger": {
+      "directoryName": "triggers",
+      "id": "apextrigger",
+      "inFolder": false,
+      "name": "ApexTrigger",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "trigger"
+    },
+    "applicationrecordtypeconfig": {
+      "directoryName": "ApplicationRecordTypeConfig",
+      "id": "applicationrecordtypeconfig",
+      "inFolder": false,
+      "name": "ApplicationRecordTypeConfig",
+      "suffix": "applicationRecordTypeConfig"
+    },
+    "applicationsubtypedefinition": {
+      "directoryName": "ApplicationSubtypeDefinitions",
+      "id": "applicationsubtypedefinition",
+      "inFolder": false,
+      "name": "ApplicationSubtypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "applicationSubtypeDefinition"
+    },
+    "appmenu": {
+      "directoryName": "appMenus",
+      "id": "appmenu",
+      "inFolder": false,
+      "name": "AppMenu",
+      "strictDirectoryName": false,
+      "suffix": "appMenu"
+    },
+    "appointmentassignmentpolicy": {
+      "directoryName": "appointmentAssignmentPolicies",
+      "id": "appointmentassignmentpolicy",
+      "inFolder": false,
+      "name": "AppointmentAssignmentPolicy",
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "appointmentschedulingpolicy": {
+      "directoryName": "appointmentSchedulingPolicies",
+      "id": "appointmentschedulingpolicy",
+      "inFolder": false,
+      "name": "AppointmentSchedulingPolicy",
+      "strictDirectoryName": true,
+      "suffix": "policy"
+    },
+    "approvalprocess": {
+      "directoryName": "approvalProcesses",
+      "id": "approvalprocess",
+      "inFolder": false,
+      "name": "ApprovalProcess",
+      "strictDirectoryName": false,
+      "suffix": "approvalProcess"
+    },
+    "assessmentconfiguration": {
+      "directoryName": "AssessmentConfigurations",
+      "id": "assessmentconfiguration",
+      "inFolder": false,
+      "name": "AssessmentConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "assessmentConfiguration"
+    },
+    "assessmentquestion": {
+      "directoryName": "AssessmentQuestions",
+      "id": "assessmentquestion",
+      "inFolder": false,
+      "name": "AssessmentQuestion",
+      "strictDirectoryName": false,
+      "suffix": "aq"
+    },
+    "assessmentquestionset": {
+      "directoryName": "AssessmentQuestionSets",
+      "id": "assessmentquestionset",
+      "inFolder": false,
+      "name": "AssessmentQuestionSet",
+      "strictDirectoryName": false,
+      "suffix": "aqs"
+    },
+    "assignmentrules": {
+      "children": {
+        "directories": {
+          "assignmentRules": "assignmentrule"
+        },
+        "suffixes": {
+          "assignmentRule": "assignmentrule"
+        },
+        "types": {
+          "assignmentrule": {
+            "directoryName": "assignmentRules",
+            "id": "assignmentrule",
+            "name": "AssignmentRule",
+            "suffix": "assignmentRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "assignmentRule"
+          }
+        }
+      },
+      "directoryName": "assignmentRules",
+      "id": "assignmentrules",
+      "inFolder": false,
+      "name": "AssignmentRules",
+      "strictDirectoryName": false,
+      "suffix": "assignmentRules"
+    },
+    "assistantcontextitem": {
+      "directoryName": "assistantContextItems",
+      "id": "assistantcontextitem",
+      "inFolder": false,
+      "name": "AssistantContextItem",
+      "suffix": "assistantContextItem"
+    },
+    "assistantdefinition": {
+      "directoryName": "assistantDefinitions",
+      "id": "assistantdefinition",
+      "inFolder": false,
+      "name": "AssistantDefinition",
+      "suffix": "assistantDefinition"
+    },
+    "assistantrecommendationtype": {
+      "directoryName": "assistantRecommendationTypes",
+      "id": "assistantrecommendationtype",
+      "inFolder": false,
+      "name": "AssistantRecommendationType",
+      "suffix": "assistantRecommendationType"
+    },
+    "assistantskillquickaction": {
+      "directoryName": "assistantSkillQuickActions",
+      "id": "assistantskillquickaction",
+      "inFolder": false,
+      "name": "AssistantSkillQuickAction",
+      "suffix": "assistantSkillQuickAction"
+    },
+    "assistantskillsobjectaction": {
+      "directoryName": "assistantSkillSobjectActions",
+      "id": "assistantskillsobjectaction",
+      "inFolder": false,
+      "name": "AssistantSkillSobjectAction",
+      "suffix": "assistantSkillSobjectAction"
+    },
+    "assistantversion": {
+      "directoryName": "assistantVersions",
+      "id": "assistantversion",
+      "inFolder": false,
+      "name": "AssistantVersion",
+      "suffix": "assistantVersion"
+    },
+    "audience": {
+      "directoryName": "audience",
+      "id": "audience",
+      "inFolder": false,
+      "name": "Audience",
+      "strictDirectoryName": false,
+      "suffix": "audience"
+    },
+    "auradefinitionbundle": {
+      "directoryName": "aura",
+      "id": "auradefinitionbundle",
+      "inFolder": false,
+      "name": "AuraDefinitionBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "authprovider": {
+      "directoryName": "authproviders",
+      "id": "authprovider",
+      "inFolder": false,
+      "name": "AuthProvider",
+      "strictDirectoryName": false,
+      "suffix": "authprovider"
+    },
+    "autoresponserules": {
+      "children": {
+        "directories": {
+          "autoResponseRules": "autoresponserule"
+        },
+        "suffixes": {
+          "autoResponseRule": "autoresponserule"
+        },
+        "types": {
+          "autoresponserule": {
+            "directoryName": "autoResponseRules",
+            "id": "autoresponserule",
+            "name": "AutoResponseRule",
+            "suffix": "autoResponseRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "autoResponseRule"
+          }
+        }
+      },
+      "directoryName": "autoResponseRules",
+      "id": "autoresponserules",
+      "inFolder": false,
+      "name": "AutoResponseRules",
+      "strictDirectoryName": false,
+      "suffix": "autoResponseRules"
+    },
+    "batchcalcjobdefinition": {
+      "directoryName": "batchCalcJobDefinitions",
+      "id": "batchcalcjobdefinition",
+      "inFolder": false,
+      "name": "BatchCalcJobDefinition",
+      "strictDirectoryName": false,
+      "suffix": "batchCalcJobDefinition"
+    },
+    "batchprocessjobdefinition": {
+      "directoryName": "batchProcessJobDefinitions",
+      "id": "batchprocessjobdefinition",
+      "name": "BatchProcessJobDefinition",
+      "strictDirectoryName": false,
+      "suffix": "batchProcessJobDefinition"
+    },
+    "benefitaction": {
+      "directoryName": "benefitActions",
+      "id": "benefitaction",
+      "name": "BenefitAction",
+      "strictDirectoryName": false,
+      "suffix": "benefitAction"
+    },
+    "blacklistedconsumer": {
+      "directoryName": "blacklistedConsumers",
+      "id": "blacklistedconsumer",
+      "inFolder": false,
+      "name": "BlacklistedConsumer",
+      "strictDirectoryName": false,
+      "suffix": "blacklistedConsumer"
+    },
+    "bldgenrgyintensitycnfg": {
+      "directoryName": "buildingEnergyIntensityConfigs",
+      "id": "bldgenrgyintensitycnfg",
+      "inFolder": false,
+      "name": "BldgEnrgyIntensityCnfg",
+      "strictDirectoryName": false,
+      "suffix": "buildingEnergyIntensityConfig"
+    },
+    "bot": {
+      "children": {
+        "directories": {
+          "botVersions": "botversion"
+        },
+        "suffixes": {
+          "botVersion": "botversion"
+        },
+        "types": {
+          "botversion": {
+            "directoryName": "botVersions",
+            "id": "botversion",
+            "name": "BotVersion",
+            "suffix": "botVersion"
+          }
+        }
+      },
+      "directoryName": "bots",
+      "id": "bot",
+      "inFolder": false,
+      "name": "Bot",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "topLevel",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "bot"
+    },
+    "botblock": {
+      "directoryName": "botBlocks",
+      "id": "botblock",
+      "inFolder": false,
+      "name": "BotBlock",
+      "strictDirectoryName": true,
+      "suffix": "botBlock"
+    },
+    "bottemplate": {
+      "directoryName": "botTemplates",
+      "id": "bottemplate",
+      "inFolder": false,
+      "name": "BotTemplate",
+      "strictDirectoryName": true,
+      "suffix": "botTemplate"
+    },
+    "brandingset": {
+      "directoryName": "brandingSets",
+      "id": "brandingset",
+      "inFolder": false,
+      "name": "BrandingSet",
+      "strictDirectoryName": false,
+      "suffix": "brandingSet"
+    },
+    "briefcasedefinition": {
+      "directoryName": "briefcaseDefinitions",
+      "id": "briefcasedefinition",
+      "name": "BriefcaseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "briefcaseDefinition"
+    },
+    "businessprocessfeedbackconfiguration": {
+      "directoryName": "businessProcessFeedbackConfigurations",
+      "id": "businessprocessfeedbackconfiguration",
+      "name": "BusinessProcessFeedbackConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessFeedbackConfiguration"
+    },
+    "businessprocessgroup": {
+      "directoryName": "businessProcessGroups",
+      "id": "businessprocessgroup",
+      "name": "BusinessProcessGroup",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessGroup"
+    },
+    "businessprocesstypedefinition": {
+      "directoryName": "BusinessProcessTypeDefinitions",
+      "id": "businessprocesstypedefinition",
+      "inFolder": false,
+      "name": "BusinessProcessTypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "businessProcessTypeDefinition"
+    },
+    "callcenter": {
+      "directoryName": "callCenters",
+      "id": "callcenter",
+      "inFolder": false,
+      "name": "CallCenter",
+      "strictDirectoryName": false,
+      "suffix": "callCenter",
+      "supportsWildcardAndName": true
+    },
+    "callcenterroutingmap": {
+      "directoryName": "callCenterRoutingMaps",
+      "id": "callcenterroutingmap",
+      "inFolder": false,
+      "name": "CallCenterRoutingMap",
+      "suffix": "callCenterRoutingMap"
+    },
+    "callcoachingmediaprovider": {
+      "directoryName": "callCoachingMediaProviders",
+      "id": "callcoachingmediaprovider",
+      "inFolder": false,
+      "name": "CallCoachingMediaProvider",
+      "strictDirectoryName": false,
+      "suffix": "callCoachingMediaProvider"
+    },
+    "callctragentfavtrfrdest": {
+      "directoryName": "callCtrAgentFavTrfrDests",
+      "id": "callctragentfavtrfrdest",
+      "inFolder": false,
+      "name": "CallCtrAgentFavTrfrDest",
+      "strictDirectoryName": false,
+      "suffix": "callCtrAgentFavTrfrDest"
+    },
+    "campaigninfluencemodel": {
+      "directoryName": "campaignInfluenceModels",
+      "id": "campaigninfluencemodel",
+      "inFolder": false,
+      "name": "CampaignInfluenceModel",
+      "suffix": "campaignInfluenceModel"
+    },
+    "canvasmetadata": {
+      "directoryName": "Canvases",
+      "id": "canvasmetadata",
+      "inFolder": false,
+      "name": "CanvasMetadata",
+      "strictDirectoryName": false,
+      "suffix": "Canvas"
+    },
+    "carebenefitverifysettings": {
+      "directoryName": "careBenefitVerifySettings",
+      "id": "carebenefitverifysettings",
+      "inFolder": false,
+      "name": "CareBenefitVerifySettings",
+      "suffix": "careBenefitVerifySettings"
+    },
+    "carelimittype": {
+      "directoryName": "careLimitTypes",
+      "id": "carelimittype",
+      "inFolder": false,
+      "name": "CareLimitType",
+      "strictDirectoryName": false,
+      "suffix": "careLimitType"
+    },
+    "careproviderafflroleconfig": {
+      "directoryName": "careProviderAfflRoleConfigs",
+      "id": "careproviderafflroleconfig",
+      "inFolder": false,
+      "name": "CareProviderAfflRoleConfig",
+      "strictDirectoryName": false,
+      "suffix": "careProviderAfflRoleConfig"
+    },
+    "careprovidersearchconfig": {
+      "directoryName": "careProviderSearchConfigs",
+      "id": "careprovidersearchconfig",
+      "name": "CareProviderSearchConfig",
+      "strictDirectoryName": false,
+      "suffix": "careProviderSearchConfig"
+    },
+    "carerequestconfiguration": {
+      "directoryName": "careRequestConfigurations",
+      "id": "carerequestconfiguration",
+      "inFolder": false,
+      "name": "CareRequestConfiguration",
+      "suffix": "careRequestConfiguration"
+    },
+    "caresystemfieldmapping": {
+      "directoryName": "careSystemFieldMappings",
+      "id": "caresystemfieldmapping",
+      "name": "CareSystemFieldMapping",
+      "strictDirectoryName": false,
+      "suffix": "careSystemFieldMapping"
+    },
+    "casesubjectparticle": {
+      "directoryName": "CaseSubjectParticles",
+      "id": "casesubjectparticle",
+      "inFolder": false,
+      "name": "CaseSubjectParticle",
+      "strictDirectoryName": false,
+      "suffix": "CaseSubjectParticle"
+    },
+    "certificate": {
+      "directoryName": "certs",
+      "id": "certificate",
+      "inFolder": false,
+      "name": "Certificate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "crt"
+    },
+    "channellayout": {
+      "directoryName": "channelLayouts",
+      "id": "channellayout",
+      "inFolder": false,
+      "name": "ChannelLayout",
+      "strictDirectoryName": false,
+      "suffix": "channelLayout"
+    },
+    "channelobjectlinkingrule": {
+      "directoryName": "ChannelObjectLinkingRules",
+      "id": "channelobjectlinkingrule",
+      "name": "ChannelObjectLinkingRule",
+      "strictDirectoryName": false,
+      "suffix": "ChannelObjectLinkingRule"
+    },
+    "chatterextension": {
+      "directoryName": "ChatterExtensions",
+      "id": "chatterextension",
+      "inFolder": false,
+      "name": "ChatterExtension",
+      "strictDirectoryName": false,
+      "suffix": "ChatterExtension"
+    },
+    "clausecatgconfiguration": {
+      "directoryName": "clauseCatgConfigurations",
+      "id": "clausecatgconfiguration",
+      "inFolder": false,
+      "name": "ClauseCatgConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "clauseCatgConfiguration"
+    },
+    "cleandataservice": {
+      "directoryName": "cleanDataServices",
+      "id": "cleandataservice",
+      "inFolder": false,
+      "name": "CleanDataService",
+      "strictDirectoryName": false,
+      "suffix": "cleanDataService"
+    },
+    "cmsconnectsource": {
+      "directoryName": "cmsConnectSource",
+      "id": "cmsconnectsource",
+      "inFolder": false,
+      "name": "CMSConnectSource",
+      "strictDirectoryName": false,
+      "suffix": "cmsConnectSource"
+    },
+    "commandaction": {
+      "directoryName": "commandActions",
+      "id": "commandaction",
+      "inFolder": false,
+      "name": "CommandAction",
+      "suffix": "commandaction"
+    },
+    "community": {
+      "directoryName": "communities",
+      "id": "community",
+      "inFolder": false,
+      "name": "Community",
+      "strictDirectoryName": false,
+      "suffix": "community"
+    },
+    "communitytemplatedefinition": {
+      "directoryName": "communityTemplateDefinitions",
+      "id": "communitytemplatedefinition",
+      "inFolder": false,
+      "name": "CommunityTemplateDefinition",
+      "strictDirectoryName": false,
+      "suffix": "communityTemplateDefinition"
+    },
+    "communitythemedefinition": {
+      "directoryName": "communityThemeDefinitions",
+      "id": "communitythemedefinition",
+      "inFolder": false,
+      "name": "CommunityThemeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "communityThemeDefinition"
+    },
+    "connectedapp": {
+      "directoryName": "connectedApps",
+      "id": "connectedapp",
+      "inFolder": false,
+      "name": "ConnectedApp",
+      "strictDirectoryName": false,
+      "suffix": "connectedApp"
+    },
+    "contentasset": {
+      "directoryName": "contentassets",
+      "id": "contentasset",
+      "inFolder": false,
+      "name": "ContentAsset",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "asset"
+    },
+    "contextdefinition": {
+      "directoryName": "contextDefinitions",
+      "id": "contextdefinition",
+      "inFolder": false,
+      "name": "ContextDefinition",
+      "strictDirectoryName": false,
+      "suffix": "contextDefinition"
+    },
+    "contextusecasemapping": {
+      "directoryName": "contextUseCaseMappings",
+      "id": "contextusecasemapping",
+      "inFolder": false,
+      "name": "ContextUseCaseMapping",
+      "strictDirectoryName": false,
+      "suffix": "contextUseCaseMapping"
+    },
+    "contracttype": {
+      "directoryName": "contractTypes",
+      "id": "contracttype",
+      "inFolder": false,
+      "name": "ContractType",
+      "strictDirectoryName": false,
+      "suffix": "contractType"
+    },
+    "conversationchanneldefinition": {
+      "directoryName": "conversationChannelDefinitions",
+      "id": "conversationchanneldefinition",
+      "inFolder": false,
+      "name": "ConversationChannelDefinition",
+      "strictDirectoryName": false,
+      "suffix": "ConversationChannelDefinition"
+    },
+    "conversationmessagedefinition": {
+      "directoryName": "conversationMessageDefinitions",
+      "id": "conversationmessagedefinition",
+      "inFolder": false,
+      "name": "ConversationMessageDefinition",
+      "strictDirectoryName": false,
+      "suffix": "conversationMessageDefinition"
+    },
+    "conversationvendorfielddef": {
+      "directoryName": "ConversationVendorFieldDefinitions",
+      "id": "conversationvendorfielddef",
+      "name": "ConversationVendorFieldDef",
+      "strictDirectoryName": false,
+      "suffix": "ConversationVendorFieldDefinition"
+    },
+    "conversationvendorinfo": {
+      "directoryName": "ConversationVendorInformation",
+      "id": "conversationvendorinfo",
+      "name": "ConversationVendorInfo",
+      "strictDirectoryName": false,
+      "suffix": "ConversationVendorInformation"
+    },
+    "corswhitelistorigin": {
+      "directoryName": "corsWhitelistOrigins",
+      "id": "corswhitelistorigin",
+      "inFolder": false,
+      "name": "CorsWhitelistOrigin",
+      "strictDirectoryName": false,
+      "suffix": "corsWhitelistOrigin"
+    },
+    "csptrustedsite": {
+      "directoryName": "cspTrustedSites",
+      "id": "csptrustedsite",
+      "inFolder": false,
+      "name": "CspTrustedSite",
+      "strictDirectoryName": false,
+      "suffix": "cspTrustedSite"
+    },
+    "customapplication": {
+      "directoryName": "applications",
+      "id": "customapplication",
+      "inFolder": false,
+      "name": "CustomApplication",
+      "strictDirectoryName": false,
+      "suffix": "app",
+      "supportsWildcardAndName": true
+    },
+    "customapplicationcomponent": {
+      "directoryName": "customApplicationComponents",
+      "id": "customapplicationcomponent",
+      "inFolder": false,
+      "name": "CustomApplicationComponent",
+      "suffix": "customApplicationComponent"
+    },
+    "customdatatype": {
+      "directoryName": "datatypes",
+      "id": "customdatatype",
+      "inFolder": false,
+      "name": "CustomDataType",
+      "suffix": "datatype"
+    },
+    "customexperience": {
+      "directoryName": "customExperiences",
+      "id": "customexperience",
+      "inFolder": false,
+      "name": "CustomExperience",
+      "suffix": "customExperience"
+    },
+    "customfeedfilter": {
+      "directoryName": "feedFilters",
+      "id": "customfeedfilter",
+      "inFolder": false,
+      "name": "CustomFeedFilter",
+      "suffix": "feedFilter"
+    },
+    "customhelpmenusection": {
+      "directoryName": "customHelpMenuSections",
+      "id": "customhelpmenusection",
+      "inFolder": false,
+      "name": "CustomHelpMenuSection",
+      "strictDirectoryName": false,
+      "suffix": "customHelpMenuSection"
+    },
+    "customindex": {
+      "directoryName": "customindex",
+      "id": "customindex",
+      "inFolder": false,
+      "name": "CustomIndex",
+      "strictDirectoryName": false,
+      "suffix": "indx"
+    },
+    "customlabels": {
+      "children": {
+        "directories": {
+          "labels": "customlabel"
+        },
+        "suffixes": {
+          "labels": "customlabel"
+        },
+        "types": {
+          "customlabel": {
+            "directoryName": "labels",
+            "id": "customlabel",
+            "ignoreParentName": true,
+            "name": "CustomLabel",
+            "suffix": "labels",
+            "supportsWildcardAndName": true,
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "labels"
+          }
+        }
+      },
+      "directoryName": "labels",
+      "id": "customlabels",
+      "ignoreParsedFullName": true,
+      "inFolder": false,
+      "name": "CustomLabels",
+      "strategies": {
+        "adapter": "default",
+        "recomposition": "startEmpty",
+        "transformer": "nonDecomposed"
+      },
+      "strictDirectoryName": false,
+      "suffix": "labels"
+    },
+    "custommetadata": {
+      "directoryName": "customMetadata",
+      "id": "custommetadata",
+      "inFolder": false,
+      "name": "CustomMetadata",
+      "strictDirectoryName": false,
+      "suffix": "md",
+      "supportsWildcardAndName": true
+    },
+    "customnotificationtype": {
+      "directoryName": "notificationtypes",
+      "id": "customnotificationtype",
+      "inFolder": false,
+      "name": "CustomNotificationType",
+      "strictDirectoryName": false,
+      "suffix": "notiftype"
+    },
+    "customobject": {
+      "children": {
+        "directories": {
+          "businessProcesses": "businessprocess",
+          "compactLayouts": "compactlayout",
+          "fieldSets": "fieldset",
+          "fields": "customfield",
+          "indexes": "index",
+          "listViews": "listview",
+          "recordTypes": "recordtype",
+          "sharingReasons": "sharingreason",
+          "validationRules": "validationrule",
+          "webLinks": "weblink"
+        },
+        "suffixes": {
+          "businessProcess": "businessprocess",
+          "compactLayout": "compactlayout",
+          "field": "customfield",
+          "fieldSet": "fieldset",
+          "index": "index",
+          "indexe": "index",
+          "listView": "listview",
+          "recordType": "recordtype",
+          "sharingReason": "sharingreason",
+          "validationRule": "validationrule",
+          "webLink": "weblink"
+        },
+        "types": {
+          "businessprocess": {
+            "directoryName": "businessProcesses",
+            "id": "businessprocess",
+            "name": "BusinessProcess",
+            "suffix": "businessProcess"
+          },
+          "compactlayout": {
+            "directoryName": "compactLayouts",
+            "id": "compactlayout",
+            "name": "CompactLayout",
+            "suffix": "compactLayout"
+          },
+          "customfield": {
+            "directoryName": "fields",
+            "id": "customfield",
+            "name": "CustomField",
+            "suffix": "field"
+          },
+          "fieldset": {
+            "directoryName": "fieldSets",
+            "id": "fieldset",
+            "name": "FieldSet",
+            "suffix": "fieldSet"
+          },
+          "index": {
+            "directoryName": "indexes",
+            "id": "index",
+            "legacySuffix": "indexe",
+            "name": "Index",
+            "suffix": "index"
+          },
+          "listview": {
+            "directoryName": "listViews",
+            "id": "listview",
+            "name": "ListView",
+            "suffix": "listView"
+          },
+          "recordtype": {
+            "directoryName": "recordTypes",
+            "id": "recordtype",
+            "name": "RecordType",
+            "suffix": "recordType"
+          },
+          "sharingreason": {
+            "directoryName": "sharingReasons",
+            "id": "sharingreason",
+            "name": "SharingReason",
+            "suffix": "sharingReason"
+          },
+          "validationrule": {
+            "directoryName": "validationRules",
+            "id": "validationrule",
+            "name": "ValidationRule",
+            "suffix": "validationRule"
+          },
+          "weblink": {
+            "directoryName": "webLinks",
+            "id": "weblink",
+            "name": "WebLink",
+            "suffix": "webLink"
+          }
+        }
+      },
+      "directoryName": "objects",
+      "id": "customobject",
+      "inFolder": false,
+      "name": "CustomObject",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "folderPerType",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "object",
+      "supportsWildcardAndName": true
+    },
+    "customobjecttranslation": {
+      "children": {
+        "directories": {
+          "fields": "customfieldtranslation"
+        },
+        "suffixes": {
+          "fieldTranslation": "customfieldtranslation"
+        },
+        "types": {
+          "customfieldtranslation": {
+            "directoryName": "fields",
+            "id": "customfieldtranslation",
+            "isAddressable": false,
+            "name": "CustomFieldTranslation",
+            "suffix": "fieldTranslation",
+            "unaddressableWithoutParent": true,
+            "uniqueIdElement": "name"
+          }
+        }
+      },
+      "directoryName": "objectTranslations",
+      "id": "customobjecttranslation",
+      "inFolder": false,
+      "name": "CustomObjectTranslation",
+      "strategies": {
+        "adapter": "decomposed",
+        "decomposition": "topLevel",
+        "transformer": "decomposed"
+      },
+      "strictDirectoryName": true,
+      "suffix": "objectTranslation",
+      "supportsWildcardAndName": true
+    },
+    "custompageweblink": {
+      "directoryName": "weblinks",
+      "id": "custompageweblink",
+      "inFolder": false,
+      "legacySuffix": "custompageweblink",
+      "name": "CustomPageWebLink",
+      "strictDirectoryName": false,
+      "suffix": "weblink"
+    },
+    "custompermission": {
+      "directoryName": "customPermissions",
+      "id": "custompermission",
+      "inFolder": false,
+      "name": "CustomPermission",
+      "strictDirectoryName": false,
+      "suffix": "customPermission"
+    },
+    "customsite": {
+      "directoryName": "sites",
+      "id": "customsite",
+      "inFolder": false,
+      "name": "CustomSite",
+      "strictDirectoryName": true,
+      "suffix": "site"
+    },
+    "customtab": {
+      "directoryName": "tabs",
+      "id": "customtab",
+      "inFolder": false,
+      "name": "CustomTab",
+      "strictDirectoryName": false,
+      "suffix": "tab",
+      "supportsWildcardAndName": true
+    },
+    "dashboard": {
+      "directoryName": "dashboards",
+      "folderType": "dashboardfolder",
+      "id": "dashboard",
+      "inFolder": true,
+      "name": "Dashboard",
+      "strictDirectoryName": false,
+      "suffix": "dashboard"
+    },
+    "dashboardfolder": {
+      "directoryName": "dashboards",
+      "folderContentType": "dashboard",
+      "id": "dashboardfolder",
+      "inFolder": false,
+      "name": "DashboardFolder",
+      "strictDirectoryName": false,
+      "suffix": "dashboardFolder"
+    },
+    "datacalcinsighttemplate": {
+      "directoryName": "dataCalcInsightTemplates",
+      "id": "datacalcinsighttemplate",
+      "name": "DataCalcInsightTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataCalcInsightTemplate"
+    },
+    "datacategorygroup": {
+      "directoryName": "datacategorygroups",
+      "id": "datacategorygroup",
+      "inFolder": false,
+      "name": "DataCategoryGroup",
+      "strictDirectoryName": false,
+      "suffix": "datacategorygroup"
+    },
+    "dataconnector": {
+      "directoryName": "dataconnectors",
+      "id": "dataconnector",
+      "inFolder": false,
+      "name": "DataConnector",
+      "strictDirectoryName": false,
+      "suffix": "dataconnector"
+    },
+    "dataconnectoringestapi": {
+      "directoryName": "dataConnectorIngestApis",
+      "id": "dataconnectoringestapi",
+      "inFolder": false,
+      "name": "DataConnectorIngestApi",
+      "strictDirectoryName": false,
+      "suffix": "dataConnectorIngestApi"
+    },
+    "dataconnectors3": {
+      "directoryName": "s3DataConnectors",
+      "id": "dataconnectors3",
+      "name": "DataConnectorS3",
+      "strictDirectoryName": false,
+      "suffix": "s3DataConnector"
+    },
+    "datakitobjectdependency": {
+      "directoryName": "dataKitObjectDependencies",
+      "id": "datakitobjectdependency",
+      "inFolder": false,
+      "name": "DataKitObjectDependency",
+      "suffix": "dataKitObjectDependency"
+    },
+    "datakitobjecttemplate": {
+      "directoryName": "dataKitObjectTemplates",
+      "id": "datakitobjecttemplate",
+      "name": "DataKitObjectTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataKitObjectTemplate"
+    },
+    "dataobjectbuildorgtemplate": {
+      "directoryName": "dataObjectBuildOrgTemplates",
+      "id": "dataobjectbuildorgtemplate",
+      "name": "DataObjectBuildOrgTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataObjectBuildOrgTemplate"
+    },
+    "datapackagekitdefinition": {
+      "directoryName": "dataPackageKitDefinitions",
+      "id": "datapackagekitdefinition",
+      "name": "DataPackageKitDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataPackageKitDefinition"
+    },
+    "datapackagekitobject": {
+      "directoryName": "DataPackageKitObjects",
+      "id": "datapackagekitobject",
+      "name": "DataPackageKitObject",
+      "strictDirectoryName": false,
+      "suffix": "DataPackageKitObject"
+    },
+    "datapipeline": {
+      "directoryName": "dataPipelines",
+      "id": "datapipeline",
+      "inFolder": false,
+      "name": "DataPipeline",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "dataPipeline"
+    },
+    "datasource": {
+      "directoryName": "mktDataSources",
+      "id": "datasource",
+      "name": "DataSource",
+      "strictDirectoryName": true,
+      "suffix": "dataSource"
+    },
+    "datasourcebundledefinition": {
+      "directoryName": "dataSourceBundleDefinitions",
+      "id": "datasourcebundledefinition",
+      "name": "DataSourceBundleDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceBundleDefinition"
+    },
+    "datasourceobject": {
+      "directoryName": "dataSourceObjects",
+      "id": "datasourceobject",
+      "name": "DataSourceObject",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceObject"
+    },
+    "datasourcetenant": {
+      "directoryName": "dataSourceTenants",
+      "id": "datasourcetenant",
+      "inFolder": false,
+      "name": "DataSourceTenant",
+      "strictDirectoryName": false,
+      "suffix": "dataSourceTenant"
+    },
+    "datasrcdatamodelfieldmap": {
+      "directoryName": "dataSrcDataModelFieldMaps",
+      "id": "datasrcdatamodelfieldmap",
+      "name": "DataSrcDataModelFieldMap",
+      "strictDirectoryName": false,
+      "suffix": "dataSrcDataModelFieldMap"
+    },
+    "datastreamdefinition": {
+      "directoryName": "dataStreamDefinitions",
+      "id": "datastreamdefinition",
+      "name": "DataStreamDefinition",
+      "strictDirectoryName": false,
+      "suffix": "dataStreamDefinition"
+    },
+    "datastreamtemplate": {
+      "directoryName": "dataStreamTemplates",
+      "id": "datastreamtemplate",
+      "name": "DataStreamTemplate",
+      "strictDirectoryName": false,
+      "suffix": "dataStreamTemplate"
+    },
+    "dataweaveresource": {
+      "directoryName": "dw",
+      "id": "dataweaveresource",
+      "inFolder": false,
+      "name": "DataWeaveResource",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "dwl"
+    },
+    "decisionmatrixdefinition": {
+      "directoryName": "decisionMatrixDefinition",
+      "id": "decisionmatrixdefinition",
+      "inFolder": false,
+      "name": "DecisionMatrixDefinition",
+      "strictDirectoryName": false,
+      "suffix": "decisionMatrixDefinition"
+    },
+    "decisionmatrixdefinitionversion": {
+      "directoryName": "decisionMatrixVersion",
+      "id": "decisionmatrixdefinitionversion",
+      "inFolder": false,
+      "name": "DecisionMatrixDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "decisionMatrixVersion"
+    },
+    "decisiontable": {
+      "directoryName": "decisionTables",
+      "id": "decisiontable",
+      "name": "DecisionTable",
+      "strictDirectoryName": false,
+      "suffix": "decisionTable"
+    },
+    "decisiontabledatasetlink": {
+      "directoryName": "decisionTableDatasetLinks",
+      "id": "decisiontabledatasetlink",
+      "name": "DecisionTableDatasetLink",
+      "strictDirectoryName": false,
+      "suffix": "decisionTableDatasetLink"
+    },
+    "delegategroup": {
+      "directoryName": "delegateGroups",
+      "id": "delegategroup",
+      "inFolder": false,
+      "name": "DelegateGroup",
+      "strictDirectoryName": false,
+      "suffix": "delegateGroup"
+    },
+    "digitalexperiencebundle": {
+      "children": {
+        "directories": {
+          "digitalExperiences": "digitalexperience"
+        },
+        "suffixes": {
+          "digitalExperience": "digitalexperience"
+        },
+        "types": {
+          "digitalexperience": {
+            "directoryName": "digitalExperiences",
+            "id": "digitalexperience",
+            "metaFileSuffix": "_meta.json",
+            "name": "DigitalExperience",
+            "strategies": {
+              "adapter": "digitalExperience"
+            },
+            "suffix": "digitalExperience",
+            "supportsPartialDelete": true
+          }
+        }
+      },
+      "directoryName": "digitalExperiences",
+      "id": "digitalexperiencebundle",
+      "inFolder": false,
+      "name": "DigitalExperienceBundle",
+      "strategies": {
+        "adapter": "digitalExperience"
+      },
+      "suffix": "digitalExperience",
+      "supportsPartialDelete": true,
+      "supportsWildcardAndName": true
+    },
+    "digitalexperienceconfig": {
+      "directoryName": "digitalExperienceConfigs",
+      "id": "digitalexperienceconfig",
+      "inFolder": false,
+      "name": "DigitalExperienceConfig",
+      "strictDirectoryName": false,
+      "suffix": "digitalExperienceConfig"
+    },
+    "disclosuredefinition": {
+      "directoryName": "disclosureDefinitions",
+      "id": "disclosuredefinition",
+      "inFolder": false,
+      "name": "DisclosureDefinition",
+      "strictDirectoryName": false,
+      "suffix": "disclosureDefinition"
+    },
+    "disclosuredefinitionversion": {
+      "directoryName": "disclosureDefinitionVersions",
+      "id": "disclosuredefinitionversion",
+      "inFolder": false,
+      "name": "DisclosureDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "disclosureDefinitionVersion"
+    },
+    "disclosuretype": {
+      "directoryName": "disclosureTypes",
+      "id": "disclosuretype",
+      "inFolder": false,
+      "name": "DisclosureType",
+      "strictDirectoryName": false,
+      "suffix": "disclosureType"
+    },
+    "discoveryaimodel": {
+      "directoryName": "discovery",
+      "id": "discoveryaimodel",
+      "name": "DiscoveryAIModel",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "model"
+    },
+    "discoverygoal": {
+      "directoryName": "discovery",
+      "id": "discoverygoal",
+      "name": "DiscoveryGoal",
+      "strictDirectoryName": false,
+      "suffix": "goal"
+    },
+    "discoverystory": {
+      "directoryName": "discovery",
+      "id": "discoverystory",
+      "inFolder": false,
+      "name": "DiscoveryStory",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "story"
+    },
+    "document": {
+      "directoryName": "documents",
+      "folderType": "documentfolder",
+      "id": "document",
+      "inFolder": true,
+      "name": "Document",
+      "strategies": {
+        "adapter": "mixedContent"
+      },
+      "strictDirectoryName": true,
+      "suffix": "document"
+    },
+    "documentcategory": {
+      "directoryName": "documentCategory",
+      "id": "documentcategory",
+      "inFolder": false,
+      "name": "DocumentCategory",
+      "strictDirectoryName": false,
+      "suffix": "documentCategory"
+    },
+    "documentcategorydocumenttype": {
+      "directoryName": "documentCategoryDocumentTypes",
+      "id": "documentcategorydocumenttype",
+      "inFolder": false,
+      "name": "DocumentCategoryDocumentType",
+      "strictDirectoryName": false,
+      "suffix": "documentCategoryDocumentType"
+    },
+    "documentfolder": {
+      "directoryName": "documents",
+      "folderContentType": "document",
+      "id": "documentfolder",
+      "inFolder": false,
+      "name": "DocumentFolder",
+      "strictDirectoryName": false,
+      "suffix": "documentFolder"
+    },
+    "documentgenerationsetting": {
+      "directoryName": "documentGenerationSettings",
+      "id": "documentgenerationsetting",
+      "inFolder": false,
+      "name": "DocumentGenerationSetting",
+      "suffix": "documentGenerationSetting"
+    },
+    "documenttemplate": {
+      "directoryName": "documentTemplates",
+      "id": "documenttemplate",
+      "inFolder": false,
+      "name": "DocumentTemplate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "dt"
+    },
+    "documenttype": {
+      "directoryName": "documentTypes",
+      "id": "documenttype",
+      "name": "DocumentType",
+      "strictDirectoryName": false,
+      "suffix": "documentType"
+    },
+    "duplicaterule": {
+      "directoryName": "duplicateRules",
+      "id": "duplicaterule",
+      "inFolder": false,
+      "name": "DuplicateRule",
+      "strictDirectoryName": false,
+      "suffix": "duplicateRule"
+    },
+    "dynamictrigger": {
+      "directoryName": "dynamicTriggers",
+      "id": "dynamictrigger",
+      "name": "DynamicTrigger",
+      "strictDirectoryName": false,
+      "suffix": "dynamicTrigger"
+    },
+    "eclairgeodata": {
+      "directoryName": "eclair",
+      "id": "eclairgeodata",
+      "inFolder": false,
+      "name": "EclairGeoData",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "geodata"
+    },
+    "emailfolder": {
+      "directoryName": "email",
+      "folderContentType": "emailtemplate",
+      "id": "emailfolder",
+      "inFolder": false,
+      "name": "EmailFolder",
+      "strictDirectoryName": false,
+      "suffix": "emailFolder"
+    },
+    "emailservicesfunction": {
+      "directoryName": "emailservices",
+      "id": "emailservicesfunction",
+      "inFolder": false,
+      "name": "EmailServicesFunction",
+      "strictDirectoryName": true,
+      "suffix": "xml"
+    },
+    "emailtemplate": {
+      "directoryName": "email",
+      "folderType": "emailfolder",
+      "id": "emailtemplate",
+      "inFolder": true,
+      "name": "EmailTemplate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "email"
+    },
+    "emailtemplatefolder": {
+      "aliasFor": "emailfolder",
+      "directoryName": "email",
+      "folderContentType": "emailtemplate",
+      "id": "emailtemplatefolder",
+      "inFolder": false,
+      "name": "EmailTemplateFolder",
+      "strictDirectoryName": false,
+      "suffix": "emailTemplateFolder"
+    },
+    "embeddedservicebranding": {
+      "directoryName": "EmbeddedServiceBranding",
+      "id": "embeddedservicebranding",
+      "inFolder": false,
+      "name": "EmbeddedServiceBranding",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceBranding"
+    },
+    "embeddedserviceconfig": {
+      "directoryName": "EmbeddedServiceConfig",
+      "id": "embeddedserviceconfig",
+      "inFolder": false,
+      "name": "EmbeddedServiceConfig",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceConfig"
+    },
+    "embeddedservicefieldservice": {
+      "directoryName": "EmbeddedServiceFieldService",
+      "id": "embeddedservicefieldservice",
+      "inFolder": false,
+      "name": "EmbeddedServiceFieldService",
+      "suffix": "EmbeddedServiceFieldService"
+    },
+    "embeddedserviceflowconfig": {
+      "directoryName": "EmbeddedServiceFlowConfig",
+      "id": "embeddedserviceflowconfig",
+      "inFolder": false,
+      "name": "EmbeddedServiceFlowConfig",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceFlowConfig"
+    },
+    "embeddedserviceliveagent": {
+      "directoryName": "EmbeddedServiceLiveAgent",
+      "id": "embeddedserviceliveagent",
+      "inFolder": false,
+      "name": "EmbeddedServiceLiveAgent",
+      "suffix": "EmbeddedServiceLiveAgent"
+    },
+    "embeddedservicemenusettings": {
+      "directoryName": "EmbeddedServiceMenuSettings",
+      "id": "embeddedservicemenusettings",
+      "inFolder": false,
+      "name": "EmbeddedServiceMenuSettings",
+      "strictDirectoryName": false,
+      "suffix": "EmbeddedServiceMenuSettings"
+    },
+    "employeedatasyncprofile": {
+      "directoryName": "employeeDataSyncProfiles",
+      "id": "employeedatasyncprofile",
+      "inFolder": false,
+      "name": "EmployeeDataSyncProfile",
+      "strictDirectoryName": false,
+      "suffix": "employeeDataSyncProfile"
+    },
+    "enablementmeasuredefinition": {
+      "directoryName": "enablementMeasureDefinitions",
+      "id": "enablementmeasuredefinition",
+      "inFolder": false,
+      "name": "EnablementMeasureDefinition",
+      "strictDirectoryName": false,
+      "suffix": "enablementMeasureDefinition"
+    },
+    "enablementprogramdefinition": {
+      "directoryName": "enablementProgramDefinitions",
+      "id": "enablementprogramdefinition",
+      "inFolder": false,
+      "name": "EnablementProgramDefinition",
+      "strictDirectoryName": false,
+      "suffix": "enablementProgramDefinition"
+    },
+    "enblprogramtasksubcategory": {
+      "directoryName": "enblProgramTaskSubCategories",
+      "id": "enblprogramtasksubcategory",
+      "inFolder": false,
+      "name": "EnblProgramTaskSubCategory",
+      "strictDirectoryName": false,
+      "suffix": "enblProgramTaskSubCategory"
+    },
+    "entitlementprocess": {
+      "directoryName": "entitlementProcesses",
+      "id": "entitlementprocess",
+      "inFolder": false,
+      "name": "EntitlementProcess",
+      "suffix": "entitlementProcess"
+    },
+    "entitlementtemplate": {
+      "directoryName": "entitlementTemplates",
+      "id": "entitlementtemplate",
+      "inFolder": false,
+      "name": "EntitlementTemplate",
+      "suffix": "entitlementTemplate"
+    },
+    "entityimplements": {
+      "directoryName": "entityImplements",
+      "id": "entityimplements",
+      "inFolder": false,
+      "name": "EntityImplements",
+      "strictDirectoryName": false,
+      "suffix": "entityImplements"
+    },
+    "escalationrules": {
+      "children": {
+        "directories": {
+          "escalationRules": "escalationrule"
+        },
+        "suffixes": {
+          "escalationRule": "escalationrule"
+        },
+        "types": {
+          "escalationrule": {
+            "directoryName": "escalationRules",
+            "id": "escalationrule",
+            "name": "EscalationRule",
+            "suffix": "escalationRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "escalationRule"
+          }
+        }
+      },
+      "directoryName": "escalationRules",
+      "id": "escalationrules",
+      "inFolder": false,
+      "name": "EscalationRules",
+      "strictDirectoryName": false,
+      "suffix": "escalationRules"
+    },
+    "esignatureconfig": {
+      "directoryName": "eSignatureConfigs",
+      "id": "esignatureconfig",
+      "inFolder": false,
+      "name": "ESignatureConfig",
+      "strictDirectoryName": false,
+      "suffix": "eSignatureConfig"
+    },
+    "esignatureenvelopeconfig": {
+      "directoryName": "eSignatureEnvelopeConfigs",
+      "id": "esignatureenvelopeconfig",
+      "inFolder": false,
+      "name": "ESignatureEnvelopeConfig",
+      "strictDirectoryName": false,
+      "suffix": "eSignatureEnvelopeConfig"
+    },
+    "eventdelivery": {
+      "directoryName": "eventDeliveries",
+      "id": "eventdelivery",
+      "inFolder": false,
+      "name": "EventDelivery",
+      "suffix": "delivery"
+    },
+    "eventrelayconfig": {
+      "directoryName": "eventRelays",
+      "id": "eventrelayconfig",
+      "inFolder": false,
+      "name": "EventRelayConfig",
+      "strictDirectoryName": false,
+      "suffix": "eventRelay"
+    },
+    "eventsubscription": {
+      "directoryName": "eventSubscriptions",
+      "id": "eventsubscription",
+      "inFolder": false,
+      "name": "EventSubscription",
+      "suffix": "subscription"
+    },
+    "eventtype": {
+      "directoryName": "eventTypes",
+      "id": "eventtype",
+      "inFolder": false,
+      "name": "EventType",
+      "suffix": "eventType"
+    },
+    "experiencebundle": {
+      "directoryName": "experiences",
+      "id": "experiencebundle",
+      "inFolder": false,
+      "name": "ExperienceBundle",
+      "strategies": {
+        "adapter": "mixedContent"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "experiencepropertytypebundle": {
+      "directoryName": "experiencePropertyTypeBundles",
+      "id": "experiencepropertytypebundle",
+      "inFolder": false,
+      "metaFileSuffix": "schema.json",
+      "name": "ExperiencePropertyTypeBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "explainabilityactiondefinition": {
+      "directoryName": "ExplainabilityActionDefinitions",
+      "id": "explainabilityactiondefinition",
+      "inFolder": false,
+      "name": "ExplainabilityActionDefinition",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityActionDefinition"
+    },
+    "explainabilityactionversion": {
+      "directoryName": "ExplainabilityActionVersions",
+      "id": "explainabilityactionversion",
+      "inFolder": false,
+      "name": "ExplainabilityActionVersion",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityActionVersion"
+    },
+    "explainabilitymsgtemplate": {
+      "directoryName": "ExplainabilityMsgTemplates",
+      "id": "explainabilitymsgtemplate",
+      "inFolder": false,
+      "name": "ExplainabilityMsgTemplate",
+      "strictDirectoryName": false,
+      "suffix": "explainabilityMsgTemplate"
+    },
+    "expressionsetdefinition": {
+      "directoryName": "expressionSetDefinition",
+      "id": "expressionsetdefinition",
+      "inFolder": false,
+      "name": "ExpressionSetDefinition",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetDefinition"
+    },
+    "expressionsetdefinitionversion": {
+      "directoryName": "expressionSetVersion",
+      "id": "expressionsetdefinitionversion",
+      "inFolder": false,
+      "name": "ExpressionSetDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetVersion"
+    },
+    "expressionsetmessagetoken": {
+      "directoryName": "expressionSetMessageToken",
+      "id": "expressionsetmessagetoken",
+      "inFolder": false,
+      "name": "ExpressionSetMessageToken",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetMessageToken"
+    },
+    "expressionsetobjectalias": {
+      "directoryName": "expressionSetObjectAlias",
+      "id": "expressionsetobjectalias",
+      "name": "ExpressionSetObjectAlias",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetObjectAlias"
+    },
+    "extdatatranobjecttemplate": {
+      "children": {
+        "directories": {
+          "extDataTranFieldTemplates": "extdatatranfieldtemplate"
+        },
+        "suffixes": {
+          "extDataTranFieldTemplate": "extdatatranfieldtemplate"
+        },
+        "types": {
+          "extdatatranfieldtemplate": {
+            "directoryName": "extDataTranFieldTemplates",
+            "id": "extdatatranfieldtemplate",
+            "name": "extDataTranFieldTemplate",
+            "suffix": "extDataTranFieldTemplate"
+          }
+        }
+      },
+      "directoryName": "extDataTranObjectTemplates",
+      "id": "extdatatranobjecttemplate",
+      "name": "ExtDataTranObjectTemplate",
+      "strictDirectoryName": false,
+      "suffix": "extDataTranObjectTemplate"
+    },
+    "externalaimodel": {
+      "directoryName": "externalAIModels",
+      "id": "externalaimodel",
+      "inFolder": false,
+      "name": "ExternalAIModel",
+      "strictDirectoryName": false,
+      "suffix": "externalAIModel"
+    },
+    "externalauthidentityprovider": {
+      "directoryName": "externalAuthIdentityProviders",
+      "id": "externalauthidentityprovider",
+      "inFolder": false,
+      "name": "ExternalAuthIdentityProvider",
+      "strictDirectoryName": false,
+      "suffix": "externalAuthIdentityProvider"
+    },
+    "externalclientapplication": {
+      "directoryName": "externalClientApps",
+      "id": "externalclientapplication",
+      "inFolder": false,
+      "name": "ExternalClientApplication",
+      "strictDirectoryName": false,
+      "suffix": "eca"
+    },
+    "externalcredential": {
+      "directoryName": "externalCredentials",
+      "id": "externalcredential",
+      "inFolder": false,
+      "name": "ExternalCredential",
+      "strictDirectoryName": false,
+      "suffix": "externalCredential"
+    },
+    "externaldataconnector": {
+      "directoryName": "externalDataConnectors",
+      "id": "externaldataconnector",
+      "name": "ExternalDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "externalDataConnector"
+    },
+    "externaldatasource": {
+      "directoryName": "dataSources",
+      "id": "externaldatasource",
+      "inFolder": false,
+      "name": "ExternalDataSource",
+      "strictDirectoryName": false,
+      "suffix": "dataSource"
+    },
+    "externaldatatranobject": {
+      "directoryName": "externalDataTranObjects",
+      "id": "externaldatatranobject",
+      "inFolder": false,
+      "name": "ExternalDataTranObject",
+      "strictDirectoryName": false,
+      "suffix": "externalDataTranObject"
+    },
+    "externaldocstorageconfig": {
+      "directoryName": "externalDocStorageConfigs",
+      "id": "externaldocstorageconfig",
+      "inFolder": false,
+      "name": "ExternalDocStorageConfig",
+      "strictDirectoryName": false,
+      "suffix": "externalDocStorageConfig"
+    },
+    "externalserviceregistration": {
+      "directoryName": "externalServiceRegistrations",
+      "id": "externalserviceregistration",
+      "inFolder": false,
+      "name": "ExternalServiceRegistration",
+      "strictDirectoryName": false,
+      "suffix": "externalServiceRegistration"
+    },
+    "extlclntappconfigurablepolicies": {
+      "directoryName": "extlClntAppPolicies",
+      "id": "extlclntappconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaPlcy"
+    },
+    "extlclntappglobaloauthsettings": {
+      "directoryName": "extlClntAppGlobalOauthSets",
+      "id": "extlclntappglobaloauthsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppGlobalOauthSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaGlblOauth"
+    },
+    "extlclntappmobileconfigurablepolicies": {
+      "directoryName": "extlClntAppMobilePolicies",
+      "id": "extlclntappmobileconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppMobileConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaMobilePlcy"
+    },
+    "extlclntappmobilesettings": {
+      "directoryName": "extlClntAppMobileSettings",
+      "id": "extlclntappmobilesettings",
+      "inFolder": false,
+      "name": "ExtlClntAppMobileSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaMobile"
+    },
+    "extlclntappnotificationsettings": {
+      "directoryName": "extlClntAppNotifSettings",
+      "id": "extlclntappnotificationsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppNotificationSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaNotifications"
+    },
+    "extlclntappoauthconfigurablepolicies": {
+      "directoryName": "extlClntAppOauthPolicies",
+      "id": "extlclntappoauthconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppOauthConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaOauthPlcy"
+    },
+    "extlclntappoauthsettings": {
+      "directoryName": "extlClntAppOauthSettings",
+      "id": "extlclntappoauthsettings",
+      "inFolder": false,
+      "name": "ExtlClntAppOauthSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaOauth"
+    },
+    "extlclntappsamlconfigurablepolicies": {
+      "directoryName": "extlClntAppSamlConfigurablePolicies",
+      "id": "extlclntappsamlconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppSamlConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaSamlPlcy"
+    },
+    "extlclntappsampleconfigurablepolicies": {
+      "directoryName": "extlClntAppSamplePolicies",
+      "id": "extlclntappsampleconfigurablepolicies",
+      "inFolder": false,
+      "name": "ExtlClntAppSampleConfigurablePolicies",
+      "strictDirectoryName": false,
+      "suffix": "ecaSmplPlcy"
+    },
+    "extlclntappsamplesettings": {
+      "directoryName": "extlClntAppSampleSettings",
+      "id": "extlclntappsamplesettings",
+      "inFolder": false,
+      "name": "ExtlClntAppSampleSettings",
+      "strictDirectoryName": false,
+      "suffix": "ecaSmpl"
+    },
+    "featureparameterboolean": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterboolean",
+      "inFolder": false,
+      "name": "FeatureParameterBoolean",
+      "suffix": "featureParameterBoolean"
+    },
+    "featureparameterdate": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterdate",
+      "inFolder": false,
+      "name": "FeatureParameterDate",
+      "suffix": "featureParameterDate"
+    },
+    "featureparameterinteger": {
+      "directoryName": "featureParameters",
+      "id": "featureparameterinteger",
+      "inFolder": false,
+      "name": "FeatureParameterInteger",
+      "suffix": "featureParameterInteger"
+    },
+    "fieldrestrictionrule": {
+      "directoryName": "fieldRestrictionRules",
+      "id": "fieldrestrictionrule",
+      "inFolder": false,
+      "name": "FieldRestrictionRule",
+      "strictDirectoryName": true,
+      "suffix": "rule"
+    },
+    "fieldservicemobileextension": {
+      "directoryName": "fieldServiceMobileExtensions",
+      "id": "fieldservicemobileextension",
+      "name": "FieldServiceMobileExtension",
+      "strictDirectoryName": false,
+      "suffix": "fieldServiceMobileExtension"
+    },
+    "fieldsrctrgtrelationship": {
+      "directoryName": "fieldSrcTrgtRelationships",
+      "id": "fieldsrctrgtrelationship",
+      "name": "FieldSrcTrgtRelationship",
+      "strictDirectoryName": false,
+      "suffix": "fieldSrcTrgtRelationship"
+    },
+    "flexipage": {
+      "directoryName": "flexipages",
+      "id": "flexipage",
+      "inFolder": false,
+      "name": "FlexiPage",
+      "strictDirectoryName": false,
+      "suffix": "flexipage"
+    },
+    "flow": {
+      "directoryName": "flows",
+      "id": "flow",
+      "inFolder": false,
+      "name": "Flow",
+      "strictDirectoryName": false,
+      "suffix": "flow",
+      "supportsWildcardAndName": true
+    },
+    "flowcategory": {
+      "directoryName": "flowCategories",
+      "id": "flowcategory",
+      "inFolder": false,
+      "name": "FlowCategory",
+      "strictDirectoryName": false,
+      "suffix": "flowCategory"
+    },
+    "flowdefinition": {
+      "directoryName": "flowDefinitions",
+      "id": "flowdefinition",
+      "inFolder": false,
+      "name": "FlowDefinition",
+      "strictDirectoryName": false,
+      "suffix": "flowDefinition",
+      "supportsWildcardAndName": true
+    },
+    "flowtest": {
+      "directoryName": "flowtests",
+      "id": "flowtest",
+      "inFolder": false,
+      "name": "FlowTest",
+      "strictDirectoryName": false,
+      "suffix": "flowtest"
+    },
+    "forecastingfilter": {
+      "directoryName": "forecastingFilters",
+      "id": "forecastingfilter",
+      "inFolder": false,
+      "name": "ForecastingFilter",
+      "strictDirectoryName": false,
+      "suffix": "forecastingFilter"
+    },
+    "forecastingfiltercondition": {
+      "directoryName": "forecastingFilterConditions",
+      "id": "forecastingfiltercondition",
+      "inFolder": false,
+      "name": "ForecastingFilterCondition",
+      "strictDirectoryName": false,
+      "suffix": "forecastingFilterCondition"
+    },
+    "forecastinggroup": {
+      "directoryName": "forecastingGroups",
+      "id": "forecastinggroup",
+      "inFolder": false,
+      "name": "ForecastingGroup",
+      "strictDirectoryName": false,
+      "suffix": "forecastingGroup"
+    },
+    "forecastingsourcedefinition": {
+      "directoryName": "forecastingSourceDefinitions",
+      "id": "forecastingsourcedefinition",
+      "inFolder": false,
+      "name": "ForecastingSourceDefinition",
+      "suffix": "forecastingSourceDefinition"
+    },
+    "forecastingtype": {
+      "directoryName": "forecastingTypes",
+      "id": "forecastingtype",
+      "inFolder": false,
+      "name": "ForecastingType",
+      "suffix": "forecastingType"
+    },
+    "forecastingtypesource": {
+      "directoryName": "forecastingTypeSources",
+      "id": "forecastingtypesource",
+      "inFolder": false,
+      "name": "ForecastingTypeSource",
+      "suffix": "forecastingTypeSource"
+    },
+    "form": {
+      "children": {
+        "directories": {
+          "formSections": "formsection"
+        },
+        "suffixes": {
+          "formSection": "formsection"
+        },
+        "types": {
+          "formsection": {
+            "directoryName": "formSections",
+            "id": "formsection",
+            "name": "FormSection",
+            "suffix": "formSection"
+          }
+        }
+      },
+      "directoryName": "forms",
+      "id": "form",
+      "inFolder": false,
+      "name": "Form",
+      "suffix": "form"
+    },
+    "fueltype": {
+      "directoryName": "fuelTypes",
+      "id": "fueltype",
+      "inFolder": false,
+      "name": "FuelType",
+      "strictDirectoryName": false,
+      "suffix": "fuelType"
+    },
+    "fueltypesustnuom": {
+      "directoryName": "fuelTypeSustnUoms",
+      "id": "fueltypesustnuom",
+      "inFolder": false,
+      "name": "FuelTypeSustnUom",
+      "strictDirectoryName": false,
+      "suffix": "fuelTypeSustnUom"
+    },
+    "functionreference": {
+      "directoryName": "functions",
+      "id": "functionreference",
+      "name": "FunctionReference",
+      "strictDirectoryName": false,
+      "suffix": "function"
+    },
+    "fundraisingconfig": {
+      "directoryName": "fundraisingConfigs",
+      "id": "fundraisingconfig",
+      "inFolder": false,
+      "name": "FundraisingConfig",
+      "strictDirectoryName": false,
+      "suffix": "fundraisingConfig"
+    },
+    "gatewayproviderpaymentmethodtype": {
+      "directoryName": "gatewayProviderPaymentMethodTypes",
+      "id": "gatewayproviderpaymentmethodtype",
+      "name": "GatewayProviderPaymentMethodType",
+      "strictDirectoryName": false,
+      "suffix": "gatewayProviderPaymentMethodType"
+    },
+    "genaifunction": {
+      "directoryName": "genAiFunctions",
+      "id": "genaifunction",
+      "inFolder": false,
+      "name": "GenAiFunction",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true
+    },
+    "genaiplanner": {
+      "directoryName": "genAiPlanners",
+      "id": "genaiplanner",
+      "inFolder": false,
+      "name": "GenAiPlanner",
+      "suffix": "genAiPlanner"
+    },
+    "genaiplannerbundle": {
+      "directoryName": "genAiPlannerBundles",
+      "id": "genaiplannerbundle",
+      "inFolder": false,
+      "name": "GenAiPlannerBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true
+    },
+    "genaiplugin": {
+      "directoryName": "genAiPlugins",
+      "id": "genaiplugin",
+      "inFolder": false,
+      "name": "GenAiPlugin",
+      "strictDirectoryName": false,
+      "suffix": "genAiPlugin"
+    },
+    "genaiprompttemplate": {
+      "directoryName": "genAiPromptTemplates",
+      "id": "genaiprompttemplate",
+      "inFolder": false,
+      "name": "GenAiPromptTemplate",
+      "strictDirectoryName": false,
+      "suffix": "genAiPromptTemplate"
+    },
+    "genaiprompttemplateactv": {
+      "directoryName": "genAiPromptTemplateActivations",
+      "id": "genaiprompttemplateactv",
+      "inFolder": false,
+      "name": "GenAiPromptTemplateActv",
+      "strictDirectoryName": false,
+      "suffix": "genAiPromptTemplateActivation"
+    },
+    "globalpicklist": {
+      "directoryName": "globalPicklists",
+      "id": "globalpicklist",
+      "inFolder": false,
+      "name": "GlobalPicklist",
+      "suffix": "globalPicklist"
+    },
+    "globalvalueset": {
+      "directoryName": "globalValueSets",
+      "id": "globalvalueset",
+      "inFolder": false,
+      "name": "GlobalValueSet",
+      "strictDirectoryName": false,
+      "suffix": "globalValueSet",
+      "supportsWildcardAndName": true
+    },
+    "globalvaluesettranslation": {
+      "directoryName": "globalValueSetTranslations",
+      "id": "globalvaluesettranslation",
+      "inFolder": false,
+      "name": "GlobalValueSetTranslation",
+      "strictDirectoryName": false,
+      "suffix": "globalValueSetTranslation",
+      "supportsWildcardAndName": true
+    },
+    "group": {
+      "directoryName": "groups",
+      "id": "group",
+      "inFolder": false,
+      "name": "Group",
+      "strictDirectoryName": false,
+      "suffix": "group"
+    },
+    "homepagecomponent": {
+      "directoryName": "homePageComponents",
+      "id": "homepagecomponent",
+      "inFolder": false,
+      "name": "HomePageComponent",
+      "strictDirectoryName": false,
+      "suffix": "homePageComponent"
+    },
+    "homepagelayout": {
+      "directoryName": "homePageLayouts",
+      "id": "homepagelayout",
+      "inFolder": false,
+      "name": "HomePageLayout",
+      "strictDirectoryName": false,
+      "suffix": "homePageLayout"
+    },
+    "icon": {
+      "directoryName": "icons",
+      "id": "icon",
+      "name": "Icon",
+      "strictDirectoryName": false,
+      "suffix": "icon"
+    },
+    "identityverificationprocdef": {
+      "directoryName": "IdentityVerificationProcDefs",
+      "id": "identityverificationprocdef",
+      "inFolder": false,
+      "name": "IdentityVerificationProcDef",
+      "strictDirectoryName": false,
+      "suffix": "IdentityVerificationProcDef"
+    },
+    "iframewhitelisturlsettings": {
+      "directoryName": "iframeWhiteListUrlSettings",
+      "id": "iframewhitelisturlsettings",
+      "inFolder": false,
+      "name": "IframeWhiteListUrlSettings",
+      "strictDirectoryName": false,
+      "suffix": "iframeWhiteListUrlSettings"
+    },
+    "inboundcertificate": {
+      "directoryName": "inboundCertificates",
+      "id": "inboundcertificate",
+      "inFolder": false,
+      "name": "InboundCertificate",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "inboundCertificate"
+    },
+    "inboundnetworkconnection": {
+      "directoryName": "inboundNetworkConnections",
+      "id": "inboundnetworkconnection",
+      "inFolder": false,
+      "name": "InboundNetworkConnection",
+      "strictDirectoryName": false,
+      "suffix": "inboundNetworkConnection"
+    },
+    "industriesmanufacturingsettings": {
+      "directoryName": "IndustriesManufacturingSettings",
+      "id": "industriesmanufacturingsettings",
+      "name": "IndustriesManufacturingSettings",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "insighttype": {
+      "directoryName": "insightTypes",
+      "id": "insighttype",
+      "inFolder": false,
+      "name": "InsightType",
+      "suffix": "insightType"
+    },
+    "installedpackage": {
+      "directoryName": "installedPackages",
+      "id": "installedpackage",
+      "inFolder": false,
+      "name": "InstalledPackage",
+      "strictDirectoryName": false,
+      "suffix": "installedPackage"
+    },
+    "integrationhubsettings": {
+      "directoryName": "integrationHub",
+      "id": "integrationhubsettings",
+      "inFolder": false,
+      "name": "IntegrationHubSettings",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "integrationhubsettingstype": {
+      "directoryName": "integrationHub",
+      "id": "integrationhubsettingstype",
+      "inFolder": false,
+      "name": "IntegrationHubSettingsType",
+      "suffix": "type"
+    },
+    "integrationproviderdef": {
+      "directoryName": "integrationProviderDefinitions",
+      "id": "integrationproviderdef",
+      "inFolder": false,
+      "name": "IntegrationProviderDef",
+      "strictDirectoryName": false,
+      "suffix": "integrationProviderDefinition"
+    },
+    "internaldataconnector": {
+      "directoryName": "internalDataConnectors",
+      "id": "internaldataconnector",
+      "inFolder": false,
+      "name": "InternalDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "internalDataConnector"
+    },
+    "internalorganization": {
+      "directoryName": "internalOrganizations",
+      "id": "internalorganization",
+      "inFolder": false,
+      "name": "InternalOrganization",
+      "suffix": "internalOrganization"
+    },
+    "ipaddressrange": {
+      "directoryName": "IPAddressRanges",
+      "id": "ipaddressrange",
+      "inFolder": false,
+      "name": "IPAddressRange",
+      "strictDirectoryName": false,
+      "suffix": "IPAddressRange"
+    },
+    "keywordlist": {
+      "directoryName": "moderation",
+      "id": "keywordlist",
+      "inFolder": false,
+      "name": "KeywordList",
+      "strictDirectoryName": false,
+      "suffix": "keywords"
+    },
+    "layout": {
+      "directoryName": "layouts",
+      "id": "layout",
+      "inFolder": false,
+      "name": "Layout",
+      "strictDirectoryName": false,
+      "suffix": "layout",
+      "supportsWildcardAndName": true
+    },
+    "leadconvertsettings": {
+      "directoryName": "LeadConvertSettings",
+      "id": "leadconvertsettings",
+      "inFolder": false,
+      "name": "LeadConvertSettings",
+      "strictDirectoryName": false,
+      "suffix": "LeadConvertSetting"
+    },
+    "learningachievementconfig": {
+      "directoryName": "learningAchievementConfigs",
+      "id": "learningachievementconfig",
+      "inFolder": false,
+      "name": "LearningAchievementConfig",
+      "strictDirectoryName": false,
+      "suffix": "learningAchievementConfig"
+    },
+    "learningitemtype": {
+      "directoryName": "learningItemTypes",
+      "id": "learningitemtype",
+      "inFolder": false,
+      "name": "LearningItemType",
+      "strictDirectoryName": false,
+      "suffix": "learningItemType"
+    },
+    "letterhead": {
+      "directoryName": "letterhead",
+      "id": "letterhead",
+      "inFolder": false,
+      "name": "Letterhead",
+      "strictDirectoryName": false,
+      "suffix": "letter",
+      "supportsWildcardAndName": true
+    },
+    "licensedefinition": {
+      "directoryName": "licenseDefinitions",
+      "id": "licensedefinition",
+      "inFolder": false,
+      "name": "LicenseDefinition",
+      "suffix": "licenseDefinition"
+    },
+    "lightningbolt": {
+      "directoryName": "lightningBolts",
+      "id": "lightningbolt",
+      "inFolder": false,
+      "name": "LightningBolt",
+      "strictDirectoryName": false,
+      "suffix": "lightningBolt"
+    },
+    "lightningcomponentbundle": {
+      "directoryName": "lwc",
+      "id": "lightningcomponentbundle",
+      "inFolder": false,
+      "name": "LightningComponentBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "lightningexperiencetheme": {
+      "directoryName": "lightningExperienceThemes",
+      "id": "lightningexperiencetheme",
+      "inFolder": false,
+      "name": "LightningExperienceTheme",
+      "strictDirectoryName": false,
+      "suffix": "lightningExperienceTheme"
+    },
+    "lightningmessagechannel": {
+      "directoryName": "messageChannels",
+      "id": "lightningmessagechannel",
+      "inFolder": false,
+      "name": "LightningMessageChannel",
+      "strictDirectoryName": false,
+      "suffix": "messageChannel"
+    },
+    "lightningonboardingconfig": {
+      "directoryName": "lightningOnboardingConfigs",
+      "id": "lightningonboardingconfig",
+      "inFolder": false,
+      "name": "LightningOnboardingConfig",
+      "strictDirectoryName": false,
+      "suffix": "lightningOnboardingConfig"
+    },
+    "livechatagentconfig": {
+      "directoryName": "liveChatAgentConfigs",
+      "id": "livechatagentconfig",
+      "inFolder": false,
+      "name": "LiveChatAgentConfig",
+      "suffix": "liveChatAgentConfig"
+    },
+    "livechatbutton": {
+      "directoryName": "liveChatButtons",
+      "id": "livechatbutton",
+      "inFolder": false,
+      "name": "LiveChatButton",
+      "suffix": "liveChatButton"
+    },
+    "livechatdeployment": {
+      "directoryName": "liveChatDeployments",
+      "id": "livechatdeployment",
+      "inFolder": false,
+      "name": "LiveChatDeployment",
+      "suffix": "liveChatDeployment"
+    },
+    "livechatsensitivedatarule": {
+      "directoryName": "liveChatSensitiveDataRule",
+      "id": "livechatsensitivedatarule",
+      "inFolder": false,
+      "name": "LiveChatSensitiveDataRule",
+      "suffix": "liveChatSensitiveDataRule"
+    },
+    "locationuse": {
+      "directoryName": "locationUses",
+      "id": "locationuse",
+      "inFolder": false,
+      "name": "LocationUse",
+      "strictDirectoryName": false,
+      "suffix": "locationUse"
+    },
+    "loyaltyprogramsetup": {
+      "directoryName": "loyaltyProgramSetups",
+      "id": "loyaltyprogramsetup",
+      "name": "LoyaltyProgramSetup",
+      "strictDirectoryName": false,
+      "suffix": "loyaltyProgramSetup"
+    },
+    "managedcontenttype": {
+      "directoryName": "managedContentTypes",
+      "id": "managedcontenttype",
+      "inFolder": false,
+      "name": "ManagedContentType",
+      "strictDirectoryName": false,
+      "suffix": "managedContentType"
+    },
+    "managedeventsubscription": {
+      "directoryName": "managedEventSubscriptions",
+      "id": "managedeventsubscription",
+      "inFolder": false,
+      "name": "ManagedEventSubscription",
+      "strictDirectoryName": false,
+      "suffix": "managedEventSubscription"
+    },
+    "managedtopics": {
+      "children": {
+        "directories": {
+          "managedTopics": "managedtopic"
+        },
+        "suffixes": {
+          "managedTopic": "managedtopic"
+        },
+        "types": {
+          "managedtopic": {
+            "directoryName": "managedTopics",
+            "id": "managedtopic",
+            "name": "ManagedTopic",
+            "suffix": "managedTopic"
+          }
+        }
+      },
+      "directoryName": "managedTopics",
+      "id": "managedtopics",
+      "inFolder": false,
+      "name": "ManagedTopics",
+      "strictDirectoryName": false,
+      "suffix": "managedTopics"
+    },
+    "marketingappextension": {
+      "directoryName": "marketingappextensions",
+      "id": "marketingappextension",
+      "inFolder": false,
+      "name": "MarketingAppExtension",
+      "suffix": "marketingappextension"
+    },
+    "marketingresourcetype": {
+      "directoryName": "marketingResourceType",
+      "id": "marketingresourcetype",
+      "inFolder": false,
+      "name": "MarketingResourceType",
+      "suffix": "marketingResourceType"
+    },
+    "marketsegmentdefinition": {
+      "directoryName": "marketSegmentDefinitions",
+      "id": "marketsegmentdefinition",
+      "inFolder": false,
+      "name": "MarketSegmentDefinition",
+      "strictDirectoryName": false,
+      "suffix": "marketSegmentDefinition"
+    },
+    "matchingrules": {
+      "children": {
+        "directories": {
+          "matchingRules": "matchingrule"
+        },
+        "suffixes": {
+          "matchingRule": "matchingrule"
+        },
+        "types": {
+          "matchingrule": {
+            "directoryName": "matchingRules",
+            "id": "matchingrule",
+            "name": "MatchingRule",
+            "suffix": "matchingRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "matchingRules"
+          }
+        }
+      },
+      "directoryName": "matchingRules",
+      "id": "matchingrules",
+      "inFolder": false,
+      "name": "MatchingRules",
+      "strictDirectoryName": false,
+      "suffix": "matchingRule"
+    },
+    "messagingchannel": {
+      "directoryName": "messagingChannels",
+      "id": "messagingchannel",
+      "inFolder": false,
+      "name": "MessagingChannel",
+      "strictDirectoryName": false,
+      "suffix": "messagingChannel"
+    },
+    "mfgprogramtemplate": {
+      "directoryName": "MfgProgramTemplate",
+      "id": "mfgprogramtemplate",
+      "inFolder": false,
+      "name": "MfgProgramTemplate",
+      "strictDirectoryName": false,
+      "suffix": "mfgProgramTemplate"
+    },
+    "milestonetype": {
+      "directoryName": "milestoneTypes",
+      "id": "milestonetype",
+      "inFolder": false,
+      "name": "MilestoneType",
+      "suffix": "milestoneType"
+    },
+    "mktcalcinsightobjectdef": {
+      "directoryName": "mktCalcInsightObjectDefs",
+      "id": "mktcalcinsightobjectdef",
+      "inFolder": false,
+      "name": "MktCalcInsightObjectDef",
+      "suffix": "mktCalcInsightObjectDef"
+    },
+    "mktdataconnection": {
+      "directoryName": "mktDataConnections",
+      "id": "mktdataconnection",
+      "inFolder": false,
+      "name": "MktDataConnection",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnection"
+    },
+    "mktdataconnectionsrcparam": {
+      "directoryName": "mktDataConnectionSrcParams",
+      "id": "mktdataconnectionsrcparam",
+      "inFolder": false,
+      "name": "MktDataConnectionSrcParam",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnectionSrcParam"
+    },
+    "mktdatatranobject": {
+      "children": {
+        "directories": {
+          "mktDataTranFields": "mktdatatranfield"
+        },
+        "suffixes": {
+          "mktDataTranField": "mktdatatranfield"
+        },
+        "types": {
+          "mktdatatranfield": {
+            "directoryName": "mktDataTranFields",
+            "id": "mktdatatranfield",
+            "name": "MktDataTranField",
+            "suffix": "mktDataTranField"
+          }
+        }
+      },
+      "directoryName": "mktDataTranObjects",
+      "id": "mktdatatranobject",
+      "name": "MktDataTranObject",
+      "strictDirectoryName": false,
+      "suffix": "mktDataTranObject"
+    },
+    "mldatadefinition": {
+      "directoryName": "mlDataDefinitions",
+      "id": "mldatadefinition",
+      "inFolder": false,
+      "name": "MLDataDefinition",
+      "strictDirectoryName": false,
+      "suffix": "mlDataDefinition"
+    },
+    "mldomain": {
+      "directoryName": "mlDomains",
+      "id": "mldomain",
+      "inFolder": false,
+      "name": "MlDomain",
+      "suffix": "mlDomain"
+    },
+    "mlpredictiondefinition": {
+      "directoryName": "mlPredictions",
+      "id": "mlpredictiondefinition",
+      "inFolder": false,
+      "name": "MLPredictionDefinition",
+      "strictDirectoryName": false,
+      "suffix": "mlPrediction"
+    },
+    "mlrecommendationdefinition": {
+      "directoryName": "mlRecommendations",
+      "id": "mlrecommendationdefinition",
+      "inFolder": false,
+      "name": "MLRecommendationDefinition",
+      "suffix": "mlRecommendation"
+    },
+    "mobileapplicationdetail": {
+      "directoryName": "MobileApplicationDetails",
+      "id": "mobileapplicationdetail",
+      "inFolder": false,
+      "name": "MobileApplicationDetail",
+      "strictDirectoryName": false,
+      "suffix": "MobileApplicationDetail"
+    },
+    "mobilesecurityassignment": {
+      "directoryName": "mobileSecurityAssignments",
+      "id": "mobilesecurityassignment",
+      "inFolder": false,
+      "name": "MobileSecurityAssignment",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityAssignment"
+    },
+    "mobilesecuritypolicy": {
+      "directoryName": "mobileSecurityPolicies",
+      "id": "mobilesecuritypolicy",
+      "inFolder": false,
+      "name": "MobileSecurityPolicy",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityPolicy"
+    },
+    "mobilesecuritypolicyset": {
+      "directoryName": "mobileSecurityPolicySets",
+      "id": "mobilesecuritypolicyset",
+      "inFolder": false,
+      "name": "MobileSecurityPolicySet",
+      "strictDirectoryName": false,
+      "suffix": "mobileSecurityPolicySet"
+    },
+    "mobsecuritycertpinconfig": {
+      "directoryName": "mobSecurityCertPinConfigs",
+      "id": "mobsecuritycertpinconfig",
+      "inFolder": false,
+      "name": "MobSecurityCertPinConfig",
+      "strictDirectoryName": false,
+      "suffix": "mobSecurityCertPinConfig"
+    },
+    "moderationrule": {
+      "directoryName": "moderation",
+      "id": "moderationrule",
+      "inFolder": false,
+      "name": "ModerationRule",
+      "strictDirectoryName": false,
+      "suffix": "rule"
+    },
+    "mutingpermissionset": {
+      "directoryName": "mutingpermissionsets",
+      "id": "mutingpermissionset",
+      "inFolder": false,
+      "name": "MutingPermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "mutingpermissionset"
+    },
+    "mydomaindiscoverablelogin": {
+      "directoryName": "myDomainDiscoverableLogins",
+      "id": "mydomaindiscoverablelogin",
+      "inFolder": false,
+      "name": "MyDomainDiscoverableLogin",
+      "strictDirectoryName": false,
+      "suffix": "myDomainDiscoverableLogin"
+    },
+    "namedcredential": {
+      "directoryName": "namedCredentials",
+      "id": "namedcredential",
+      "inFolder": false,
+      "name": "NamedCredential",
+      "strictDirectoryName": false,
+      "suffix": "namedCredential"
+    },
+    "navigationmenu": {
+      "directoryName": "navigationMenus",
+      "id": "navigationmenu",
+      "inFolder": false,
+      "name": "NavigationMenu",
+      "strictDirectoryName": false,
+      "suffix": "navigationMenu"
+    },
+    "network": {
+      "directoryName": "networks",
+      "id": "network",
+      "inFolder": false,
+      "name": "Network",
+      "strictDirectoryName": false,
+      "suffix": "network"
+    },
+    "networkbranding": {
+      "directoryName": "networkBranding",
+      "id": "networkbranding",
+      "inFolder": false,
+      "name": "NetworkBranding",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "networkBranding"
+    },
+    "notificationtypeconfig": {
+      "directoryName": "notificationTypeConfig",
+      "id": "notificationtypeconfig",
+      "inFolder": false,
+      "name": "NotificationTypeConfig",
+      "strictDirectoryName": false,
+      "suffix": "config"
+    },
+    "oauthcustomscope": {
+      "directoryName": "oauthcustomscopes",
+      "id": "oauthcustomscope",
+      "inFolder": false,
+      "name": "OauthCustomScope",
+      "strictDirectoryName": false,
+      "suffix": "oauthcustomscope"
+    },
+    "oauthtokenexchangehandler": {
+      "directoryName": "oauthtokenexchangehandlers",
+      "id": "oauthtokenexchangehandler",
+      "inFolder": false,
+      "name": "OauthTokenExchangeHandler",
+      "strictDirectoryName": false,
+      "suffix": "oauthtokenexchangehandler"
+    },
+    "objecthierarchyrelationship": {
+      "directoryName": "ObjectHierarchyRelationship",
+      "id": "objecthierarchyrelationship",
+      "name": "ObjectHierarchyRelationship",
+      "strictDirectoryName": true,
+      "suffix": "settings"
+    },
+    "objectsourcetargetmap": {
+      "directoryName": "objectSourceTargetMaps",
+      "id": "objectsourcetargetmap",
+      "name": "ObjectSourceTargetMap",
+      "strictDirectoryName": false,
+      "suffix": "objectSourceTargetMap"
+    },
+    "objintegproviderdefmapping": {
+      "directoryName": "objIntegProviderDefMappings",
+      "id": "objintegproviderdefmapping",
+      "name": "ObjIntegProviderDefMapping",
+      "strictDirectoryName": false,
+      "suffix": "objIntegProviderDefMapping"
+    },
+    "ocrsampledocument": {
+      "directoryName": "ocrSampleDocuments",
+      "id": "ocrsampledocument",
+      "name": "OcrSampleDocument",
+      "strictDirectoryName": false,
+      "suffix": "ocrSampleDocument"
+    },
+    "ocrtemplate": {
+      "directoryName": "ocrTemplates",
+      "id": "ocrtemplate",
+      "name": "OcrTemplate",
+      "strictDirectoryName": false,
+      "suffix": "ocrTemplate"
+    },
+    "omnidatatransform": {
+      "directoryName": "omniDataTransforms",
+      "id": "omnidatatransform",
+      "inFolder": false,
+      "name": "OmniDataTransform",
+      "strictDirectoryName": false,
+      "suffix": "rpt"
+    },
+    "omniexttrackingdef": {
+      "directoryName": "OmniExtTrackingDefs",
+      "id": "omniexttrackingdef",
+      "inFolder": false,
+      "name": "OmniExtTrackingDef",
+      "strictDirectoryName": false,
+      "suffix": "OmniExtTrackingDef"
+    },
+    "omniintegrationprocedure": {
+      "directoryName": "omniIntegrationProcedures",
+      "id": "omniintegrationprocedure",
+      "inFolder": false,
+      "name": "OmniIntegrationProcedure",
+      "strictDirectoryName": false,
+      "suffix": "oip"
+    },
+    "omniinteractionaccessconfig": {
+      "directoryName": "OmniInteractionAccessConfig",
+      "id": "omniinteractionaccessconfig",
+      "inFolder": false,
+      "name": "OmniInteractionAccessConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniInteractionAccessConfig"
+    },
+    "omniinteractionconfig": {
+      "directoryName": "OmniInteractionConfig",
+      "id": "omniinteractionconfig",
+      "inFolder": false,
+      "name": "OmniInteractionConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniInteractionConfig"
+    },
+    "omniscript": {
+      "directoryName": "omniScripts",
+      "id": "omniscript",
+      "inFolder": false,
+      "name": "OmniScript",
+      "strictDirectoryName": false,
+      "suffix": "os"
+    },
+    "omnisupervisorconfig": {
+      "directoryName": "omniSupervisorConfigs",
+      "id": "omnisupervisorconfig",
+      "inFolder": false,
+      "name": "OmniSupervisorConfig",
+      "strictDirectoryName": false,
+      "suffix": "omniSupervisorConfig"
+    },
+    "omnitrackinggroup": {
+      "directoryName": "OmniTrackingGroups",
+      "id": "omnitrackinggroup",
+      "inFolder": false,
+      "name": "OmniTrackingGroup",
+      "strictDirectoryName": false,
+      "suffix": "OmniTrackingGroup"
+    },
+    "omniuicard": {
+      "directoryName": "omniUiCard",
+      "id": "omniuicard",
+      "inFolder": false,
+      "name": "OmniUiCard",
+      "strictDirectoryName": false,
+      "suffix": "ouc"
+    },
+    "orchestration": {
+      "directoryName": "iot",
+      "id": "orchestration",
+      "inFolder": false,
+      "name": "Orchestration",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "orchestration"
+    },
+    "orchestrationcontext": {
+      "directoryName": "iot",
+      "id": "orchestrationcontext",
+      "inFolder": false,
+      "name": "OrchestrationContext",
+      "suffix": "orchestrationContext"
+    },
+    "outboundnetworkconnection": {
+      "directoryName": "outboundNetworkConnections",
+      "id": "outboundnetworkconnection",
+      "inFolder": false,
+      "name": "OutboundNetworkConnection",
+      "strictDirectoryName": false,
+      "suffix": "outboundNetworkConnection"
+    },
+    "participantrole": {
+      "directoryName": "participantRoles",
+      "id": "participantrole",
+      "name": "ParticipantRole",
+      "strictDirectoryName": false,
+      "suffix": "participantRole"
+    },
+    "pathassistant": {
+      "directoryName": "pathAssistants",
+      "id": "pathassistant",
+      "inFolder": false,
+      "name": "PathAssistant",
+      "strictDirectoryName": false,
+      "suffix": "pathAssistant",
+      "supportsWildcardAndName": true
+    },
+    "paymentgatewayprovider": {
+      "directoryName": "paymentGatewayProviders",
+      "id": "paymentgatewayprovider",
+      "inFolder": false,
+      "name": "PaymentGatewayProvider",
+      "suffix": "paymentGatewayProvider"
+    },
+    "permissionset": {
+      "directoryName": "permissionsets",
+      "id": "permissionset",
+      "inFolder": false,
+      "name": "PermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "permissionset"
+    },
+    "permissionsetgroup": {
+      "directoryName": "permissionsetgroups",
+      "id": "permissionsetgroup",
+      "inFolder": false,
+      "name": "PermissionSetGroup",
+      "strictDirectoryName": false,
+      "suffix": "permissionsetgroup"
+    },
+    "permissionsetlicensedefinition": {
+      "directoryName": "permissionSetLicenseDefinitions",
+      "id": "permissionsetlicensedefinition",
+      "inFolder": false,
+      "name": "PermissionSetLicenseDefinition",
+      "strictDirectoryName": false,
+      "suffix": "permissionSetLicenseDefinition"
+    },
+    "personaccountownerpoweruser": {
+      "directoryName": "personAccountOwnerPowerUsers",
+      "id": "personaccountownerpoweruser",
+      "inFolder": false,
+      "name": "PersonAccountOwnerPowerUser",
+      "strictDirectoryName": false,
+      "suffix": "personAccountOwnerPowerUser"
+    },
+    "pipelineinspmetricconfig": {
+      "directoryName": "pipelineInspMetricConfigs",
+      "id": "pipelineinspmetricconfig",
+      "inFolder": false,
+      "name": "PipelineInspMetricConfig",
+      "strictDirectoryName": false,
+      "suffix": "pipelineInspMetricConfig"
+    },
+    "platformcachepartition": {
+      "directoryName": "cachePartitions",
+      "id": "platformcachepartition",
+      "inFolder": false,
+      "name": "PlatformCachePartition",
+      "strictDirectoryName": false,
+      "suffix": "cachePartition"
+    },
+    "platformeventchannel": {
+      "directoryName": "platformEventChannels",
+      "id": "platformeventchannel",
+      "inFolder": false,
+      "name": "PlatformEventChannel",
+      "strictDirectoryName": false,
+      "suffix": "platformEventChannel"
+    },
+    "platformeventchannelmember": {
+      "directoryName": "platformEventChannelMembers",
+      "id": "platformeventchannelmember",
+      "inFolder": false,
+      "name": "PlatformEventChannelMember",
+      "strictDirectoryName": false,
+      "suffix": "platformEventChannelMember"
+    },
+    "platformeventsubscriberconfig": {
+      "directoryName": "PlatformEventSubscriberConfigs",
+      "id": "platformeventsubscriberconfig",
+      "inFolder": false,
+      "name": "PlatformEventSubscriberConfig",
+      "strictDirectoryName": false,
+      "suffix": "platformEventSubscriberConfig"
+    },
+    "portal": {
+      "directoryName": "portals",
+      "id": "portal",
+      "inFolder": false,
+      "name": "Portal",
+      "suffix": "portal"
+    },
+    "portaldelegablepermissionset": {
+      "directoryName": "portalDelegablePermissionSet",
+      "id": "portaldelegablepermissionset",
+      "inFolder": false,
+      "name": "PortalDelegablePermissionSet",
+      "strictDirectoryName": false,
+      "suffix": "portalDelegablePermissionSet"
+    },
+    "posttemplate": {
+      "directoryName": "postTemplates",
+      "id": "posttemplate",
+      "inFolder": false,
+      "name": "PostTemplate",
+      "strictDirectoryName": false,
+      "suffix": "postTemplate"
+    },
+    "presencedeclinereason": {
+      "directoryName": "presenceDeclineReasons",
+      "id": "presencedeclinereason",
+      "inFolder": false,
+      "name": "PresenceDeclineReason",
+      "suffix": "presenceDeclineReason"
+    },
+    "presenceuserconfig": {
+      "directoryName": "presenceUserConfigs",
+      "id": "presenceuserconfig",
+      "inFolder": false,
+      "name": "PresenceUserConfig",
+      "suffix": "presenceUserConfig"
+    },
+    "pricingactionparameters": {
+      "directoryName": "pricingActionParameters",
+      "id": "pricingactionparameters",
+      "inFolder": false,
+      "name": "PricingActionParameters",
+      "strictDirectoryName": false,
+      "suffix": "pricingActionParameters"
+    },
+    "pricingrecipe": {
+      "directoryName": "pricingRecipe",
+      "id": "pricingrecipe",
+      "name": "PricingRecipe",
+      "strictDirectoryName": false,
+      "suffix": "pricingRecipe"
+    },
+    "processflowmigration": {
+      "directoryName": "processflowmigrations",
+      "id": "processflowmigration",
+      "inFolder": false,
+      "name": "ProcessFlowMigration",
+      "strictDirectoryName": false,
+      "suffix": "processflowmigration"
+    },
+    "productattrdisplayconfig": {
+      "directoryName": "productAttrDisplayConfigs",
+      "id": "productattrdisplayconfig",
+      "inFolder": false,
+      "name": "ProductAttrDisplayConfig",
+      "strictDirectoryName": false,
+      "suffix": "productAttrDisplayConfig"
+    },
+    "productattributeset": {
+      "directoryName": "productAttributeSets",
+      "id": "productattributeset",
+      "inFolder": false,
+      "name": "ProductAttributeSet",
+      "strictDirectoryName": false,
+      "suffix": "productAttributeSet"
+    },
+    "productspecificationrectype": {
+      "directoryName": "productSpecificationRecTypes",
+      "id": "productspecificationrectype",
+      "inFolder": false,
+      "name": "ProductSpecificationRecType",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationRecType"
+    },
+    "productspecificationtype": {
+      "directoryName": "productSpecificationTypes",
+      "id": "productspecificationtype",
+      "inFolder": false,
+      "name": "ProductSpecificationType",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationType"
+    },
+    "productspecificationtypedefinition": {
+      "directoryName": "productSpecificationTypeDefinitions",
+      "id": "productspecificationtypedefinition",
+      "inFolder": false,
+      "name": "ProductSpecificationTypeDefinition",
+      "strictDirectoryName": false,
+      "suffix": "productSpecificationTypeDefinition"
+    },
+    "profile": {
+      "directoryName": "profiles",
+      "id": "profile",
+      "inFolder": false,
+      "name": "Profile",
+      "strictDirectoryName": false,
+      "suffix": "profile"
+    },
+    "profilepasswordpolicy": {
+      "directoryName": "profilePasswordPolicies",
+      "id": "profilepasswordpolicy",
+      "inFolder": false,
+      "name": "ProfilePasswordPolicy",
+      "strictDirectoryName": false,
+      "suffix": "profilePasswordPolicy"
+    },
+    "profilesessionsetting": {
+      "directoryName": "profileSessionSettings",
+      "id": "profilesessionsetting",
+      "inFolder": false,
+      "name": "ProfileSessionSetting",
+      "strictDirectoryName": false,
+      "suffix": "profileSessionSetting"
+    },
+    "prompt": {
+      "directoryName": "prompts",
+      "id": "prompt",
+      "inFolder": false,
+      "name": "Prompt",
+      "strictDirectoryName": false,
+      "suffix": "prompt"
+    },
+    "queue": {
+      "directoryName": "queues",
+      "id": "queue",
+      "inFolder": false,
+      "name": "Queue",
+      "strictDirectoryName": false,
+      "suffix": "queue"
+    },
+    "queueroutingconfig": {
+      "directoryName": "queueRoutingConfigs",
+      "id": "queueroutingconfig",
+      "inFolder": false,
+      "name": "QueueRoutingConfig",
+      "suffix": "queueRoutingConfig"
+    },
+    "quickaction": {
+      "directoryName": "quickActions",
+      "id": "quickaction",
+      "inFolder": false,
+      "name": "QuickAction",
+      "strictDirectoryName": false,
+      "suffix": "quickAction",
+      "supportsWildcardAndName": true
+    },
+    "recalrtdatasrcexpsetdef": {
+      "directoryName": "recAlrtDataSrcExpSetDefs",
+      "id": "recalrtdatasrcexpsetdef",
+      "inFolder": false,
+      "name": "RecAlrtDataSrcExpSetDef",
+      "strictDirectoryName": false,
+      "suffix": "recAlrtDataSrcExpSetDef"
+    },
+    "recommendationstrategy": {
+      "directoryName": "recommendationStrategies",
+      "id": "recommendationstrategy",
+      "inFolder": false,
+      "name": "RecommendationStrategy",
+      "strictDirectoryName": false,
+      "suffix": "recommendationStrategy"
+    },
+    "recordactiondeployment": {
+      "directoryName": "recordActionDeployments",
+      "id": "recordactiondeployment",
+      "inFolder": false,
+      "name": "RecordActionDeployment",
+      "strictDirectoryName": false,
+      "suffix": "deployment"
+    },
+    "recordaggregationdefinition": {
+      "directoryName": "RecordAggregationDefinitions",
+      "id": "recordaggregationdefinition",
+      "inFolder": false,
+      "name": "RecordAggregationDefinition",
+      "strictDirectoryName": false,
+      "suffix": "RecordAggregationDefinition"
+    },
+    "recordalertcategory": {
+      "directoryName": "recordAlertCategories",
+      "id": "recordalertcategory",
+      "inFolder": false,
+      "name": "RecordAlertCategory",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertCategory"
+    },
+    "recordalertdatasource": {
+      "directoryName": "recordAlertDataSources",
+      "id": "recordalertdatasource",
+      "inFolder": false,
+      "name": "RecordAlertDataSource",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertDataSource"
+    },
+    "recordalerttemplate": {
+      "directoryName": "recordAlertTemplates",
+      "id": "recordalerttemplate",
+      "inFolder": false,
+      "name": "RecordAlertTemplate",
+      "strictDirectoryName": false,
+      "suffix": "recordAlertTemplate"
+    },
+    "redirectwhitelisturl": {
+      "directoryName": "redirectWhitelistUrls",
+      "id": "redirectwhitelisturl",
+      "inFolder": false,
+      "name": "RedirectWhitelistUrl",
+      "strictDirectoryName": false,
+      "suffix": "redirectWhitelistUrl"
+    },
+    "referenceddashboard": {
+      "directoryName": "wave",
+      "id": "referenceddashboard",
+      "inFolder": false,
+      "name": "ReferencedDashboard",
+      "strictDirectoryName": false,
+      "suffix": "refdash"
+    },
+    "registeredexternalservice": {
+      "directoryName": "registeredExternalServices",
+      "id": "registeredexternalservice",
+      "inFolder": false,
+      "name": "RegisteredExternalService",
+      "strictDirectoryName": false,
+      "suffix": "registeredExternalService"
+    },
+    "relatedrecordassoccriteria": {
+      "directoryName": "relatedRecordAssocCriteria",
+      "id": "relatedrecordassoccriteria",
+      "inFolder": false,
+      "name": "RelatedRecordAssocCriteria",
+      "strictDirectoryName": false,
+      "suffix": "relatedRecordAssocCriteria"
+    },
+    "relationshipgraphdefinition": {
+      "directoryName": "relationshipGraphDefinitions",
+      "id": "relationshipgraphdefinition",
+      "inFolder": false,
+      "name": "RelationshipGraphDefinition",
+      "strictDirectoryName": false,
+      "suffix": "relationshipGraphDefinition"
+    },
+    "remotesitesetting": {
+      "directoryName": "remoteSiteSettings",
+      "id": "remotesitesetting",
+      "inFolder": false,
+      "name": "RemoteSiteSetting",
+      "strictDirectoryName": false,
+      "suffix": "remoteSite",
+      "supportsWildcardAndName": true
+    },
+    "report": {
+      "directoryName": "reports",
+      "folderType": "reportfolder",
+      "id": "report",
+      "inFolder": true,
+      "name": "Report",
+      "strictDirectoryName": false,
+      "suffix": "report"
+    },
+    "reportfolder": {
+      "directoryName": "reports",
+      "folderContentType": "report",
+      "id": "reportfolder",
+      "inFolder": false,
+      "name": "ReportFolder",
+      "strictDirectoryName": false,
+      "suffix": "reportFolder"
+    },
+    "reporttype": {
+      "directoryName": "reportTypes",
+      "id": "reporttype",
+      "inFolder": false,
+      "name": "ReportType",
+      "strictDirectoryName": false,
+      "suffix": "reportType",
+      "supportsWildcardAndName": true
+    },
+    "restrictionrule": {
+      "directoryName": "restrictionRules",
+      "id": "restrictionrule",
+      "name": "RestrictionRule",
+      "strictDirectoryName": true,
+      "suffix": "rule"
+    },
+    "retrievalsummarydefinition": {
+      "directoryName": "RetrievalSummaryDefinitions",
+      "id": "retrievalsummarydefinition",
+      "inFolder": false,
+      "name": "RetrievalSummaryDefinition",
+      "strictDirectoryName": false,
+      "suffix": "RetrievalSummaryDefinition"
+    },
+    "role": {
+      "directoryName": "roles",
+      "id": "role",
+      "inFolder": false,
+      "name": "Role",
+      "strictDirectoryName": false,
+      "suffix": "role"
+    },
+    "salesagreementsettings": {
+      "directoryName": "salesAgreementSettings",
+      "id": "salesagreementsettings",
+      "name": "SalesAgreementSettings",
+      "strictDirectoryName": false,
+      "suffix": "salesAgreementSetting"
+    },
+    "samlssoconfig": {
+      "directoryName": "samlssoconfigs",
+      "id": "samlssoconfig",
+      "inFolder": false,
+      "name": "SamlSsoConfig",
+      "strictDirectoryName": false,
+      "suffix": "samlssoconfig"
+    },
+    "schedulingobjective": {
+      "directoryName": "SchedulingObjectives",
+      "id": "schedulingobjective",
+      "inFolder": false,
+      "name": "SchedulingObjective",
+      "strictDirectoryName": false,
+      "suffix": "schedulingObjective"
+    },
+    "schedulingrule": {
+      "directoryName": "SchedulingRules",
+      "id": "schedulingrule",
+      "name": "SchedulingRule",
+      "strictDirectoryName": false,
+      "suffix": "schedulingRule"
+    },
+    "scontrol": {
+      "directoryName": "scontrols",
+      "id": "scontrol",
+      "inFolder": false,
+      "name": "Scontrol",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "scf"
+    },
+    "scorecategory": {
+      "directoryName": "scoreCategories",
+      "id": "scorecategory",
+      "inFolder": false,
+      "name": "ScoreCategory",
+      "suffix": "scoreCategory"
+    },
+    "searchableobjdatasyncinfo": {
+      "directoryName": "SearchableObjDataSyncInfoSettings",
+      "id": "searchableobjdatasyncinfo",
+      "inFolder": false,
+      "name": "SearchableObjDataSyncInfo",
+      "strictDirectoryName": false,
+      "suffix": "SearchableObjDataSyncInfoSetting"
+    },
+    "searchcriteriaconfiguration": {
+      "directoryName": "SearchCriteriaConfigurationSettings",
+      "id": "searchcriteriaconfiguration",
+      "inFolder": false,
+      "name": "SearchCriteriaConfiguration",
+      "strictDirectoryName": false,
+      "suffix": "SearchCriteriaConfigurationSetting"
+    },
+    "searchcustomization": {
+      "directoryName": "searchCustomizations",
+      "id": "searchcustomization",
+      "inFolder": false,
+      "name": "SearchCustomization",
+      "strictDirectoryName": false,
+      "suffix": "searchCustomization"
+    },
+    "searchorgwideobjectconfig": {
+      "directoryName": "searchOrgWideConfiguration",
+      "id": "searchorgwideobjectconfig",
+      "inFolder": false,
+      "name": "SearchOrgWideObjectConfig",
+      "strictDirectoryName": false,
+      "suffix": "searchOrgWideObjectConfig"
+    },
+    "serviceaisetupdefinition": {
+      "directoryName": "serviceAISetupDescriptions",
+      "id": "serviceaisetupdefinition",
+      "inFolder": false,
+      "name": "ServiceAISetupDefinition",
+      "strictDirectoryName": false,
+      "suffix": "serviceAISetupDescription"
+    },
+    "serviceaisetupfield": {
+      "directoryName": "serviceAISetupFields",
+      "id": "serviceaisetupfield",
+      "inFolder": false,
+      "name": "ServiceAISetupField",
+      "strictDirectoryName": false,
+      "suffix": "serviceAISetupField"
+    },
+    "servicechannel": {
+      "directoryName": "serviceChannels",
+      "id": "servicechannel",
+      "inFolder": false,
+      "name": "ServiceChannel",
+      "suffix": "serviceChannel"
+    },
+    "servicepresencestatus": {
+      "directoryName": "servicePresenceStatuses",
+      "id": "servicepresencestatus",
+      "inFolder": false,
+      "name": "ServicePresenceStatus",
+      "suffix": "servicePresenceStatus"
+    },
+    "serviceprocess": {
+      "directoryName": "serviceprocess",
+      "id": "serviceprocess",
+      "inFolder": false,
+      "name": "ServiceProcess",
+      "strictDirectoryName": false,
+      "suffix": "serviceprocess"
+    },
+    "settings": {
+      "directoryName": "settings",
+      "id": "settings",
+      "inFolder": false,
+      "name": "Settings",
+      "strictDirectoryName": false,
+      "suffix": "settings"
+    },
+    "sharingrules": {
+      "children": {
+        "directories": {
+          "sharingCriteriaRules": "sharingRules",
+          "sharingGuestRules": "sharingRules",
+          "sharingOwnerRules": "sharingRules",
+          "sharingTerritoryRules": "sharingRules"
+        },
+        "suffixes": {
+          "sharingCriteriaRule": "sharingcriteriarule",
+          "sharingGuestRule": "sharingguestrule",
+          "sharingOwnerRule": "sharingownerrule",
+          "sharingTerritoryRule": "sharingterritoryrule"
+        },
+        "types": {
+          "sharingcriteriarule": {
+            "directoryName": "sharingRules",
+            "id": "sharingcriteriarule",
+            "name": "SharingCriteriaRule",
+            "suffix": "sharingCriteriaRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingCriteriaRules"
+          },
+          "sharingguestrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingguestrule",
+            "name": "SharingGuestRule",
+            "suffix": "sharingGuestRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingGuestRules"
+          },
+          "sharingownerrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingownerrule",
+            "name": "SharingOwnerRule",
+            "suffix": "sharingOwnerRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingOwnerRules"
+          },
+          "sharingterritoryrule": {
+            "directoryName": "sharingRules",
+            "id": "sharingterritoryrule",
+            "name": "SharingTerritoryRule",
+            "suffix": "sharingTerritoryRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "sharingTerritoryRules"
+          }
+        }
+      },
+      "directoryName": "sharingRules",
+      "id": "sharingrules",
+      "inFolder": false,
+      "name": "SharingRules",
+      "strictDirectoryName": false,
+      "suffix": "sharingRules",
+      "supportsWildcardAndName": true
+    },
+    "sharingset": {
+      "directoryName": "sharingSets",
+      "id": "sharingset",
+      "inFolder": false,
+      "name": "SharingSet",
+      "strictDirectoryName": false,
+      "suffix": "sharingSet"
+    },
+    "sitedotcom": {
+      "directoryName": "siteDotComSites",
+      "id": "sitedotcom",
+      "inFolder": false,
+      "name": "SiteDotCom",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": true,
+      "suffix": "site"
+    },
+    "skill": {
+      "directoryName": "skills",
+      "id": "skill",
+      "inFolder": false,
+      "name": "Skill",
+      "suffix": "skill"
+    },
+    "skilltype": {
+      "directoryName": "skilltypes",
+      "id": "skilltype",
+      "inFolder": false,
+      "name": "SkillType",
+      "suffix": "skilltype"
+    },
+    "slackapp": {
+      "directoryName": "slackapps",
+      "id": "slackapp",
+      "inFolder": false,
+      "name": "SlackApp",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "slackapp"
+    },
+    "stagedefinition": {
+      "directoryName": "stageDefinitions",
+      "id": "stagedefinition",
+      "inFolder": false,
+      "name": "StageDefinition",
+      "strictDirectoryName": false,
+      "suffix": "stageDefinition"
+    },
+    "standardvalueset": {
+      "directoryName": "standardValueSets",
+      "id": "standardvalueset",
+      "inFolder": false,
+      "name": "StandardValueSet",
+      "strictDirectoryName": false,
+      "suffix": "standardValueSet"
+    },
+    "standardvaluesettranslation": {
+      "directoryName": "standardValueSetTranslations",
+      "id": "standardvaluesettranslation",
+      "inFolder": false,
+      "name": "StandardValueSetTranslation",
+      "strictDirectoryName": false,
+      "suffix": "standardValueSetTranslation"
+    },
+    "staticresource": {
+      "directoryName": "staticresources",
+      "id": "staticresource",
+      "inFolder": false,
+      "name": "StaticResource",
+      "strategies": {
+        "adapter": "mixedContent",
+        "transformer": "staticResource"
+      },
+      "strictDirectoryName": true,
+      "suffix": "resource",
+      "supportsPartialDelete": true
+    },
+    "stnryassetenvsrccnfg": {
+      "directoryName": "stationaryAssetEnvSourceConfigs",
+      "id": "stnryassetenvsrccnfg",
+      "inFolder": false,
+      "name": "StnryAssetEnvSrcCnfg",
+      "strictDirectoryName": false,
+      "suffix": "stationaryAssetEnvSourceConfig"
+    },
+    "streamingappdataconnector": {
+      "directoryName": "streamingAppDataConnectors",
+      "id": "streamingappdataconnector",
+      "inFolder": false,
+      "name": "StreamingAppDataConnector",
+      "strictDirectoryName": false,
+      "suffix": "streamingAppDataConnector"
+    },
+    "sustainabilityuom": {
+      "directoryName": "sustainabilityUoms",
+      "id": "sustainabilityuom",
+      "inFolder": false,
+      "name": "SustainabilityUom",
+      "strictDirectoryName": false,
+      "suffix": "sustainabilityUom"
+    },
+    "sustnuomconversion": {
+      "directoryName": "sustnUomConversions",
+      "id": "sustnuomconversion",
+      "inFolder": false,
+      "name": "SustnUomConversion",
+      "strictDirectoryName": false,
+      "suffix": "sustnUomConversion"
+    },
+    "svccatalogcategory": {
+      "directoryName": "svcCatalogCategories",
+      "id": "svccatalogcategory",
+      "inFolder": false,
+      "name": "SvcCatalogCategory",
+      "strictDirectoryName": false,
+      "suffix": "category"
+    },
+    "svccatalogfiltercondition": {
+      "directoryName": "svcCatalogFilterConditions",
+      "id": "svccatalogfiltercondition",
+      "inFolder": false,
+      "name": "SvcCatalogFilterCondition",
+      "strictDirectoryName": false,
+      "suffix": "catalogFilterCondition"
+    },
+    "svccatalogfiltercriteria": {
+      "directoryName": "svcCatalogFilterCriterias",
+      "id": "svccatalogfiltercriteria",
+      "inFolder": false,
+      "name": "SvcCatalogFilterCriteria",
+      "strictDirectoryName": false,
+      "suffix": "catalogFilterCriteria"
+    },
+    "svccatalogfulfillmentflow": {
+      "directoryName": "svcCatalogFulfillmentFlows",
+      "id": "svccatalogfulfillmentflow",
+      "inFolder": false,
+      "name": "SvcCatalogFulfillmentFlow",
+      "strictDirectoryName": false,
+      "suffix": "fulfillmentFlow"
+    },
+    "svccatalogitemdef": {
+      "directoryName": "svcCatalogItems",
+      "id": "svccatalogitemdef",
+      "inFolder": false,
+      "name": "SvcCatalogItemDef",
+      "strictDirectoryName": false,
+      "suffix": "catalogItem"
+    },
+    "svccatalogitemdeffiltrcrit": {
+      "directoryName": "svcCatalogItemDefFiltrCrits",
+      "id": "svccatalogitemdeffiltrcrit",
+      "inFolder": false,
+      "name": "SvcCatalogItemDefFiltrCrit",
+      "strictDirectoryName": false,
+      "suffix": "catalogItemDefFiltrCrit"
+    },
+    "synonymdictionary": {
+      "directoryName": "synonymDictionaries",
+      "id": "synonymdictionary",
+      "inFolder": false,
+      "name": "SynonymDictionary",
+      "strictDirectoryName": false,
+      "suffix": "synonymDictionary"
+    },
+    "territory": {
+      "directoryName": "territories",
+      "id": "territory",
+      "inFolder": false,
+      "name": "Territory",
+      "suffix": "territory"
+    },
+    "territory2": {
+      "directoryName": "territories",
+      "folderType": "territory2model",
+      "id": "territory2",
+      "inFolder": false,
+      "name": "Territory2",
+      "suffix": "territory2"
+    },
+    "territory2model": {
+      "directoryName": "territory2Models",
+      "folderType": "territory2model",
+      "id": "territory2model",
+      "inFolder": false,
+      "name": "Territory2Model",
+      "suffix": "territory2Model"
+    },
+    "territory2rule": {
+      "directoryName": "rules",
+      "folderType": "territory2model",
+      "id": "territory2rule",
+      "inFolder": false,
+      "name": "Territory2Rule",
+      "suffix": "territory2Rule"
+    },
+    "territory2type": {
+      "directoryName": "territory2Types",
+      "id": "territory2type",
+      "inFolder": false,
+      "name": "Territory2Type",
+      "suffix": "territory2Type"
+    },
+    "timelineobjectdefinition": {
+      "directoryName": "timelineObjectDefinitions",
+      "id": "timelineobjectdefinition",
+      "inFolder": false,
+      "name": "TimelineObjectDefinition",
+      "strictDirectoryName": false,
+      "suffix": "timelineObjectDefinition"
+    },
+    "timesheettemplate": {
+      "directoryName": "timeSheetTemplates",
+      "id": "timesheettemplate",
+      "name": "TimeSheetTemplate",
+      "strictDirectoryName": false,
+      "suffix": "timeSheetTemplate"
+    },
+    "topicsforobjects": {
+      "directoryName": "topicsForObjects",
+      "id": "topicsforobjects",
+      "inFolder": false,
+      "name": "TopicsForObjects",
+      "strictDirectoryName": false,
+      "suffix": "topicsForObjects"
+    },
+    "transactionsecuritypolicy": {
+      "directoryName": "transactionSecurityPolicies",
+      "id": "transactionsecuritypolicy",
+      "inFolder": false,
+      "name": "TransactionSecurityPolicy",
+      "suffix": "transactionSecurityPolicy"
+    },
+    "translations": {
+      "directoryName": "translations",
+      "id": "translations",
+      "inFolder": false,
+      "name": "Translations",
+      "suffix": "translation"
+    },
+    "uiformatspecificationset": {
+      "directoryName": "uiFormatSpecificationSets",
+      "id": "uiformatspecificationset",
+      "inFolder": false,
+      "name": "UiFormatSpecificationSet",
+      "strictDirectoryName": false,
+      "suffix": "uiFormatSpecificationSet"
+    },
+    "uiobjectrelationconfig": {
+      "directoryName": "uiObjectRelationConfigs",
+      "id": "uiobjectrelationconfig",
+      "inFolder": false,
+      "name": "UIObjectRelationConfig",
+      "suffix": "uiObjectRelationConfig"
+    },
+    "uiplugin": {
+      "directoryName": "uiplugins",
+      "id": "uiplugin",
+      "inFolder": false,
+      "name": "UiPlugin",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "uiplugin"
+    },
+    "uiviewdefinition": {
+      "directoryName": "uiviews",
+      "id": "uiviewdefinition",
+      "inFolder": false,
+      "name": "UiViewDefinition",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "uiview"
+    },
+    "useraccesspolicy": {
+      "directoryName": "useraccesspolicies",
+      "id": "useraccesspolicy",
+      "inFolder": false,
+      "name": "UserAccessPolicy",
+      "strictDirectoryName": false,
+      "suffix": "useraccesspolicy"
+    },
+    "userauthcertificate": {
+      "directoryName": "userAuthCertificates",
+      "id": "userauthcertificate",
+      "inFolder": false,
+      "name": "UserAuthCertificate",
+      "suffix": "userAuthCertificate"
+    },
+    "usercriteria": {
+      "directoryName": "userCriteria",
+      "id": "usercriteria",
+      "inFolder": false,
+      "name": "UserCriteria",
+      "strictDirectoryName": false,
+      "suffix": "userCriteria"
+    },
+    "userprofilesearchscope": {
+      "directoryName": "userProfileSearchScopes",
+      "id": "userprofilesearchscope",
+      "inFolder": false,
+      "name": "UserProfileSearchScope",
+      "strictDirectoryName": false,
+      "suffix": "userProfileSearchScope"
+    },
+    "userprovisioningconfig": {
+      "directoryName": "userProvisioningConfigs",
+      "id": "userprovisioningconfig",
+      "inFolder": false,
+      "name": "UserProvisioningConfig",
+      "strictDirectoryName": false,
+      "suffix": "userProvisioningConfig"
+    },
+    "vehicleassetemssnsrccnfg": {
+      "directoryName": "vehicleAssetEmssnSourceConfigs",
+      "id": "vehicleassetemssnsrccnfg",
+      "inFolder": false,
+      "name": "VehicleAssetEmssnSrcCnfg",
+      "strictDirectoryName": false,
+      "suffix": "vehicleAssetEmssnSourceConfig"
+    },
+    "viewdefinition": {
+      "directoryName": "viewdefinitions",
+      "id": "viewdefinition",
+      "inFolder": false,
+      "name": "ViewDefinition",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "strictDirectoryName": false,
+      "suffix": "view"
+    },
+    "virtualvisitconfig": {
+      "directoryName": "VirtualVisitConfigs",
+      "id": "virtualvisitconfig",
+      "inFolder": false,
+      "name": "VirtualVisitConfig",
+      "strictDirectoryName": false,
+      "suffix": "virtualVisitConfig"
+    },
+    "visualizationplugin": {
+      "directoryName": "visualizationPlugins",
+      "id": "visualizationplugin",
+      "inFolder": false,
+      "name": "VisualizationPlugin",
+      "suffix": "visualizationPlugin"
+    },
+    "waveanalyticassetcollection": {
+      "directoryName": "wave",
+      "id": "waveanalyticassetcollection",
+      "inFolder": false,
+      "name": "WaveAnalyticAssetCollection",
+      "strictDirectoryName": false,
+      "suffix": "collection"
+    },
+    "waveapplication": {
+      "directoryName": "wave",
+      "id": "waveapplication",
+      "inFolder": false,
+      "name": "WaveApplication",
+      "suffix": "wapp"
+    },
+    "wavecomponent": {
+      "directoryName": "wave",
+      "id": "wavecomponent",
+      "inFolder": false,
+      "name": "WaveComponent",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wcomp"
+    },
+    "wavedashboard": {
+      "directoryName": "wave",
+      "id": "wavedashboard",
+      "inFolder": false,
+      "name": "WaveDashboard",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdash"
+    },
+    "wavedataflow": {
+      "directoryName": "wave",
+      "id": "wavedataflow",
+      "inFolder": false,
+      "name": "WaveDataflow",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdf"
+    },
+    "wavedataset": {
+      "directoryName": "wave",
+      "id": "wavedataset",
+      "inFolder": false,
+      "name": "WaveDataset",
+      "suffix": "wds"
+    },
+    "wavelens": {
+      "directoryName": "wave",
+      "id": "wavelens",
+      "inFolder": false,
+      "name": "WaveLens",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wlens"
+    },
+    "waverecipe": {
+      "directoryName": "wave",
+      "id": "waverecipe",
+      "inFolder": false,
+      "name": "WaveRecipe",
+      "strategies": {
+        "adapter": "matchingContentFile"
+      },
+      "suffix": "wdpr"
+    },
+    "wavetemplatebundle": {
+      "directoryName": "waveTemplates",
+      "id": "wavetemplatebundle",
+      "inFolder": false,
+      "name": "WaveTemplateBundle",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "wavexmd": {
+      "directoryName": "wave",
+      "id": "wavexmd",
+      "inFolder": false,
+      "name": "WaveXmd",
+      "suffix": "xmd"
+    },
+    "webstorebundle": {
+      "directoryName": "webStoreBundles",
+      "id": "webstorebundle",
+      "inFolder": false,
+      "name": "WebStoreBundle",
+      "strictDirectoryName": false,
+      "suffix": "webStoreBundle"
+    },
+    "webstoretemplate": {
+      "directoryName": "webStoreTemplates",
+      "id": "webstoretemplate",
+      "name": "WebStoreTemplate",
+      "strictDirectoryName": false,
+      "suffix": "webStoreTemplate"
+    },
+    "workflowflowautomation": {
+      "directoryName": "workflowFlowAutomations",
+      "id": "workflowflowautomation",
+      "name": "WorkflowFlowAutomation",
+      "strictDirectoryName": false,
+      "suffix": "workflowFlowAutomation"
+    },
+    "workflow": {
+      "children": {
+        "directories": {
+          "workflowAlerts": "workflowalert",
+          "workflowFieldUpdates": "workflowfieldupdate",
+          "workflowFlowActions": "workflowflowaction",
+          "workflowKnowledgePublishs": "workflowknowledgepublish",
+          "workflowOutboundMessages": "workflowoutboundmessage",
+          "workflowRules": "workflowrule",
+          "workflowSends": "workflowsend",
+          "workflowTasks": "workflowtask"
+        },
+        "suffixes": {
+          "workflowAlert": "workflowalert",
+          "workflowFieldUpdate": "workflowfieldupdate",
+          "workflowFlowAction": "workflowflowaction",
+          "workflowKnowledgePublish": "workflowknowledgepublish",
+          "workflowOutboundMessage": "workflowoutboundmessage",
+          "workflowRule": "workflowrule",
+          "workflowSend": "workflowsend",
+          "workflowTask": "workflowtask"
+        },
+        "types": {
+          "workflowalert": {
+            "directoryName": "workflowAlerts",
+            "id": "workflowalert",
+            "name": "WorkflowAlert",
+            "suffix": "workflowAlert",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "alerts"
+          },
+          "workflowfieldupdate": {
+            "directoryName": "workflowFieldUpdates",
+            "id": "workflowfieldupdate",
+            "name": "WorkflowFieldUpdate",
+            "suffix": "workflowFieldUpdate",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "fieldUpdates"
+          },
+          "workflowflowaction": {
+            "directoryName": "workflowFlowActions",
+            "id": "workflowflowaction",
+            "name": "WorkflowFlowAction",
+            "suffix": "workflowFlowAction",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "flowActions"
+          },
+          "workflowknowledgepublish": {
+            "directoryName": "workflowKnowledgePublishs",
+            "id": "workflowknowledgepublish",
+            "name": "WorkflowKnowledgePublish",
+            "suffix": "workflowKnowledgePublish",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "knowledgePublishes"
+          },
+          "workflowoutboundmessage": {
+            "directoryName": "workflowOutboundMessages",
+            "id": "workflowoutboundmessage",
+            "name": "WorkflowOutboundMessage",
+            "suffix": "workflowOutboundMessage",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "outboundMessages"
+          },
+          "workflowrule": {
+            "directoryName": "workflowRules",
+            "id": "workflowrule",
+            "name": "WorkflowRule",
+            "suffix": "workflowRule",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "rules"
+          },
+          "workflowsend": {
+            "directoryName": "workflowSends",
+            "id": "workflowsend",
+            "name": "WorkflowSend",
+            "suffix": "workflowSend",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "send"
+          },
+          "workflowtask": {
+            "directoryName": "workflowTasks",
+            "id": "workflowtask",
+            "name": "WorkflowTask",
+            "suffix": "workflowTask",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "tasks"
+          }
+        }
+      },
+      "directoryName": "workflows",
+      "id": "workflow",
+      "inFolder": false,
+      "name": "Workflow",
+      "strictDirectoryName": false,
+      "suffix": "workflow",
+      "supportsWildcardAndName": true
+    },
+    "workskillrouting": {
+      "children": {
+        "directories": {
+          "workSkillRoutingAttributes": "workskillroutingattribute"
+        },
+        "suffixes": {
+          "workSkillRoutingAttribute": "workskillroutingattribute"
+        },
+        "types": {
+          "workskillroutingattribute": {
+            "directoryName": "workSkillRoutingAttributes",
+            "id": "workskillroutingattribute",
+            "name": "WorkSkillRoutingAttribute",
+            "suffix": "workSkillRoutingAttribute"
+          }
+        }
+      },
+      "directoryName": "workSkillRoutings",
+      "id": "workskillrouting",
+      "name": "WorkSkillRouting",
+      "strictDirectoryName": false,
+      "suffix": "workSkillRouting"
+    },
+    "xorghub": {
+      "directoryName": "xorghubs",
+      "id": "xorghub",
+      "inFolder": false,
+      "name": "XOrgHub",
+      "suffix": "xorghub"
+    },
+    "extlclntapppushsettings": {
+      "id": "extlclntapppushsettings",
+      "name": "ExtlClntAppPushSettings",
+      "suffix": "ecaPush",
+      "directoryName": "extlClntAppPushSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntapppushconfigurablepolicies": {
+      "id": "extlclntapppushconfigurablepolicies",
+      "name": "ExtlClntAppPushConfigurablePolicies",
+      "suffix": "ecaPushPlcy",
+      "directoryName": "extlClntAppPushPolicies",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "appframeworktemplatebundle": {
+      "directoryName": "appTemplates",
+      "id": "appframeworktemplatebundle",
+      "name": "AppFrameworkTemplateBundle",
+      "inFolder": false,
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true
+    },
+    "choicelist": {
+      "id": "choicelist",
+      "name": "ChoiceList",
+      "suffix": "ChoiceList",
+      "directoryName": "ChoiceList",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "convintelligencesignalrule": {
+      "id": "convintelligencesignalrule",
+      "name": "ConvIntelligenceSignalRule",
+      "suffix": "ConvIntelligenceSignalRule",
+      "directoryName": "ConvIntelligenceSignalRule",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "publickeycertificate": {
+      "id": "publickeycertificate",
+      "name": "PublicKeyCertificate",
+      "suffix": "PublicKeyCertificate",
+      "directoryName": "PublicKeyCertificate",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "publickeycertificateset": {
+      "id": "publickeycertificateset",
+      "name": "PublicKeyCertificateSet",
+      "suffix": "PublicKeyCertificateSet",
+      "directoryName": "PublicKeyCertificateSet",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "aievaluationdefinition": {
+      "id": "aievaluationdefinition",
+      "name": "AiEvaluationDefinition",
+      "suffix": "aiEvaluationDefinition",
+      "directoryName": "aiEvaluationDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsdashboard": {
+      "id": "analyticsdashboard",
+      "name": "AnalyticsDashboard",
+      "suffix": "uadash",
+      "directoryName": "analyticsDashboards",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsvisualization": {
+      "id": "analyticsvisualization",
+      "name": "AnalyticsVisualization",
+      "suffix": "uaviz",
+      "directoryName": "analyticsVisualizations",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "analyticsworkspace": {
+      "id": "analyticsworkspace",
+      "name": "AnalyticsWorkspace",
+      "suffix": "uawork",
+      "directoryName": "analyticsWorkspaces",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lightningtypebundle": {
+      "id": "lightningtypebundle",
+      "name": "LightningTypeBundle",
+      "directoryName": "lightningTypes",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "metaFileSuffix": "schema.json",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true
+    },
+    "contenttypebundle": {
+      "id": "contenttypebundle",
+      "name": "ContentTypeBundle",
+      "directoryName": "contentTypes",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "metaFileSuffix": "schema.json",
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true
+    },
+    "lifesciconfigcategory": {
+      "id": "lifesciconfigcategory",
+      "name": "LifeSciConfigCategory",
+      "suffix": "lifeSciConfigCategory",
+      "directoryName": "lifeSciConfigCategories",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lifesciconfigrecord": {
+      "id": "lifesciconfigrecord",
+      "name": "LifeSciConfigRecord",
+      "suffix": "lifeSciConfigRecord",
+      "directoryName": "lifeSciConfigRecords",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "invocableactionextension": {
+      "id": "invocableactionextension",
+      "name": "InvocableActionExtension",
+      "suffix": "invocableactionextension",
+      "directoryName": "invocableactionextensions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "fieldservicemobileconfig": {
+      "id": "fieldservicemobileconfig",
+      "name": "FieldServiceMobileConfig",
+      "suffix": "fieldServiceMobileConfig",
+      "directoryName": "fieldServiceMobileConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprovider": {
+      "id": "dgtassetmgmtprovider",
+      "name": "DgtAssetMgmtProvider",
+      "suffix": "dgtAssetMgmtProvider",
+      "directoryName": "dgtAssetMgmtProviders",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprvdlghtcpnt": {
+      "id": "dgtassetmgmtprvdlghtcpnt",
+      "name": "DgtAssetMgmtPrvdLghtCpnt",
+      "suffix": "dgtAssetMgmtPrvdLghtCpnt",
+      "directoryName": "dgtAssetMgmtPrvdLghtCpnts",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappcanvasstngs": {
+      "id": "extlclntappcanvasstngs",
+      "name": "ExtlClntAppCanvasStngs",
+      "suffix": "ecaCanvas",
+      "directoryName": "extlClntAppCanvasStngs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "apinamedquery": {
+      "id": "apinamedquery",
+      "name": "ApiNamedQuery",
+      "suffix": "apiNamedQuery",
+      "directoryName": "apiNamedQueries",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "externalstorageprvdconfig": {
+      "id": "externalstorageprvdconfig",
+      "name": "ExternalStoragePrvdConfig",
+      "suffix": "ExternalStoragePrvdConfigSet",
+      "directoryName": "ExternalStoragePrvdConfig",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapi": {
+      "id": "catalogedapi",
+      "name": "CatalogedApi",
+      "suffix": "catalogedApi",
+      "directoryName": "catalogedApis",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapiversion": {
+      "id": "catalogedapiversion",
+      "name": "CatalogedApiVersion",
+      "suffix": "catalogedApiVersion",
+      "directoryName": "catalogedApiVersions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "catalogedapiartifactversioninfo": {
+      "id": "catalogedapiartifactversioninfo",
+      "name": "CatalogedApiArtifactVersionInfo",
+      "suffix": "catalogedApiArtifactVersionInfo",
+      "directoryName": "catalogedApiArtifactsVersionInfo",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "rulelibrarydefinition": {
+      "id": "rulelibrarydefinition",
+      "name": "RuleLibraryDefinition",
+      "suffix": "ruleLibraryDefinition",
+      "directoryName": "ruleLibraryDefinition",
+      "inFolder": false,
+      "strictDirectoryName": false
+    }
+  }
+}


### PR DESCRIPTION
Implement metadata copying and format conversion between SFDX (source)
and MDAPI (metadata) formats. Major architectural changes include:

- Add `copy` command for bidirectional metadata format conversion
- Refactor multi-file metadata types to separate XML parsing from file I/O
- Add Files() interface for metadata types that generate multiple files
- Create compose helpers for merging decomposed CustomObject components
- Add CustomObjectTranslation composition support (fields only, following SFDX conventions)
- Implement Tidy interface for more types
